### PR TITLE
Clarify tick input timing, per-tick processing order, and diagram arrow semantics in architecture docs

### DIFF
--- a/PROJECT_TODO.md
+++ b/PROJECT_TODO.md
@@ -24,8 +24,9 @@ This file is maintained by both human contributors and AI assistants.
   - [x] Document module boundaries (timeline, ecs, bridge)
   - [x] Capture invariants and determinism requirements in `doc/architecture.md`
 - [ ] Testing baseline
-  - [ ] Add unit tests for existing crates/modules
+  - [ ] Expand unit test coverage across existing crates/modules
   - [ ] Add integration tests covering sample logic flows
+  - [ ] Add deterministic replay test coverage for tick/event streams
 - [ ] Publish-readiness checklist per crate
   - [ ] Fill in package metadata and `include` directives
   - [ ] Validate `cargo publish --dry-run` where applicable

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -58,6 +58,8 @@ Kitu separates **authoritative runtime logic** (Rust) from **presentation and pl
 
 Kitu is organized as a layered architecture where core primitives sit at the bottom, orchestration in the middle, and integration/tooling at the boundary.
 
+For diagram readability: arrows in dependency diagrams mean "depends on", while arrows in architecture flow diagrams mean information or control flow.
+
 ```mermaid
 flowchart LR
     subgraph Authoring[Authoring and Build Inputs]
@@ -121,10 +123,11 @@ The runtime model is **authoritative, tick-driven, and deterministic-first**.
 
 ### Per-tick execution phases (current MVP)
 
-1. Dispatch ECS systems for current tick.
-2. Poll transport events currently queued.
-3. Route/process message events (currently placeholder in skeleton).
-4. Increment tick counter.
+1. Freeze the committed input batch for the current tick.
+2. Dispatch ECS systems for the current tick.
+3. Emit runtime outputs/events produced by this tick.
+4. Poll transport events and enqueue newly received inputs for the next committed batch.
+5. Increment tick counter.
 
 ### Runtime extension points (planned but bounded by this architecture)
 
@@ -153,6 +156,14 @@ sequenceDiagram
     Modules-->>Runtime: generated runtime actions
     Runtime-->>Host: Result and next tick value
 ```
+
+### Input Application Timing
+
+Inputs received during tick `N` are not applied immediately to authoritative simulation state.
+They are queued and become part of the committed input batch for tick `N+1`.
+This keeps tick evaluation deterministic and independent from transport polling timing.
+
+This timing rule supports deterministic replay, stable network synchronization, and transport timing independence.
 
 ### Tick-based processing order requirements
 


### PR DESCRIPTION
### Motivation

- Reduce ambiguity in how inputs are applied relative to tick boundaries so replay and networking expectations are clear. 
- Make the runtime tick processing order explicit so tooling and implementers can rely on a single, stable per-tick model. 
- Avoid confusion between dependency and information-flow diagrams when reading architecture docs.

### Description

- Added a short clarification near the first architecture diagram that states arrows in dependency diagrams mean "depends on" while arrows in architecture flow diagrams mean information or control flow, to avoid cross-document ambiguity. 
- Reworked the per-tick execution phase list in `doc/architecture.md` into an explicit five-step ordered model: freeze committed input batch, dispatch ECS systems, emit outputs/events, poll transports and enqueue new inputs, then increment the tick. 
- Inserted a new `Input Application Timing` subsection under the existing `Tick and event flow` heading (placed after the sequence diagram and before the tick-order requirements) that specifies inputs received during tick `N` are queued and become the committed input batch for tick `N+1`, and explains that this supports deterministic replay, stable network synchronization, and transport timing independence. 
- Updated `PROJECT_TODO.md` to change the testing baseline wording to emphasize expanding unit test coverage, adding integration tests, and adding deterministic replay test coverage for tick/event streams.

### Testing

- This change is documentation-only; no crate compilation or unit/integration tests were executed locally against the codebase. 
- Performed local diff inspection of the modified files (`doc/architecture.md` and `PROJECT_TODO.md`) to verify the intended minimal edits were applied successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac339730bc8328a442752afe64ce57)