### PR TITLE
Document crates for publish readiness

### DIFF
--- a/crates/kitu-core/Cargo.toml
+++ b/crates/kitu-core/Cargo.toml
@@ -3,6 +3,13 @@ name = "kitu-core"
 version = "0.1.0"
 edition = "2021"
 publish = false
+description = "Foundational Kitu runtime types, errors, and timing primitives."
+license = "MIT"
+repository = "https://github.com/Nagitch/kitu-logic-processor"
+readme = "README.md"
+keywords = ["kitu", "runtime", "core"]
+categories = ["game-development", "data-structures"]
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 thiserror = { workspace = true }

--- a/crates/kitu-core/README.md
+++ b/crates/kitu-core/README.md
@@ -1,0 +1,20 @@
+# kitu-core
+
+Foundational Kitu runtime primitives (errors, ticks, timestamps, and shared utilities) used across the workspace crates.
+
+## Responsibilities
+- Provide the shared `KituError` type and `Result` alias so downstream crates can stay dependency-light.
+- Keep tick and timestamp helpers consistent between the runtime loop and supporting tooling.
+- Host small, reusable utilities that should not pull in heavier dependencies.
+
+## Publish readiness
+- Status: internal-only for now (`publish = false`), but metadata is filled so the crate can be packaged when the MVP is ready.
+- Before toggling publication, run the workspace quality gates:
+  - `cargo fmt --check`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo test`
+  - `cargo doc --no-deps`
+  - `cargo publish --dry-run`
+
+## Related docs
+- Workspace map and crate relationships: `doc/crates-overview.md`

--- a/crates/kitu-data-sqlite/Cargo.toml
+++ b/crates/kitu-data-sqlite/Cargo.toml
@@ -3,6 +3,13 @@ name = "kitu-data-sqlite"
 version = "0.1.0"
 edition = "2021"
 publish = false
+description = "SQLite-backed data utilities and schema helpers for Kitu tooling."
+license = "MIT"
+repository = "https://github.com/Nagitch/kitu-logic-processor"
+readme = "README.md"
+keywords = ["kitu", "sqlite", "data"]
+categories = ["database", "game-development"]
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 kitu-core = { path = "../kitu-core" }

--- a/crates/kitu-data-sqlite/README.md
+++ b/crates/kitu-data-sqlite/README.md
@@ -1,0 +1,20 @@
+# kitu-data-sqlite
+
+SQLite-backed data utilities and schema helpers for Kitu pipelines and runtime consumers.
+
+## Responsibilities
+- Encapsulate SQLite schema management, migrations, and query helpers shared across tools.
+- Keep storage concerns isolated from runtime/timeline logic.
+- Provide deterministic data access patterns suitable for headless or embedded hosts.
+
+## Publish readiness
+- Status: internal-only (`publish = false`), but crates.io-facing metadata and README are prepared.
+- Execute the gate before changing publication flags:
+  - `cargo fmt --check`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo test`
+  - `cargo doc --no-deps`
+  - `cargo publish --dry-run`
+
+## Related docs
+- Workspace crate overview: `doc/crates-overview.md`

--- a/crates/kitu-data-tmd/Cargo.toml
+++ b/crates/kitu-data-tmd/Cargo.toml
@@ -3,6 +3,13 @@ name = "kitu-data-tmd"
 version = "0.1.0"
 edition = "2021"
 publish = false
+description = "Parser and loader utilities for Tanu Markdown (TMD) data."
+license = "MIT"
+repository = "https://github.com/Nagitch/kitu-logic-processor"
+readme = "README.md"
+keywords = ["kitu", "tmd", "data"]
+categories = ["game-development", "parser-implementations"]
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 kitu-core = { path = "../kitu-core" }

--- a/crates/kitu-data-tmd/README.md
+++ b/crates/kitu-data-tmd/README.md
@@ -1,0 +1,20 @@
+# kitu-data-tmd
+
+Parser and loader utilities for Tanu Markdown (TMD) data used by the Kitu runtime.
+
+## Responsibilities
+- Parse authored TMD assets into strongly typed structures.
+- Keep schema evolution and validation logic isolated from runtime code.
+- Prepare data for deterministic playback pipelines.
+
+## Publish readiness
+- Status: internal (`publish = false`), with crates.io metadata and README in place for future packaging.
+- Run the workspace gates before enabling publication:
+  - `cargo fmt --check`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo test`
+  - `cargo doc --no-deps`
+  - `cargo publish --dry-run`
+
+## Related docs
+- Workspace crate overview: `doc/crates-overview.md`

--- a/crates/kitu-ecs/Cargo.toml
+++ b/crates/kitu-ecs/Cargo.toml
@@ -3,6 +3,13 @@ name = "kitu-ecs"
 version = "0.1.0"
 edition = "2021"
 publish = false
+description = "Lightweight ECS world and scheduler used by the Kitu runtime loop."
+license = "MIT"
+repository = "https://github.com/Nagitch/kitu-logic-processor"
+readme = "README.md"
+keywords = ["kitu", "ecs", "runtime"]
+categories = ["game-development", "data-structures"]
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 kitu-core = { path = "../kitu-core" }

--- a/crates/kitu-ecs/README.md
+++ b/crates/kitu-ecs/README.md
@@ -1,0 +1,20 @@
+# kitu-ecs
+
+Lightweight ECS world and scheduler powering the Kitu runtime loop.
+
+## Responsibilities
+- Track registered component types without locking the runtime into a heavyweight backend.
+- Provide system scheduling hooks that keep ticking deterministic and testable.
+- Serve as the glue between runtime orchestration and domain-specific systems.
+
+## Publish readiness
+- Status: internal-only (`publish = false`), but metadata and README are ready for packaging once the MVP stabilizes.
+- Run the standard gates before flipping publication flags:
+  - `cargo fmt --check`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo test`
+  - `cargo doc --no-deps`
+  - `cargo publish --dry-run`
+
+## Related docs
+- Crate map and dependencies: `doc/crates-overview.md`

--- a/crates/kitu-osc-ir/Cargo.toml
+++ b/crates/kitu-osc-ir/Cargo.toml
@@ -3,6 +3,13 @@ name = "kitu-osc-ir"
 version = "0.1.0"
 edition = "2021"
 publish = false
+description = "OSC-inspired intermediate representation for Kitu runtime messaging."
+license = "MIT"
+repository = "https://github.com/Nagitch/kitu-logic-processor"
+readme = "README.md"
+keywords = ["kitu", "osc", "messaging"]
+categories = ["network-programming", "data-structures"]
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 kitu-core = { path = "../kitu-core" }

--- a/crates/kitu-osc-ir/README.md
+++ b/crates/kitu-osc-ir/README.md
@@ -1,0 +1,20 @@
+# kitu-osc-ir
+
+OSC-inspired intermediate representation for messages flowing through Kitu transports and runtime APIs.
+
+## Responsibilities
+- Define the message shapes exchanged between transports and higher-level runtime logic.
+- Stay transport-agnostic so tooling and backends can interoperate safely.
+- Provide a stable surface area that downstream crates can depend on without heavy dependencies.
+
+## Publish readiness
+- Status: internal (`publish = false`), but metadata and README are ready for crates.io when publishing is allowed.
+- Execute the standard quality gates before changing publication settings:
+  - `cargo fmt --check`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo test`
+  - `cargo doc --no-deps`
+  - `cargo publish --dry-run`
+
+## Related docs
+- Crate map and data-flow notes: `doc/crates-overview.md`

--- a/crates/kitu-runtime/Cargo.toml
+++ b/crates/kitu-runtime/Cargo.toml
@@ -3,6 +3,13 @@ name = "kitu-runtime"
 version = "0.1.0"
 edition = "2021"
 publish = false
+description = "Tick-based orchestrator that wires ECS, transports, and scripting layers."
+license = "MIT"
+repository = "https://github.com/Nagitch/kitu-logic-processor"
+readme = "README.md"
+keywords = ["kitu", "runtime", "ecs"]
+categories = ["game-development"]
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 kitu-core = { path = "../kitu-core" }

--- a/crates/kitu-runtime/README.md
+++ b/crates/kitu-runtime/README.md
@@ -1,0 +1,20 @@
+# kitu-runtime
+
+Tick-based orchestrator that wires Kitu ECS, transports, and future scripting/timeline layers.
+
+## Responsibilities
+- Advance the simulation tick-by-tick and dispatch ECS systems deterministically.
+- Bridge transports, scripting, and data playback while keeping the loop embeddable.
+- Expose configuration hooks (tick rate, logging) that callers can tune per host.
+
+## Publish readiness
+- Status: internal (`publish = false`) but documentation and metadata follow the crates.io guidelines for later publication.
+- Run the full gate before toggling publication flags:
+  - `cargo fmt --check`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo test`
+  - `cargo doc --no-deps`
+  - `cargo publish --dry-run`
+
+## Related docs
+- Runtime position within the workspace: `doc/crates-overview.md`

--- a/crates/kitu-scripting-rhai/Cargo.toml
+++ b/crates/kitu-scripting-rhai/Cargo.toml
@@ -3,6 +3,13 @@ name = "kitu-scripting-rhai"
 version = "0.1.0"
 edition = "2021"
 publish = false
+description = "Rhai scripting bindings and helpers for the Kitu runtime."
+license = "MIT"
+repository = "https://github.com/Nagitch/kitu-logic-processor"
+readme = "README.md"
+keywords = ["kitu", "rhai", "scripting"]
+categories = ["game-development"]
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 kitu-core = { path = "../kitu-core" }

--- a/crates/kitu-scripting-rhai/README.md
+++ b/crates/kitu-scripting-rhai/README.md
@@ -1,0 +1,20 @@
+# kitu-scripting-rhai
+
+Rhai scripting bindings and helpers for embedding scripts into the Kitu runtime.
+
+## Responsibilities
+- Provide a safe Rhai host configured for runtime data and APIs.
+- Expose bindings that keep scripts decoupled from ECS internals while remaining deterministic.
+- Offer helpers for loading, validating, and executing Rhai scripts during development.
+
+## Publish readiness
+- Status: internal (`publish = false`), but crates.io metadata is prepared alongside this README.
+- Run the standard gate before flipping publication flags:
+  - `cargo fmt --check`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo test`
+  - `cargo doc --no-deps`
+  - `cargo publish --dry-run`
+
+## Related docs
+- Workspace crate map: `doc/crates-overview.md`

--- a/crates/kitu-shell/Cargo.toml
+++ b/crates/kitu-shell/Cargo.toml
@@ -3,6 +3,13 @@ name = "kitu-shell"
 version = "0.1.0"
 edition = "2021"
 publish = false
+description = "CLI shell primitives for driving and inspecting the Kitu runtime."
+license = "MIT"
+repository = "https://github.com/Nagitch/kitu-logic-processor"
+readme = "README.md"
+keywords = ["kitu", "cli", "runtime"]
+categories = ["command-line-utilities", "game-development"]
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 kitu-core = { path = "../kitu-core" }

--- a/crates/kitu-shell/README.md
+++ b/crates/kitu-shell/README.md
@@ -1,0 +1,20 @@
+# kitu-shell
+
+CLI shell primitives for driving and inspecting the Kitu runtime during development.
+
+## Responsibilities
+- Offer developer-focused commands for diagnostics, replay, and scripting entry points.
+- Stay thin, delegating core logic to runtime crates while providing ergonomic wrappers.
+- Enable headless testing workflows that mirror embedded host behavior.
+
+## Publish readiness
+- Status: internal (`publish = false`), but crates.io metadata and README are staged for future publication.
+- Execute the publication gate before enabling releases:
+  - `cargo fmt --check`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo test`
+  - `cargo doc --no-deps`
+  - `cargo publish --dry-run`
+
+## Related docs
+- Workspace crate overview: `doc/crates-overview.md`

--- a/crates/kitu-transport/Cargo.toml
+++ b/crates/kitu-transport/Cargo.toml
@@ -3,6 +3,13 @@ name = "kitu-transport"
 version = "0.1.0"
 edition = "2021"
 publish = false
+description = "Transport abstraction and adapters for moving OSC/IR messages."
+license = "MIT"
+repository = "https://github.com/Nagitch/kitu-logic-processor"
+readme = "README.md"
+keywords = ["kitu", "transport", "messaging"]
+categories = ["network-programming", "game-development"]
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 kitu-core = { path = "../kitu-core" }

--- a/crates/kitu-transport/README.md
+++ b/crates/kitu-transport/README.md
@@ -1,0 +1,20 @@
+# kitu-transport
+
+Transport abstraction and adapters for moving OSC/IR messages between the runtime and external systems.
+
+## Responsibilities
+- Define the `Transport` trait for sending and receiving OSC/IR envelopes.
+- Provide composable adapters (in-memory, network, etc.) without dictating routing policies.
+- Keep the runtime deterministic by clearly separating transport concerns from game logic.
+
+## Publish readiness
+- Status: internal-only (`publish = false`) while the MVP takes shape; metadata now aligns with crates.io requirements.
+- Before enabling publication, run the workspace gates:
+  - `cargo fmt --check`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo test`
+  - `cargo doc --no-deps`
+  - `cargo publish --dry-run`
+
+## Related docs
+- Transport positioning within the runtime: `doc/crates-overview.md`

--- a/crates/kitu-tsq1/Cargo.toml
+++ b/crates/kitu-tsq1/Cargo.toml
@@ -3,6 +3,13 @@ name = "kitu-tsq1"
 version = "0.1.0"
 edition = "2021"
 publish = false
+description = "TSQ1 timeline AST and playback helpers for Kitu."
+license = "MIT"
+repository = "https://github.com/Nagitch/kitu-logic-processor"
+readme = "README.md"
+keywords = ["kitu", "timeline", "tsq1"]
+categories = ["game-development", "parser-implementations"]
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 kitu-core = { path = "../kitu-core" }

--- a/crates/kitu-tsq1/README.md
+++ b/crates/kitu-tsq1/README.md
@@ -1,0 +1,20 @@
+# kitu-tsq1
+
+TSQ1 timeline AST and playback helpers for Kitu presentation flows.
+
+## Responsibilities
+- Model TSQ1 timelines and events in a deterministic, testable form.
+- Provide helpers for driving playback that emit OSC/IR messages.
+- Remain decoupled from transport specifics so multiple frontends can reuse the logic.
+
+## Publish readiness
+- Status: internal (`publish = false`), but crates.io metadata and README are ready for packaging.
+- Run the publication gate before enabling release:
+  - `cargo fmt --check`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo test`
+  - `cargo doc --no-deps`
+  - `cargo publish --dry-run`
+
+## Related docs
+- Timeline positioning within the workspace: `doc/crates-overview.md`

--- a/crates/kitu-unity-ffi/Cargo.toml
+++ b/crates/kitu-unity-ffi/Cargo.toml
@@ -3,6 +3,13 @@ name = "kitu-unity-ffi"
 version = "0.1.0"
 edition = "2021"
 publish = false
+description = "C ABI bindings that expose the Kitu runtime to Unity hosts."
+license = "MIT"
+repository = "https://github.com/Nagitch/kitu-logic-processor"
+readme = "README.md"
+keywords = ["kitu", "unity", "ffi"]
+categories = ["api-bindings", "game-development"]
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 kitu-core = { path = "../kitu-core" }

--- a/crates/kitu-unity-ffi/README.md
+++ b/crates/kitu-unity-ffi/README.md
@@ -1,0 +1,20 @@
+# kitu-unity-ffi
+
+C ABI bindings that expose the Kitu runtime to Unity hosts.
+
+## Responsibilities
+- Marshal data between Unity buffers and the Rust runtime API.
+- Provide a stable ABI surface appropriate for a `cdylib` target.
+- Keep Unity-facing details isolated from core runtime logic.
+
+## Publish readiness
+- Status: internal (`publish = false`), but metadata and README prepare the crate for crates.io packaging.
+- Run the gate before enabling publication:
+  - `cargo fmt --check`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo test`
+  - `cargo doc --no-deps`
+  - `cargo publish --dry-run`
+
+## Related docs
+- Workspace crate overview: `doc/crates-overview.md`

--- a/crates/kitu-web-admin-backend/Cargo.toml
+++ b/crates/kitu-web-admin-backend/Cargo.toml
@@ -3,6 +3,13 @@ name = "kitu-web-admin-backend"
 version = "0.1.0"
 edition = "2021"
 publish = false
+description = "Backend glue (HTTP/WS) for the Kitu web admin experience."
+license = "MIT"
+repository = "https://github.com/Nagitch/kitu-logic-processor"
+readme = "README.md"
+keywords = ["kitu", "web", "admin"]
+categories = ["web-programming::http-server", "game-development"]
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 kitu-core = { path = "../kitu-core" }

--- a/crates/kitu-web-admin-backend/README.md
+++ b/crates/kitu-web-admin-backend/README.md
@@ -1,0 +1,20 @@
+# kitu-web-admin-backend
+
+Backend glue (HTTP/WS) for the Kitu web admin experience.
+
+## Responsibilities
+- Provide HTTP/WS endpoints that surface runtime diagnostics and controls.
+- Delegate simulation work to runtime crates while keeping web concerns isolated.
+- Support live inspection hooks needed by the admin frontend.
+
+## Publish readiness
+- Status: internal-only (`publish = false`), with crates.io-ready metadata and README committed.
+- Run the quality gate before enabling publication:
+  - `cargo fmt --check`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo test`
+  - `cargo doc --no-deps`
+  - `cargo publish --dry-run`
+
+## Related docs
+- Workspace crate overview: `doc/crates-overview.md`


### PR DESCRIPTION
## Summary
- add README files for each crate describing responsibilities and publish-readiness steps
- enrich crate Cargo.toml metadata with descriptions, licensing, repository links, and packaging includes
- align crate metadata with crates.io preparation guidelines while keeping publish=false

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b781772288328bf1866b5e88eef99)