### PR TITLE
Clarify runtime execution contract and add fixed-step runtime with next-tick IO

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ The Rust backend is the authoritative “game universe”.
 Core responsibilities:
 
 - ECS entities/components/systems for all simulation
-- Game loop driven by a high‑precision timer
-- Handling OSC input events from Unity/Web Admin/tests
+- Game loop driven by a fixed-timestep accumulator (`update(dt)` -> deterministic ticks)
+- Handling OSC input events from Unity/Web Admin/tests with next-tick application (`N` receive -> `N+1` apply)
 - Running Rhai scripts for configurable behavior (skills, quests, AI, etc.)
 - Executing TSQ1 timelines
 - Loading and validating TMD + SQLite data
@@ -86,6 +86,8 @@ The backend can run:
 - As an **embedded cdylib** inside Unity (for offline or single‑player builds)
 
 In both cases, the logic code is identical, ensuring identical behavior.
+
+Runtime execution contract: [`specs/runtime-execution-contract.md`](specs/runtime-execution-contract.md).
 
 
 ## Communication Layer (OSC + osc-ir + MessagePack)

--- a/crates/kitu-runtime/README.md
+++ b/crates/kitu-runtime/README.md
@@ -4,8 +4,10 @@ Tick-based orchestrator that wires Kitu ECS, transports, and future scripting/ti
 
 ## Responsibilities
 - Advance the simulation tick-by-tick and dispatch ECS systems deterministically.
+- Run `update(dt)` with a fixed-timestep accumulator.
+- Apply transport input on the next tick (`N` receive -> `N+1` apply).
+- Emit staged runtime output after ECS dispatch and before transport polling.
 - Bridge transports, scripting, and data playback while keeping the loop embeddable.
-- Expose configuration hooks (tick rate, logging) that callers can tune per host.
 
 ## Publish readiness
 - Status: internal (`publish = false`) but documentation and metadata follow the crates.io guidelines for later publication.
@@ -17,4 +19,5 @@ Tick-based orchestrator that wires Kitu ECS, transports, and future scripting/ti
   - `cargo publish --dry-run`
 
 ## Related docs
+- Runtime contract: `specs/runtime-execution-contract.md`
 - Runtime position within the workspace: `doc/crates-overview.md`

--- a/crates/kitu-runtime/src/lib.rs
+++ b/crates/kitu-runtime/src/lib.rs
@@ -123,7 +123,7 @@ impl<T: Transport> Runtime<T> {
         }
 
         let dt_secs = f64::from(dt);
-        if dt_secs > Duration::MAX.as_secs_f64() {
+        if dt_secs >= Duration::MAX.as_secs_f64() {
             return Err(KituError::InvalidInput("dt is too large"));
         }
 
@@ -284,6 +284,9 @@ mod tests {
     fn update_rejects_oversized_dt() {
         let mut runtime = build_runtime(LocalChannel::default());
         assert!(runtime.update(f32::MAX).is_err());
+
+        let boundary = Duration::MAX.as_secs_f64() as f32;
+        assert!(runtime.update(boundary).is_err());
     }
 
     #[test]

--- a/crates/kitu-runtime/src/lib.rs
+++ b/crates/kitu-runtime/src/lib.rs
@@ -102,10 +102,22 @@ impl<T: Transport> Runtime<T> {
         self.output_buffer.drain(..).collect()
     }
 
+    /// Drains committed input bundles in FIFO order.
+    ///
+    /// Input bundles are committed at the beginning of a tick and remain
+    /// available until explicitly drained by the caller.
+    pub fn drain_committed_inputs(&mut self) -> Vec<OscBundle> {
+        self.committed_inputs.drain(..).collect()
+    }
+
     /// Processes as many fixed ticks as `dt` allows.
     ///
     /// Returns how many ticks were executed.
     pub fn update(&mut self, dt: f32) -> Result<u32> {
+        if !dt.is_finite() {
+            return Err(KituError::InvalidInput("dt must be finite"));
+        }
+
         if dt.is_sign_negative() {
             return Err(KituError::InvalidInput("dt must be non-negative"));
         }
@@ -141,7 +153,7 @@ impl<T: Transport> Runtime<T> {
     /// assert_eq!(runtime.current_tick().get(), 1);
     /// ```
     pub fn tick_once(&mut self) -> Result<()> {
-        self.committed_inputs = std::mem::take(&mut self.pending_inputs);
+        self.committed_inputs.append(&mut self.pending_inputs);
 
         self.world.dispatch(self.tick)?;
 
@@ -245,6 +257,13 @@ mod tests {
     }
 
     #[test]
+    fn update_rejects_non_finite_dt() {
+        let mut runtime = build_runtime(LocalChannel::default());
+        assert!(runtime.update(f32::NAN).is_err());
+        assert!(runtime.update(f32::INFINITY).is_err());
+    }
+
+    #[test]
     fn tick_applies_transport_input_on_next_tick() {
         struct ScriptedTransport {
             events: VecDeque<TransportEvent>,
@@ -274,8 +293,23 @@ mod tests {
         assert_eq!(runtime.pending_inputs.len(), 1);
 
         runtime.tick_once().unwrap();
-        assert_eq!(runtime.committed_inputs.len(), 1);
+        let committed = runtime.drain_committed_inputs();
+        assert_eq!(committed.len(), 1);
         assert_eq!(runtime.pending_inputs.len(), 0);
+    }
+
+    #[test]
+    fn committed_inputs_are_preserved_until_drained() {
+        let mut runtime = build_runtime(LocalChannel::default());
+        let mut input = OscBundle::new();
+        input.push(kitu_osc_ir::OscMessage::new("/input/attack"));
+        runtime.enqueue_input(input.clone());
+
+        runtime.tick_once().unwrap();
+        runtime.tick_once().unwrap();
+
+        let committed = runtime.drain_committed_inputs();
+        assert_eq!(committed, vec![input]);
     }
 
     #[test]

--- a/crates/kitu-runtime/src/lib.rs
+++ b/crates/kitu-runtime/src/lib.rs
@@ -122,8 +122,25 @@ impl<T: Transport> Runtime<T> {
             return Err(KituError::InvalidInput("dt must be non-negative"));
         }
 
-        self.accumulator += Duration::from_secs_f32(dt);
+        let dt_secs = f64::from(dt);
+        if dt_secs > Duration::MAX.as_secs_f64() {
+            return Err(KituError::InvalidInput("dt is too large"));
+        }
+
+        if self.config.tick_rate_hz == 0 {
+            return Err(KituError::InvalidInput(
+                "tick_rate_hz must be greater than zero",
+            ));
+        }
+
+        self.accumulator += Duration::from_secs_f64(dt_secs);
         let frame_time = self.config.frame_time();
+        if frame_time.is_zero() {
+            return Err(KituError::InvalidInput(
+                "frame_time must be greater than zero",
+            ));
+        }
+
         let mut executed = 0;
 
         while self.accumulator >= frame_time {
@@ -261,6 +278,26 @@ mod tests {
         let mut runtime = build_runtime(LocalChannel::default());
         assert!(runtime.update(f32::NAN).is_err());
         assert!(runtime.update(f32::INFINITY).is_err());
+    }
+
+    #[test]
+    fn update_rejects_oversized_dt() {
+        let mut runtime = build_runtime(LocalChannel::default());
+        assert!(runtime.update(f32::MAX).is_err());
+    }
+
+    #[test]
+    fn update_rejects_invalid_tick_rate() {
+        let mut runtime = Runtime::new(RuntimeConfig { tick_rate_hz: 0 }, LocalChannel::default());
+        assert!(runtime.update(0.016).is_err());
+
+        let mut runtime = Runtime::new(
+            RuntimeConfig {
+                tick_rate_hz: u32::MAX,
+            },
+            LocalChannel::default(),
+        );
+        assert!(runtime.update(0.016).is_err());
     }
 
     #[test]

--- a/crates/kitu-runtime/src/lib.rs
+++ b/crates/kitu-runtime/src/lib.rs
@@ -10,10 +10,11 @@
 //! (`kitu-osc-ir`), and future data or scripting layers. See `doc/crates-overview.md` for how the
 //! runtime coordinates the workspace crates.
 
-use std::time::Duration;
+use std::{collections::VecDeque, time::Duration};
 
-use kitu_core::{Result, Tick};
+use kitu_core::{KituError, Result, Tick};
 use kitu_ecs::EcsWorld;
+use kitu_osc_ir::OscBundle;
 use kitu_transport::{Transport, TransportEvent};
 
 /// Configuration for the runtime loop.
@@ -45,8 +46,13 @@ impl RuntimeConfig {
 pub struct Runtime<T: Transport> {
     config: RuntimeConfig,
     tick: Tick,
+    accumulator: Duration,
     transport: T,
     world: EcsWorld,
+    committed_inputs: VecDeque<OscBundle>,
+    pending_inputs: VecDeque<OscBundle>,
+    staged_outputs: VecDeque<OscBundle>,
+    output_buffer: VecDeque<OscBundle>,
 }
 
 impl<T: Transport> Runtime<T> {
@@ -66,8 +72,13 @@ impl<T: Transport> Runtime<T> {
         Self {
             config,
             tick: Tick::start(),
+            accumulator: Duration::ZERO,
             transport,
             world: EcsWorld::default(),
+            committed_inputs: VecDeque::new(),
+            pending_inputs: VecDeque::new(),
+            staged_outputs: VecDeque::new(),
+            output_buffer: VecDeque::new(),
         }
     }
 
@@ -76,11 +87,47 @@ impl<T: Transport> Runtime<T> {
         &mut self.world
     }
 
+    /// Enqueues an input bundle for the next tick.
+    pub fn enqueue_input(&mut self, input: OscBundle) {
+        self.pending_inputs.push_back(input);
+    }
+
+    /// Stages an output bundle that becomes visible after the current tick.
+    pub fn queue_output(&mut self, output: OscBundle) {
+        self.staged_outputs.push_back(output);
+    }
+
+    /// Drains all emitted output bundles in FIFO order.
+    pub fn drain_output_buffer(&mut self) -> Vec<OscBundle> {
+        self.output_buffer.drain(..).collect()
+    }
+
+    /// Processes as many fixed ticks as `dt` allows.
+    ///
+    /// Returns how many ticks were executed.
+    pub fn update(&mut self, dt: f32) -> Result<u32> {
+        if dt.is_sign_negative() {
+            return Err(KituError::InvalidInput("dt must be non-negative"));
+        }
+
+        self.accumulator += Duration::from_secs_f32(dt);
+        let frame_time = self.config.frame_time();
+        let mut executed = 0;
+
+        while self.accumulator >= frame_time {
+            self.tick_once()?;
+            self.accumulator -= frame_time;
+            executed += 1;
+        }
+
+        Ok(executed)
+    }
+
     /// Processes a single tick of the runtime loop.
     ///
-    /// This dispatches all scheduled ECS systems for the current tick and
-    /// polls the transport for pending events before incrementing the tick
-    /// counter.
+    /// This dispatches all scheduled ECS systems for the current tick, emits
+    /// staged outputs, polls transport events, and increments the tick counter.
+    /// Inputs received while polling are queued for the next tick.
     ///
     /// # Examples
     ///
@@ -94,12 +141,18 @@ impl<T: Transport> Runtime<T> {
     /// assert_eq!(runtime.current_tick().get(), 1);
     /// ```
     pub fn tick_once(&mut self) -> Result<()> {
+        self.committed_inputs = std::mem::take(&mut self.pending_inputs);
+
         self.world.dispatch(self.tick)?;
+
+        self.output_buffer.append(&mut self.staged_outputs);
+
         while let Some(event) = self.transport.poll_event() {
-            if let TransportEvent::Message(_) = event {
-                // Future work: route to ECS systems or script hooks.
+            if let TransportEvent::Message(bundle) = event {
+                self.pending_inputs.push_back(bundle);
             }
         }
+
         self.tick = self.tick.next();
         Ok(())
     }
@@ -152,7 +205,6 @@ pub fn build_runtime<T: Transport>(transport: T) -> Runtime<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kitu_core::KituError;
     use kitu_transport::LocalChannel;
 
     #[test]
@@ -180,19 +232,63 @@ mod tests {
     }
 
     #[test]
-    fn tick_once_returns_error_when_dispatch_fails() {
-        struct FailingTransport;
-        impl Transport for FailingTransport {
+    fn update_uses_fixed_timestep_accumulator() {
+        let mut runtime = build_runtime(LocalChannel::default());
+
+        let executed = runtime.update(0.010).unwrap();
+        assert_eq!(executed, 0);
+        assert_eq!(runtime.current_tick().get(), 0);
+
+        let executed = runtime.update(0.010).unwrap();
+        assert_eq!(executed, 1);
+        assert_eq!(runtime.current_tick().get(), 1);
+    }
+
+    #[test]
+    fn tick_applies_transport_input_on_next_tick() {
+        struct ScriptedTransport {
+            events: VecDeque<TransportEvent>,
+        }
+
+        impl Transport for ScriptedTransport {
             fn send(&mut self, _message: kitu_osc_ir::OscMessage) -> Result<()> {
-                Err(KituError::NotImplemented("send".into()))
+                Ok(())
             }
 
             fn poll_event(&mut self) -> Option<TransportEvent> {
-                None
+                self.events.pop_front()
             }
         }
 
-        let mut runtime = build_runtime(FailingTransport);
-        assert!(runtime.tick_once().is_ok());
+        let mut bundle = OscBundle::new();
+        bundle.push(kitu_osc_ir::OscMessage::new("/input/move"));
+
+        let transport = ScriptedTransport {
+            events: VecDeque::from([TransportEvent::Message(bundle)]),
+        };
+
+        let mut runtime = build_runtime(transport);
+
+        runtime.tick_once().unwrap();
+        assert_eq!(runtime.committed_inputs.len(), 0);
+        assert_eq!(runtime.pending_inputs.len(), 1);
+
+        runtime.tick_once().unwrap();
+        assert_eq!(runtime.committed_inputs.len(), 1);
+        assert_eq!(runtime.pending_inputs.len(), 0);
+    }
+
+    #[test]
+    fn outputs_are_emitted_after_tick() {
+        let mut runtime = build_runtime(LocalChannel::default());
+        let mut output = OscBundle::new();
+        output.push(kitu_osc_ir::OscMessage::new("/render/player/transform"));
+
+        runtime.queue_output(output.clone());
+        assert!(runtime.drain_output_buffer().is_empty());
+
+        runtime.tick_once().unwrap();
+        let drained = runtime.drain_output_buffer();
+        assert_eq!(drained, vec![output]);
     }
 }

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -119,7 +119,8 @@ The runtime model is **authoritative, tick-driven, and deterministic-first**.
 
 - `kitu-runtime` owns the `Tick` counter and increments exactly once per successful `tick_once`.
 - `RuntimeConfig.tick_rate_hz` defines fixed tick cadence and frame duration.
-- Runtime loop is expected to run at fixed-step simulation; rendering side may interpolate externally.
+- `Runtime::update(dt)` uses a fixed-timestep accumulator and executes zero or more `tick_once` calls depending on accumulated time.
+- Runtime loop is fixed-step simulation; rendering side may interpolate externally.
 
 ### Per-tick execution phases (current MVP)
 
@@ -138,6 +139,7 @@ The runtime model is **authoritative, tick-driven, and deterministic-first**.
 ## Tick and event flow
 
 The per-tick order must remain explicit and stable, because replay/debug tools depend on it.
+Normative reference: `specs/runtime-execution-contract.md`.
 
 ```mermaid
 sequenceDiagram
@@ -145,15 +147,15 @@ sequenceDiagram
     participant Runtime as kitu-runtime
     participant ECS as kitu-ecs world
     participant Transport as kitu-transport
-    participant Modules as TSQ1 or Rhai or Data hooks
 
     Host->>Runtime: tick_once()
-    Runtime->>ECS: dispatch systems at current tick
+    Runtime->>Runtime: commit pending_inputs as tick N inputs
+    Runtime->>ECS: dispatch systems at tick N
     ECS-->>Runtime: deterministic state updates
+    Runtime->>Runtime: emit staged outputs to output_buffer
     Runtime->>Transport: poll_event() until empty
-    Transport-->>Runtime: TransportEvent values
-    Runtime->>Modules: process queued messages and hooks
-    Modules-->>Runtime: generated runtime actions
+    Transport-->>Runtime: Message events for tick N+1
+    Runtime->>Runtime: increment tick to N+1
     Runtime-->>Host: Result and next tick value
 ```
 

--- a/doc/detailed-flows.md
+++ b/doc/detailed-flows.md
@@ -170,12 +170,12 @@ Each Unity `Update()` sends `deltaTime` to Rust. KituRuntime advances simulation
 ```csharp
 void Update(){
     var dt = Time.deltaTime;
-    KituNative.Update(dt);
     SendInputIfAny();
+    KituNative.Update(dt);
 }
 ```
 
-Unity responsibilities: notify elapsed time, send input events (e.g., `/input/move`, `/input/attack`), avoid game logic. Rust API: `kitu-unity-ffi::kitu_update(handle, delta_seconds: f32)`.
+Unity responsibilities: notify elapsed time, send input events (e.g., `/input/move`, `/input/attack`), avoid game logic. Rust API: `kitu-unity-ffi::kitu_update(handle, delta_seconds: f32)`. Inputs that arrive during tick `N` are applied in tick `N+1`.
 
 ### Rust: `KituRuntime.update(dt)`
 
@@ -195,12 +195,14 @@ Accumulates deltaTime, runs as many ticks as needed, and keeps the simulation on
 
 Phases (order fixed for determinism):
 
-1. **Input processing**: apply `/input/move`, `/input/attack`, etc. to ECS state.
-2. **AI / scripts**: enemy behavior and quest logic via Rhai.
-3. **Physics / movement**: apply velocity to position, simple collision.
-4. **Combat / damage**: hit checks, skill effects, HP updates.
-5. **Death handling**: mark dead entities, despawn.
-6. **Collect render data**: transforms, UI info, enqueue Unity-bound events.
+1. **Commit queued inputs**: freeze previously queued input bundle as tick `N` input.
+2. **Input processing**: apply `/input/move`, `/input/attack`, etc. from committed inputs to ECS state.
+3. **AI / scripts**: enemy behavior and quest logic via Rhai.
+4. **Physics / movement**: apply velocity to position, simple collision.
+5. **Combat / damage**: hit checks, skill effects, HP updates.
+6. **Death handling**: mark dead entities, despawn.
+7. **Collect render data**: transforms, UI info, enqueue Unity-bound events.
+8. **Transport poll**: queue newly received inputs for tick `N+1`.
 
 Crates: `kitu-ecs`, `game-ecs-features`, `game-logic`, `kitu-tsq1` (when skills present), `kitu-runtime` (event management).
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,3 +1,5 @@
 # Specifications
 
-Protocol and data format specifications (e.g., TSQ1, TMD, OSC-IR) will live here alongside reference assets.
+Protocol and behavior specifications live here.
+
+- `runtime-execution-contract.md`: authoritative runtime tick order, input timing, transport polling timing, and output emission timing.

--- a/specs/runtime-execution-contract.md
+++ b/specs/runtime-execution-contract.md
@@ -1,0 +1,64 @@
+# Runtime Execution Contract (MVP)
+
+This document defines the authoritative runtime loop contract for `kitu-runtime`.
+It is the normative specification for tick order, input timing, transport polling, and output emission.
+
+## Scope
+
+- Authoritative simulation loop in Rust (`kitu-runtime`).
+- Unity remains presentation + input boundary only.
+- Transport remains delivery-only and must not own gameplay logic.
+
+## Fixed timestep and `update(dt)`
+
+- `RuntimeConfig.tick_rate_hz` defines the fixed simulation step (`frame_time`).
+- `Runtime::update(dt)` accumulates wall-clock delta and executes `tick_once()` while `accumulator >= frame_time`.
+- `dt < 0` is invalid input.
+
+Pseudo flow:
+
+1. `accumulator += dt`
+2. While `accumulator >= frame_time`:
+   1. Execute one authoritative tick via `tick_once()`
+   2. `accumulator -= frame_time`
+
+## Tick contract
+
+For tick `N`, execution order is fixed as follows:
+
+1. **Commit input batch for tick `N`**
+   - Move `pending_inputs` into `committed_inputs`.
+2. **Dispatch ECS systems for tick `N`**
+   - Authoritative state update phase.
+3. **Emit outputs for tick `N`**
+   - Move staged outputs into externally visible `output_buffer`.
+4. **Poll transport**
+   - Drain `poll_event()` until empty.
+   - Any received `TransportEvent::Message` is enqueued into `pending_inputs`.
+5. **Advance tick**
+   - `tick = tick.next()`.
+
+## Input timing rule (normative)
+
+Inputs received during tick `N` are never applied during tick `N`.
+They are queued in `pending_inputs` and become the committed input batch at tick `N+1`.
+
+This rule is mandatory for deterministic replay and transport-timing independence.
+
+## Output timing rule
+
+Outputs generated during tick `N` are staged during execution and only become externally visible in the output buffer at phase 3 of tick `N`.
+Hosts should poll outputs after `update()`/`tick_once()` returns.
+
+## Minimal API surface (MVP)
+
+- `update(dt: f32) -> Result<u32>`: advance fixed ticks from an accumulator.
+- `tick_once() -> Result<()>`: execute exactly one authoritative tick with the fixed phase order.
+- `enqueue_input(bundle)`: queue host-provided input for a future tick.
+- `queue_output(bundle)`: stage runtime outputs for emission at phase 3.
+- `drain_output_buffer()`: read emitted outputs in FIFO order.
+
+## Relationship to architecture docs
+
+- `doc/architecture.md` defines architecture-level invariants.
+- `doc/detailed-flows.md` uses this tick contract when describing UC-02 and runtime boundaries.

--- a/specs/runtime-execution-contract.md
+++ b/specs/runtime-execution-contract.md
@@ -13,6 +13,7 @@ It is the normative specification for tick order, input timing, transport pollin
 
 - `RuntimeConfig.tick_rate_hz` defines the fixed simulation step (`frame_time`).
 - `Runtime::update(dt)` accumulates wall-clock delta and executes `tick_once()` while `accumulator >= frame_time`.
+- non-finite `dt` (`NaN`, `+/-∞`) is invalid input.
 - `dt < 0` is invalid input.
 
 Pseudo flow:
@@ -27,7 +28,7 @@ Pseudo flow:
 For tick `N`, execution order is fixed as follows:
 
 1. **Commit input batch for tick `N`**
-   - Move `pending_inputs` into `committed_inputs`.
+   - Append `pending_inputs` into `committed_inputs` (preserving any previously committed, not-yet-consumed inputs).
 2. **Dispatch ECS systems for tick `N`**
    - Authoritative state update phase.
 3. **Emit outputs for tick `N`**
@@ -57,6 +58,7 @@ Hosts should poll outputs after `update()`/`tick_once()` returns.
 - `enqueue_input(bundle)`: queue host-provided input for a future tick.
 - `queue_output(bundle)`: stage runtime outputs for emission at phase 3.
 - `drain_output_buffer()`: read emitted outputs in FIFO order.
+- `drain_committed_inputs()`: consume the committed input batch in FIFO order.
 
 ## Relationship to architecture docs
 

--- a/specs/runtime-execution-contract.md
+++ b/specs/runtime-execution-contract.md
@@ -15,6 +15,8 @@ It is the normative specification for tick order, input timing, transport pollin
 - `Runtime::update(dt)` accumulates wall-clock delta and executes `tick_once()` while `accumulator >= frame_time`.
 - non-finite `dt` (`NaN`, `+/-∞`) is invalid input.
 - `dt < 0` is invalid input.
+- `dt` that exceeds `Duration::MAX` is invalid input.
+- `tick_rate_hz` must be non-zero and produce a positive non-zero `frame_time`.
 
 Pseudo flow:
 


### PR DESCRIPTION
### Motivation
- Make the authoritative runtime execution timing explicit so deterministic replay and transport independence are guaranteed. 
- Specify whether inputs take effect in the current or next tick and fix tick-phase ordering to remove ambiguity between transport polling and ECS dispatch. 
- Provide a minimal, extendable runtime API that hosts (Unity / tools) can rely on for stable embedding and future features.

### Description
- Add a normative specification `specs/runtime-execution-contract.md` that defines the fixed-timestep accumulator behavior, per-tick phase order, the rule that inputs received in tick `N` apply in tick `N+1`, and output emission timing. 
- Implement a minimal fixed-step runtime in `crates/kitu-runtime/src/lib.rs` including `update(dt)`, `tick_once()`, an accumulator, next-tick input queues (`pending_inputs` → `committed_inputs`), staged outputs (`staged_outputs` → `output_buffer`), and helper APIs `enqueue_input`, `queue_output`, and `drain_output_buffer`. 
- Update architecture and detailed-flow docs (`doc/architecture.md`, `doc/detailed-flows.md`) and README files to reflect the contract and show the revised sequence (commit inputs → dispatch ECS → emit outputs → poll transport → advance tick). 
- Add unit tests in `crates/kitu-runtime` that assert the fixed-timestep accumulator semantics, that transport messages received during tick `N` are applied at tick `N+1`, and that outputs are emitted only after the tick.

### Testing
- Ran formatting and static checks with `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings`, both completed without issues. 
- Executed the full test suite with `cargo test --all`, and all tests (including the new `kitu-runtime` tests for accumulator, input timing, and output emission) passed. 
- Verified documentation updates to `doc/architecture.md`, `doc/detailed-flows.md`, and crate READMEs to ensure they reference the new runtime contract and are consistent with the implementation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad68db521c8328b6914c8d5622567b)