### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,18 @@
+FROM mcr.microsoft.com/devcontainers/rust:1-bullseye
+
+# Core build and troubleshooting tools
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        clang \
+        lld \
+        pkg-config \
+        libssl-dev \
+        git \
+        zsh \
+        fzf \
+        ripgrep \
+    && rm -rf /var/lib/apt/lists/*
+
+# Ensure required Rust components and helper tools are available
+RUN rustup component add clippy rustfmt \
+    && if ! command -v just >/dev/null 2>&1; then cargo install --locked just; fi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "kitu-logic-processor",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "postCreateCommand": "rustup show && cargo --version",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml",
+        "usernamehw.errorlens",
+        "eamodio.gitlens",
+        "EditorConfig.EditorConfig"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "rust-analyzer.check.command": "clippy",
+        "rust-analyzer.cargo.allFeatures": true,
+        "rust-analyzer.procMacro.enable": true,
+        "terminal.integrated.defaultProfile.linux": "zsh"
+      }
+    }
+  }
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "rust-lang.rust-analyzer",
+    "tamasfe.even-better-toml",
+    "usernamehw.errorlens",
+    "eamodio.gitlens",
+    "EditorConfig.EditorConfig"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.formatOnSave": true,
+  "rust-analyzer.check.command": "clippy",
+  "rust-analyzer.cargo.allFeatures": true,
+  "rust-analyzer.procMacro.enable": true
+}


### PR DESCRIPTION
## Summary
- add a devcontainer definition using the Rust base image and common build dependencies
- ensure rustfmt, clippy, and just are installed in the container and surface recommended VS Code extensions/settings for Rust workflows

## Testing
- not run (devcontainer setup only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e531e3ff0832887a147bb8122f0bd)