### PR TITLE
Add skeleton public APIs for workspace crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,22 +18,37 @@ dependencies = [
 [[package]]
 name = "kitu-core"
 version = "0.1.0"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "kitu-data-sqlite"
 version = "0.1.0"
+dependencies = [
+ "kitu-core",
+]
 
 [[package]]
 name = "kitu-data-tmd"
 version = "0.1.0"
+dependencies = [
+ "kitu-core",
+]
 
 [[package]]
 name = "kitu-ecs"
 version = "0.1.0"
+dependencies = [
+ "kitu-core",
+]
 
 [[package]]
 name = "kitu-osc-ir"
 version = "0.1.0"
+dependencies = [
+ "kitu-core",
+]
 
 [[package]]
 name = "kitu-replay-runner"
@@ -45,27 +60,109 @@ dependencies = [
 [[package]]
 name = "kitu-runtime"
 version = "0.1.0"
+dependencies = [
+ "kitu-core",
+ "kitu-ecs",
+ "kitu-osc-ir",
+ "kitu-transport",
+]
 
 [[package]]
 name = "kitu-scripting-rhai"
 version = "0.1.0"
+dependencies = [
+ "kitu-core",
+]
 
 [[package]]
 name = "kitu-shell"
 version = "0.1.0"
+dependencies = [
+ "kitu-core",
+]
 
 [[package]]
 name = "kitu-transport"
 version = "0.1.0"
+dependencies = [
+ "kitu-core",
+ "kitu-osc-ir",
+]
 
 [[package]]
 name = "kitu-tsq1"
 version = "0.1.0"
+dependencies = [
+ "kitu-core",
+]
 
 [[package]]
 name = "kitu-unity-ffi"
 version = "0.1.0"
+dependencies = [
+ "kitu-core",
+ "kitu-runtime",
+ "kitu-transport",
+]
 
 [[package]]
 name = "kitu-web-admin-backend"
 version = "0.1.0"
+dependencies = [
+ "kitu-core",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ publish = false
 
 [workspace.dependencies]
 anyhow = "1"
+thiserror = "1"

--- a/crates/kitu-core/Cargo.toml
+++ b/crates/kitu-core/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
+thiserror = { workspace = true }

--- a/crates/kitu-core/src/lib.rs
+++ b/crates/kitu-core/src/lib.rs
@@ -1,5 +1,101 @@
-//! kitu-core crate placeholder.
+//! Core types and utilities shared across the Kitu runtime crates.
 
-/// Placeholder type to ensure the crate compiles.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct Placeholder;
+use std::time::Duration;
+
+use thiserror::Error;
+
+/// Convenient result alias used across Kitu crates.
+pub type Result<T, E = KituError> = std::result::Result<T, E>;
+
+/// Unified error enum for the core crates. Additional variants should be added as
+/// behavior becomes concrete.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum KituError {
+    /// Placeholder for unimplemented or unconfigured features.
+    #[error("not implemented: {0}")]
+    NotImplemented(String),
+
+    /// Represents invalid user or data input.
+    #[error("invalid input: {0}")]
+    InvalidInput(&'static str),
+}
+
+/// Tick represents a deterministic, monotonic counter for the runtime loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Tick(u64);
+
+impl Tick {
+    /// Creates a new tick starting at zero.
+    pub const fn start() -> Self {
+        Self(0)
+    }
+
+    /// Advances the tick by one.
+    pub const fn next(self) -> Self {
+        Self(self.0 + 1)
+    }
+
+    /// Advances the tick by the provided offset.
+    pub const fn advance_by(self, offset: u64) -> Self {
+        Self(self.0 + offset)
+    }
+
+    /// Returns the raw tick counter value.
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Represents a monotonically increasing timestamp based on tick duration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Timestamp {
+    tick: Tick,
+    frame_time: Duration,
+}
+
+impl Timestamp {
+    /// Creates a timestamp from the given tick and per-frame duration.
+    pub const fn new(tick: Tick, frame_time: Duration) -> Self {
+        Self { tick, frame_time }
+    }
+
+    /// Returns elapsed time since tick zero.
+    pub fn elapsed(&self) -> Duration {
+        self.frame_time * self.tick.0 as u32
+    }
+
+    /// Accessor for the internal tick.
+    pub const fn tick(&self) -> Tick {
+        self.tick
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tick_advances_monotonically() {
+        let start = Tick::start();
+        let next = start.next();
+        assert_eq!(start.get(), 0);
+        assert_eq!(next.get(), 1);
+        assert!(next > start);
+    }
+
+    #[test]
+    fn timestamp_reports_elapsed_duration() {
+        let frame_time = Duration::from_millis(16);
+        let ts = Timestamp::new(Tick::start().advance_by(3), frame_time);
+        assert_eq!(ts.elapsed(), frame_time * 3);
+        assert_eq!(ts.tick(), Tick::start().advance_by(3));
+    }
+
+    #[test]
+    fn errors_display_meaningful_messages() {
+        let not_impl = KituError::NotImplemented("feature".into()).to_string();
+        let invalid = KituError::InvalidInput("bad").to_string();
+        assert!(not_impl.contains("feature"));
+        assert!(invalid.contains("bad"));
+    }
+}

--- a/crates/kitu-data-sqlite/Cargo.toml
+++ b/crates/kitu-data-sqlite/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
+kitu-core = { path = "../kitu-core" }

--- a/crates/kitu-data-sqlite/src/lib.rs
+++ b/crates/kitu-data-sqlite/src/lib.rs
@@ -1,5 +1,87 @@
-//! kitu-data-sqlite crate placeholder.
+//! SQLite data access layer placeholder.
 
-/// Placeholder type to ensure the crate compiles.
+use std::collections::HashMap;
+
+use kitu_core::{KituError, Result};
+
+/// Represents a simplistic table as a list of rows (column -> value).
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct Placeholder;
+pub struct Table {
+    pub name: String,
+    pub rows: Vec<HashMap<String, String>>,
+}
+
+/// In-memory stand-in for an actual SQLite connection.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct SqliteStore {
+    tables: HashMap<String, Table>,
+}
+
+impl SqliteStore {
+    /// Creates an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers a new empty table.
+    pub fn create_table(&mut self, name: impl Into<String>) -> Result<()> {
+        let name = name.into();
+        if self.tables.contains_key(&name) {
+            return Err(KituError::InvalidInput("table already exists"));
+        }
+        self.tables.insert(
+            name.clone(),
+            Table {
+                name,
+                rows: Vec::new(),
+            },
+        );
+        Ok(())
+    }
+
+    /// Inserts a row into an existing table.
+    pub fn insert(&mut self, table: &str, row: HashMap<String, String>) -> Result<()> {
+        let table = self
+            .tables
+            .get_mut(table)
+            .ok_or(KituError::InvalidInput("missing table"))?;
+        table.rows.push(row);
+        Ok(())
+    }
+
+    /// Simple query returning all rows for a table.
+    pub fn query_all(&self, table: &str) -> Result<&[HashMap<String, String>]> {
+        let table = self
+            .tables
+            .get(table)
+            .ok_or(KituError::InvalidInput("missing table"))?;
+        Ok(&table.rows)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn creating_tables_and_inserting_rows() {
+        let mut store = SqliteStore::new();
+        store.create_table("items").unwrap();
+
+        let mut row = HashMap::new();
+        row.insert("id".into(), "1".into());
+        row.insert("name".into(), "potion".into());
+        store.insert("items", row.clone()).unwrap();
+
+        let rows = store.query_all("items").unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].get("name").unwrap(), "potion");
+    }
+
+    #[test]
+    fn duplicate_table_creation_is_an_error() {
+        let mut store = SqliteStore::new();
+        store.create_table("dupe").unwrap();
+        assert!(store.create_table("dupe").is_err());
+    }
+}

--- a/crates/kitu-data-tmd/Cargo.toml
+++ b/crates/kitu-data-tmd/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
+kitu-core = { path = "../kitu-core" }

--- a/crates/kitu-data-tmd/src/lib.rs
+++ b/crates/kitu-data-tmd/src/lib.rs
@@ -1,5 +1,68 @@
-//! kitu-data-tmd crate placeholder.
+//! Data ingestion helpers for the TMD format.
 
-/// Placeholder type to ensure the crate compiles.
+use std::collections::HashMap;
+
+use kitu_core::{KituError, Result};
+
+/// Minimal representation of a TMD entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TmdEntry {
+    pub key: String,
+    pub value: String,
+}
+
+/// Parsed TMD document as a key-value map.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct Placeholder;
+pub struct TmdDocument {
+    entries: HashMap<String, String>,
+}
+
+impl TmdDocument {
+    /// Parses a simple `key: value` style document.
+    pub fn parse(input: &str) -> Result<Self> {
+        let mut entries = HashMap::new();
+        for line in input.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+            if let Some((key, value)) = trimmed.split_once(':') {
+                entries.insert(key.trim().to_string(), value.trim().to_string());
+            } else {
+                return Err(KituError::InvalidInput("expected key: value"));
+            }
+        }
+        Ok(Self { entries })
+    }
+
+    /// Retrieves a parsed entry by key.
+    pub fn get(&self, key: &str) -> Option<TmdEntry> {
+        self.entries.get(key).cloned().map(|value| TmdEntry {
+            key: key.to_string(),
+            value,
+        })
+    }
+
+    /// Returns how many entries were parsed.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_key_value_pairs() {
+        let doc = TmdDocument::parse("hp: 10\nname: hero").unwrap();
+        assert_eq!(doc.len(), 2);
+        assert_eq!(doc.get("hp").unwrap().value, "10");
+    }
+
+    #[test]
+    fn parsing_invalid_line_returns_error() {
+        let result = TmdDocument::parse("invalid line");
+        assert!(matches!(result, Err(KituError::InvalidInput(_))));
+    }
+}

--- a/crates/kitu-ecs/Cargo.toml
+++ b/crates/kitu-ecs/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
+kitu-core = { path = "../kitu-core" }

--- a/crates/kitu-ecs/src/lib.rs
+++ b/crates/kitu-ecs/src/lib.rs
@@ -1,5 +1,98 @@
-//! kitu-ecs crate placeholder.
+//! Thin ECS abstraction used by the runtime.
 
-/// Placeholder type to ensure the crate compiles.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct Placeholder;
+use std::collections::{HashMap, VecDeque};
+
+use kitu_core::{KituError, Result, Tick};
+
+/// Represents a system that can be scheduled for a tick.
+pub trait System: Send + Sync + 'static {
+    /// Executes the system for the given tick.
+    fn run(&mut self, world: &mut EcsWorld, tick: Tick) -> Result<()>;
+}
+
+/// Minimal world representation for registering components and systems.
+#[derive(Default)]
+pub struct EcsWorld {
+    components: Vec<String>,
+    scheduled: VecDeque<Box<dyn System>>,
+}
+
+impl EcsWorld {
+    /// Registers a component type by name. The concrete storage will be wired later.
+    pub fn register_component(&mut self, name: impl Into<String>) -> Result<()> {
+        let name = name.into();
+        if self.components.contains(&name) {
+            return Err(KituError::InvalidInput("component already registered"));
+        }
+        self.components.push(name);
+        Ok(())
+    }
+
+    /// Schedules a system to run on the next tick.
+    pub fn schedule_system<S: System>(&mut self, system: S) {
+        self.scheduled.push_back(Box::new(system));
+    }
+
+    /// Executes all scheduled systems in FIFO order and clears the queue.
+    pub fn dispatch(&mut self, tick: Tick) -> Result<()> {
+        while let Some(mut system) = self.scheduled.pop_front() {
+            system.run(self, tick)?;
+        }
+        Ok(())
+    }
+
+    /// Returns a snapshot of registered component names.
+    pub fn registered_components(&self) -> Vec<String> {
+        self.components.clone()
+    }
+}
+
+/// Example system that simply records that it has run.
+#[derive(Default)]
+pub struct RecordingSystem {
+    pub runs: HashMap<u64, usize>,
+}
+
+impl System for RecordingSystem {
+    fn run(&mut self, _world: &mut EcsWorld, tick: Tick) -> Result<()> {
+        *self.runs.entry(tick.get()).or_default() += 1;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn component_registration_rejects_duplicates() {
+        let mut world = EcsWorld::default();
+        world.register_component("Transform").unwrap();
+        assert!(world.register_component("Transform").is_err());
+        assert_eq!(world.register_component("Velocity").unwrap(), ());
+        assert_eq!(
+            world.registered_components(),
+            vec!["Transform".to_string(), "Velocity".to_string()]
+        );
+    }
+
+    #[test]
+    fn scheduled_systems_execute_in_order() {
+        let mut world = EcsWorld::default();
+        let system = RecordingSystem::default();
+        world.schedule_system(RecordingSystem::default());
+        world.schedule_system(system);
+        let tick = Tick::start().advance_by(2);
+        world.dispatch(tick).unwrap();
+    }
+
+    #[test]
+    fn recording_system_counts_runs_per_tick() {
+        let tick = Tick::start();
+        let mut world = EcsWorld::default();
+        let mut system = RecordingSystem::default();
+        system.run(&mut world, tick).unwrap();
+        system.run(&mut world, tick).unwrap();
+        assert_eq!(system.runs.get(&tick.get()), Some(&2));
+    }
+}

--- a/crates/kitu-osc-ir/Cargo.toml
+++ b/crates/kitu-osc-ir/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
+kitu-core = { path = "../kitu-core" }

--- a/crates/kitu-osc-ir/src/lib.rs
+++ b/crates/kitu-osc-ir/src/lib.rs
@@ -1,5 +1,110 @@
-//! kitu-osc-ir crate placeholder.
+//! OSC-IR message representation used by transports and runtime.
 
-/// Placeholder type to ensure the crate compiles.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct Placeholder;
+use std::fmt::Write;
+
+use kitu_core::Result;
+
+/// Supported OSC-IR argument types.
+#[derive(Debug, Clone, PartialEq)]
+pub enum OscArg {
+    Int(i32),
+    Float(f32),
+    Str(String),
+    Bool(bool),
+}
+
+/// OSC-IR message consisting of an address and a list of arguments.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OscMessage {
+    pub address: String,
+    pub args: Vec<OscArg>,
+}
+
+impl OscMessage {
+    /// Creates a new message with the provided address.
+    pub fn new(address: impl Into<String>) -> Self {
+        Self {
+            address: address.into(),
+            args: Vec::new(),
+        }
+    }
+
+    /// Appends an argument to the message.
+    pub fn push_arg(&mut self, arg: OscArg) {
+        self.args.push(arg);
+    }
+
+    /// Renders the message into a debug-friendly string for logging.
+    pub fn to_debug_string(&self) -> Result<String> {
+        let mut buf = String::new();
+        write!(&mut buf, "{}(", self.address).unwrap();
+        for (i, arg) in self.args.iter().enumerate() {
+            if i > 0 {
+                buf.push_str(", ");
+            }
+            match arg {
+                OscArg::Int(v) => write!(&mut buf, "{v}").unwrap(),
+                OscArg::Float(v) => write!(&mut buf, "{v}").unwrap(),
+                OscArg::Str(v) => write!(&mut buf, "\"{v}\"").unwrap(),
+                OscArg::Bool(v) => write!(&mut buf, "{v}").unwrap(),
+            }
+        }
+        buf.push(')');
+        Ok(buf)
+    }
+}
+
+/// A collection of messages bundled for atomic delivery.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct OscBundle {
+    pub messages: Vec<OscMessage>,
+}
+
+impl OscBundle {
+    /// Creates an empty bundle.
+    pub fn new() -> Self {
+        Self {
+            messages: Vec::new(),
+        }
+    }
+
+    /// Pushes a message into the bundle.
+    pub fn push(&mut self, message: OscMessage) {
+        self.messages.push(message);
+    }
+
+    /// Returns the number of contained messages.
+    pub fn len(&self) -> usize {
+        self.messages.len()
+    }
+
+    /// Whether the bundle contains no messages.
+    pub fn is_empty(&self) -> bool {
+        self.messages.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_building_and_debugging() {
+        let mut msg = OscMessage::new("/player/move");
+        msg.push_arg(OscArg::Int(1));
+        msg.push_arg(OscArg::Bool(true));
+        let rendered = msg.to_debug_string().unwrap();
+        assert!(rendered.contains("/player/move"));
+        assert!(rendered.contains("true"));
+        assert_eq!(msg.args.len(), 2);
+    }
+
+    #[test]
+    fn bundle_collects_messages() {
+        let mut bundle = OscBundle::new();
+        assert!(bundle.is_empty());
+        bundle.push(OscMessage::new("/a"));
+        bundle.push(OscMessage::new("/b"));
+        assert_eq!(bundle.len(), 2);
+    }
+}

--- a/crates/kitu-runtime/Cargo.toml
+++ b/crates/kitu-runtime/Cargo.toml
@@ -5,3 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
+kitu-core = { path = "../kitu-core" }
+kitu-ecs = { path = "../kitu-ecs" }
+kitu-transport = { path = "../kitu-transport" }
+kitu-osc-ir = { path = "../kitu-osc-ir" }

--- a/crates/kitu-runtime/src/lib.rs
+++ b/crates/kitu-runtime/src/lib.rs
@@ -1,5 +1,133 @@
-//! kitu-runtime crate placeholder.
+//! Tick-based runtime loop orchestrating ECS and transport.
 
-/// Placeholder type to ensure the crate compiles.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct Placeholder;
+use std::time::Duration;
+
+use kitu_core::{Result, Tick};
+use kitu_ecs::EcsWorld;
+use kitu_transport::{Transport, TransportEvent};
+
+/// Configuration for the runtime loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RuntimeConfig {
+    pub tick_rate_hz: u32,
+}
+
+impl RuntimeConfig {
+    /// Creates a configuration with a default 60Hz tick rate.
+    pub const fn default_60hz() -> Self {
+        Self { tick_rate_hz: 60 }
+    }
+
+    /// Duration for a single frame.
+    pub fn frame_time(&self) -> Duration {
+        Duration::from_secs_f32(1.0 / self.tick_rate_hz as f32)
+    }
+}
+
+/// Central orchestrator tying together ECS and message transport.
+pub struct Runtime<T: Transport> {
+    config: RuntimeConfig,
+    tick: Tick,
+    transport: T,
+    world: EcsWorld,
+}
+
+impl<T: Transport> Runtime<T> {
+    /// Creates a new runtime with the given transport and configuration.
+    pub fn new(config: RuntimeConfig, transport: T) -> Self {
+        Self {
+            config,
+            tick: Tick::start(),
+            transport,
+            world: EcsWorld::default(),
+        }
+    }
+
+    /// Returns the world instance for registering systems and components.
+    pub fn world_mut(&mut self) -> &mut EcsWorld {
+        &mut self.world
+    }
+
+    /// Processes a single tick of the runtime loop.
+    pub fn tick_once(&mut self) -> Result<()> {
+        self.world.dispatch(self.tick)?;
+        while let Some(event) = self.transport.poll_event() {
+            if let TransportEvent::Message(_) = event {
+                // Future work: route to ECS systems or script hooks.
+            }
+        }
+        self.tick = self.tick.next();
+        Ok(())
+    }
+
+    /// Returns the current tick counter.
+    pub fn current_tick(&self) -> Tick {
+        self.tick
+    }
+
+    /// Returns the configuration used to construct the runtime.
+    pub fn config(&self) -> RuntimeConfig {
+        self.config
+    }
+
+    /// Runs the runtime for the requested number of ticks.
+    pub fn run_for_ticks(&mut self, count: u64) -> Result<()> {
+        for _ in 0..count {
+            self.tick_once()?;
+        }
+        Ok(())
+    }
+}
+
+/// Convenience helper for building a runtime with default configuration.
+pub fn build_runtime<T: Transport>(transport: T) -> Runtime<T> {
+    Runtime::new(RuntimeConfig::default_60hz(), transport)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kitu_core::KituError;
+    use kitu_transport::LocalChannel;
+
+    #[test]
+    fn runtime_advances_ticks() {
+        let mut runtime = build_runtime(LocalChannel::default());
+        assert_eq!(runtime.current_tick().get(), 0);
+        runtime.tick_once().unwrap();
+        assert_eq!(runtime.current_tick().get(), 1);
+    }
+
+    #[test]
+    fn runtime_processes_multiple_ticks() {
+        let mut runtime = build_runtime(LocalChannel::default());
+        runtime.run_for_ticks(3).unwrap();
+        assert_eq!(runtime.current_tick().get(), 3);
+    }
+
+    #[test]
+    fn frame_time_matches_tick_rate() {
+        let config = RuntimeConfig { tick_rate_hz: 120 };
+        let frame = config.frame_time();
+        let expected = 1.0 / 120.0;
+        let actual = frame.as_secs_f64();
+        assert!((actual - expected).abs() < 1e-6);
+    }
+
+    #[test]
+    fn tick_once_returns_error_when_dispatch_fails() {
+        struct FailingTransport;
+        impl Transport for FailingTransport {
+            fn send(&mut self, _message: kitu_osc_ir::OscMessage) -> Result<()> {
+                Err(KituError::NotImplemented("send".into()))
+            }
+
+            fn poll_event(&mut self) -> Option<TransportEvent> {
+                None
+            }
+        }
+
+        let mut runtime = build_runtime(FailingTransport);
+        assert!(runtime.tick_once().is_ok());
+    }
+}

--- a/crates/kitu-scripting-rhai/Cargo.toml
+++ b/crates/kitu-scripting-rhai/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
+kitu-core = { path = "../kitu-core" }

--- a/crates/kitu-scripting-rhai/src/lib.rs
+++ b/crates/kitu-scripting-rhai/src/lib.rs
@@ -1,5 +1,65 @@
-//! kitu-scripting-rhai crate placeholder.
+//! Rhai scripting integration skeleton.
 
-/// Placeholder type to ensure the crate compiles.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct Placeholder;
+use std::collections::HashMap;
+
+use kitu_core::{KituError, Result};
+
+/// Represents a compiled or cached Rhai script (placeholder for now).
+#[derive(Debug, Clone)]
+pub struct Script {
+    pub name: String,
+    pub source: String,
+}
+
+/// Hosts registered scripts and provides an entry point to invoke them.
+#[derive(Default)]
+pub struct ScriptHost {
+    scripts: HashMap<String, Script>,
+}
+
+impl ScriptHost {
+    /// Registers a script under a given name.
+    pub fn register_script(&mut self, name: impl Into<String>, source: impl Into<String>) {
+        let script = Script {
+            name: name.into(),
+            source: source.into(),
+        };
+        self.scripts.insert(script.name.clone(), script);
+    }
+
+    /// Invokes a function within the named script.
+    pub fn invoke(&self, script: &str, func: &str) -> Result<()> {
+        if !self.scripts.contains_key(script) {
+            return Err(KituError::InvalidInput("missing script"));
+        }
+        // Actual Rhai evaluation will be added later.
+        Err(KituError::NotImplemented(func.to_string()))
+    }
+
+    /// Returns the number of registered scripts.
+    pub fn len(&self) -> usize {
+        self.scripts.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registering_and_invoking_scripts() {
+        let mut host = ScriptHost::default();
+        host.register_script("demo", "fn run() { 1 }");
+        assert_eq!(host.len(), 1);
+
+        let err = host.invoke("demo", "run").unwrap_err();
+        assert!(matches!(err, KituError::NotImplemented(value) if value == "run"));
+    }
+
+    #[test]
+    fn invoking_missing_script_returns_error() {
+        let host = ScriptHost::default();
+        let err = host.invoke("missing", "run").unwrap_err();
+        assert!(matches!(err, KituError::InvalidInput("missing script")));
+    }
+}

--- a/crates/kitu-shell/Cargo.toml
+++ b/crates/kitu-shell/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
+kitu-core = { path = "../kitu-core" }

--- a/crates/kitu-shell/src/lib.rs
+++ b/crates/kitu-shell/src/lib.rs
@@ -1,5 +1,69 @@
-//! kitu-shell crate placeholder.
+//! CLI shell skeleton for driving the runtime.
 
-/// Placeholder type to ensure the crate compiles.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct Placeholder;
+use std::collections::HashMap;
+
+use kitu_core::{KituError, Result};
+
+/// Represents a shell command handler.
+pub trait CommandHandler: Send + Sync {
+    /// Executes the command with provided arguments.
+    fn execute(&self, args: &[String]) -> Result<String>;
+}
+
+/// Simple shell registry and dispatcher.
+#[derive(Default)]
+pub struct Shell {
+    commands: HashMap<String, Box<dyn CommandHandler>>,
+}
+
+impl Shell {
+    /// Registers a command by name.
+    pub fn register_command<C: CommandHandler + 'static>(
+        &mut self,
+        name: impl Into<String>,
+        handler: C,
+    ) {
+        self.commands.insert(name.into(), Box::new(handler));
+    }
+
+    /// Executes a command, returning its string response.
+    pub fn run(&self, command: &str, args: &[String]) -> Result<String> {
+        let handler = self
+            .commands
+            .get(command)
+            .ok_or(KituError::InvalidInput("unknown command"))?;
+        handler.execute(args)
+    }
+}
+
+/// A basic echo command useful for testing.
+#[derive(Default)]
+pub struct EchoCommand;
+
+impl CommandHandler for EchoCommand {
+    fn execute(&self, args: &[String]) -> Result<String> {
+        Ok(args.join(" "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn running_registered_command_returns_output() {
+        let mut shell = Shell::default();
+        shell.register_command("echo", EchoCommand);
+        let out = shell
+            .run("echo", &["hello".into(), "world".into()])
+            .unwrap();
+        assert_eq!(out, "hello world");
+    }
+
+    #[test]
+    fn running_unknown_command_errors() {
+        let shell = Shell::default();
+        let err = shell.run("missing", &[]).unwrap_err();
+        assert!(matches!(err, KituError::InvalidInput("unknown command")));
+    }
+}

--- a/crates/kitu-transport/Cargo.toml
+++ b/crates/kitu-transport/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
+kitu-core = { path = "../kitu-core" }
+kitu-osc-ir = { path = "../kitu-osc-ir" }

--- a/crates/kitu-transport/src/lib.rs
+++ b/crates/kitu-transport/src/lib.rs
@@ -1,5 +1,86 @@
-//! kitu-transport crate placeholder.
+//! Transport abstraction for delivering OSC-IR messages between peers.
 
-/// Placeholder type to ensure the crate compiles.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct Placeholder;
+use std::collections::VecDeque;
+
+use kitu_core::{KituError, Result};
+use kitu_osc_ir::{OscBundle, OscMessage};
+
+/// Event emitted by a transport implementation.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TransportEvent {
+    Connected,
+    Disconnected,
+    Message(OscBundle),
+}
+
+/// Common interface for transports.
+pub trait Transport {
+    /// Sends a single OSC message.
+    fn send(&mut self, message: OscMessage) -> Result<()>;
+
+    /// Receives the next pending event, if any.
+    fn poll_event(&mut self) -> Option<TransportEvent>;
+}
+
+/// In-memory channel transport useful for tests and local simulations.
+#[derive(Default)]
+pub struct LocalChannel {
+    inbox: VecDeque<TransportEvent>,
+}
+
+impl LocalChannel {
+    /// Creates a connected channel with no queued messages.
+    pub fn connected() -> Self {
+        let mut channel = Self::default();
+        channel.inbox.push_back(TransportEvent::Connected);
+        channel
+    }
+}
+
+impl Transport for LocalChannel {
+    fn send(&mut self, message: OscMessage) -> Result<()> {
+        let mut bundle = OscBundle::new();
+        bundle.push(message);
+        self.inbox.push_back(TransportEvent::Message(bundle));
+        Ok(())
+    }
+
+    fn poll_event(&mut self) -> Option<TransportEvent> {
+        self.inbox.pop_front()
+    }
+}
+
+/// Validates that transports transition to disconnected state.
+pub fn disconnect<T: Transport>(transport: &mut T) -> Result<()> {
+    let _ = transport;
+    Err(KituError::NotImplemented("disconnect".into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_channel_reports_connection_then_messages() {
+        let mut channel = LocalChannel::connected();
+        assert_eq!(channel.poll_event(), Some(TransportEvent::Connected));
+
+        channel
+            .send(OscMessage::new("/ping"))
+            .expect("send should enqueue message");
+        match channel.poll_event() {
+            Some(TransportEvent::Message(bundle)) => {
+                assert_eq!(bundle.len(), 1);
+                assert_eq!(bundle.messages[0].address, "/ping");
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn disconnect_returns_not_implemented_error() {
+        let mut channel = LocalChannel::default();
+        let result = disconnect(&mut channel);
+        assert!(matches!(result, Err(KituError::NotImplemented(_))));
+    }
+}

--- a/crates/kitu-tsq1/Cargo.toml
+++ b/crates/kitu-tsq1/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
+kitu-core = { path = "../kitu-core" }

--- a/crates/kitu-tsq1/src/lib.rs
+++ b/crates/kitu-tsq1/src/lib.rs
@@ -1,5 +1,83 @@
-//! kitu-tsq1 crate placeholder.
+//! TSQ1 timeline parser and scheduler skeleton.
 
-/// Placeholder type to ensure the crate compiles.
+use std::collections::VecDeque;
+
+use kitu_core::{KituError, Result, Tick};
+
+/// A single timeline step.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TimelineStep {
+    Emit(String),
+    Wait(u64),
+}
+
+/// Parsed TSQ1 script consisting of ordered steps.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct Placeholder;
+pub struct Timeline {
+    steps: VecDeque<TimelineStep>,
+}
+
+impl Timeline {
+    /// Parses a very small subset of TSQ1 where each line is either `emit:value` or `wait:n`.
+    pub fn parse(script: &str) -> Result<Self> {
+        let mut steps = VecDeque::new();
+        for line in script.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if let Some(rest) = trimmed.strip_prefix("emit:") {
+                steps.push_back(TimelineStep::Emit(rest.trim().to_string()));
+            } else if let Some(rest) = trimmed.strip_prefix("wait:") {
+                let ticks: u64 = rest
+                    .trim()
+                    .parse()
+                    .map_err(|_| KituError::InvalidInput("wait expects integer"))?;
+                steps.push_back(TimelineStep::Wait(ticks));
+            } else {
+                return Err(KituError::InvalidInput("unknown directive"));
+            }
+        }
+        Ok(Self { steps })
+    }
+
+    /// Pops the next step for the provided tick.
+    pub fn next_step(&mut self, _tick: Tick) -> Option<TimelineStep> {
+        self.steps.pop_front()
+    }
+
+    /// Returns whether all steps have been consumed.
+    pub fn is_finished(&self) -> bool {
+        self.steps.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_emit_and_wait_steps() {
+        let script = "emit: start\nwait:2\nemit: end";
+        let mut timeline = Timeline::parse(script).unwrap();
+        assert_eq!(
+            timeline.next_step(Tick::start()),
+            Some(TimelineStep::Emit("start".into()))
+        );
+        assert_eq!(
+            timeline.next_step(Tick::start()),
+            Some(TimelineStep::Wait(2))
+        );
+        assert_eq!(
+            timeline.next_step(Tick::start()),
+            Some(TimelineStep::Emit("end".into()))
+        );
+        assert!(timeline.is_finished());
+    }
+
+    #[test]
+    fn unknown_directives_error() {
+        let script = "noop";
+        assert!(Timeline::parse(script).is_err());
+    }
+}

--- a/crates/kitu-unity-ffi/Cargo.toml
+++ b/crates/kitu-unity-ffi/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2021"
 publish = false
 
 [dependencies]
+kitu-core = { path = "../kitu-core" }
+kitu-runtime = { path = "../kitu-runtime" }
+kitu-transport = { path = "../kitu-transport" }

--- a/crates/kitu-unity-ffi/src/lib.rs
+++ b/crates/kitu-unity-ffi/src/lib.rs
@@ -1,5 +1,69 @@
-//! kitu-unity-ffi crate placeholder.
+//! FFI boundary for embedding the runtime in Unity.
 
-/// Placeholder type to ensure the crate compiles.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct Placeholder;
+use std::sync::{Arc, Mutex};
+
+use kitu_core::Result;
+use kitu_runtime::{build_runtime, Runtime};
+use kitu_transport::LocalChannel;
+
+/// Managed handle exposed to Unity.
+#[derive(Clone)]
+pub struct UnityHandle {
+    runtime: Arc<Mutex<Runtime<LocalChannel>>>,
+}
+
+impl UnityHandle {
+    /// Initializes the runtime and returns a handle safe to share across FFI boundaries.
+    pub fn initialize() -> Self {
+        let runtime = build_runtime(LocalChannel::connected());
+        Self {
+            runtime: Arc::new(Mutex::new(runtime)),
+        }
+    }
+
+    /// Advances the runtime by one tick.
+    pub fn tick(&self) -> Result<()> {
+        let mut guard = self.runtime.lock().expect("runtime mutex poisoned");
+        guard.tick_once()
+    }
+}
+
+/// C ABI entry point to create a new runtime handle.
+#[no_mangle]
+pub extern "C" fn kitu_init() -> *mut UnityHandle {
+    Box::into_raw(Box::new(UnityHandle::initialize()))
+}
+
+/// C ABI entry point to advance the runtime.
+#[no_mangle]
+pub unsafe extern "C" fn kitu_tick(handle: *mut UnityHandle) -> i32 {
+    let Some(handle) = handle.as_mut() else {
+        return -1;
+    };
+    match handle.tick() {
+        Ok(_) => 0,
+        Err(_) => 1,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handle_advances_runtime() {
+        let handle = UnityHandle::initialize();
+        handle.tick().unwrap();
+        handle.tick().unwrap();
+        let runtime = handle.runtime.lock().unwrap();
+        assert_eq!(runtime.current_tick().get(), 2);
+    }
+
+    #[test]
+    fn ffi_functions_return_success() {
+        let ptr = kitu_init();
+        let status = unsafe { kitu_tick(ptr) };
+        assert_eq!(status, 0);
+        unsafe { drop(Box::from_raw(ptr)) };
+    }
+}

--- a/crates/kitu-web-admin-backend/Cargo.toml
+++ b/crates/kitu-web-admin-backend/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
+kitu-core = { path = "../kitu-core" }

--- a/crates/kitu-web-admin-backend/src/lib.rs
+++ b/crates/kitu-web-admin-backend/src/lib.rs
@@ -1,5 +1,99 @@
-//! kitu-web-admin-backend crate placeholder.
+//! Web admin backend skeleton.
 
-/// Placeholder type to ensure the crate compiles.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct Placeholder;
+use std::collections::HashMap;
+
+use kitu_core::{KituError, Result};
+
+/// Represents a simple HTTP-like request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Request {
+    pub path: String,
+}
+
+/// Represents a simple response structure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Response {
+    pub status: u16,
+    pub body: String,
+}
+
+/// Basic backend server with in-memory route handlers.
+#[derive(Default)]
+pub struct WebAdminServer {
+    routes: HashMap<String, Box<dyn Fn(&Request) -> Result<Response> + Send + Sync>>,
+    running: bool,
+}
+
+impl WebAdminServer {
+    /// Registers a route handler.
+    pub fn register_route<F>(&mut self, path: impl Into<String>, handler: F)
+    where
+        F: Fn(&Request) -> Result<Response> + Send + Sync + 'static,
+    {
+        self.routes.insert(path.into(), Box::new(handler));
+    }
+
+    /// Marks the server as running; networking is added later.
+    pub fn start(&mut self) {
+        self.running = true;
+    }
+
+    /// Stops the server.
+    pub fn stop(&mut self) {
+        self.running = false;
+    }
+
+    /// Handles a request using the registered route table.
+    pub fn handle(&self, request: Request) -> Result<Response> {
+        if !self.running {
+            return Err(KituError::NotImplemented("server not started".into()));
+        }
+        let handler = self
+            .routes
+            .get(&request.path)
+            .ok_or(KituError::InvalidInput("missing route"))?;
+        handler(&request)
+    }
+
+    /// Whether the server is marked as running.
+    pub fn is_running(&self) -> bool {
+        self.running
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registering_route_and_handling_request() {
+        let mut server = WebAdminServer::default();
+        server.register_route("/health", |_req| {
+            Ok(Response {
+                status: 200,
+                body: "ok".into(),
+            })
+        });
+        server.start();
+        let response = server
+            .handle(Request {
+                path: "/health".into(),
+            })
+            .unwrap();
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body, "ok");
+    }
+
+    #[test]
+    fn handling_missing_route_errors() {
+        let mut server = WebAdminServer::default();
+        server.start();
+        let result = server.handle(Request {
+            path: "/unknown".into(),
+        });
+        assert!(matches!(
+            result,
+            Err(KituError::InvalidInput("missing route"))
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
- add shared core error/tick utilities and minimal ECS, transport, and runtime orchestrations
- introduce placeholder data, scripting, timeline, shell, and web admin APIs with basic behaviors and tests
- wire Unity FFI and local channel transport handles to exercise the runtime surface

## Testing
- cargo test --all

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937ac9f446483288e9707998447ad49)