### PR TITLE
Align runtime execution contract wording across architecture and detailed flows

### DIFF
--- a/doc/detailed-flows.md
+++ b/doc/detailed-flows.md
@@ -193,15 +193,15 @@ Accumulates deltaTime, runs as many ticks as needed, and keeps the simulation on
 
 ### ECS scheduling per tick
 
-The authoritative runtime contract for tick `N` is fixed as: 
+The authoritative runtime contract for tick `N` is fixed as the following ordered phases (same contract as `doc/architecture.md`):
 
-1. **Current tick batch freeze**: clear previous committed inputs, then commit `pending_inputs` as tick `N` input batch.
+1. **Current tick batch freeze**: clear the previous committed batch, then move `pending_inputs` into the committed input batch for tick `N`.
 2. **ECS dispatch**: run deterministic systems for tick `N` (input processing, AI/scripts, physics/movement, combat/damage, death handling, render-data collection).
 3. **Output emission**: move staged runtime outputs for tick `N` into the externally visible output buffer.
-4. **Transport poll for next tick input**: drain transport events and queue messages into `pending_inputs` for tick `N+1`.
+4. **Transport poll for next tick input**: drain transport events and queue received messages into `pending_inputs` for tick `N+1`.
 5. **Tick increment**: advance from tick `N` to `N+1` as the final phase.
 
-Important timing rule: inputs received while tick `N` is running are never applied in tick `N`; they are first eligible in tick `N+1`. Transport polling alone must not directly mutate world state.
+Important timing rule: inputs received while tick `N` is running are never applied in tick `N`; they are first eligible in tick `N+1` when that tick starts and freezes its committed batch. Transport polling alone must not directly mutate authoritative world state.
 
 Crates: `kitu-ecs`, `game-ecs-features`, `game-logic`, `kitu-tsq1` (when skills present), `kitu-runtime` (authoritative phase orchestration and buffers).
 
@@ -602,4 +602,3 @@ Layers: Unity `com.kitu.runtime` (event bus) and `com.stella.game` (view). Unity
 1. **Save**: serialize necessary ECS components/resources (player state, quests, inventory, flags) to a versioned format (e.g., SQLite/MessagePack file).
 2. **Load**: pause runtime, rebuild world from the save data, then resume ticks.
 3. **Validation**: handle schema migrations or missing data gracefully; emit UI notices on success/failure.
-

--- a/specs/runtime-execution-contract.md
+++ b/specs/runtime-execution-contract.md
@@ -30,12 +30,12 @@ Pseudo flow:
 For tick `N`, execution order is fixed as follows:
 
 1. **Commit input batch for tick `N`**
-   - Append `pending_inputs` into `committed_inputs` (preserving any previously committed, not-yet-consumed inputs).
+   - Clear previous committed inputs, then move `pending_inputs` into `committed_inputs` for tick `N`.
 2. **Dispatch ECS systems for tick `N`**
    - Authoritative state update phase.
 3. **Emit outputs for tick `N`**
    - Move staged outputs into externally visible `output_buffer`.
-4. **Poll transport**
+4. **Poll transport for next tick input**
    - Drain `poll_event()` until empty.
    - Any received `TransportEvent::Message` is enqueued into `pending_inputs`.
 5. **Advance tick**


### PR DESCRIPTION
### Motivation
- Remove interpretation gaps between `doc/architecture.md`, `doc/detailed-flows.md`, and the normative `specs/runtime-execution-contract.md` so the execution ordering is unambiguous. 
- Make the input/tick timing rule explicit: inputs received during tick `N` must only be eligible when tick `N+1` begins (freeze/commit semantics). 

### Description
- Updated `doc/detailed-flows.md` to exactly match the authoritative per-tick phase ordering (`freeze` committed batch → `ECS` dispatch → `output` emission → `transport` poll for next-tick inputs → `tick` increment) and clarified that transport polling does not directly mutate authoritative world state. 
- Updated `specs/runtime-execution-contract.md` wording to use the same freeze/commit semantics (`clear previous committed inputs, then move pending into committed`) and renamed the phase to `Poll transport for next tick input` for clarity. 
- Verified `crates/kitu-runtime` already contains the minimal required runtime primitives (`update(dt)` fixed-timestep accumulator, `tick_once()` primitive, `pending`/`committed` input queues, staged output buffering, and `drain_output_buffer()`/`drain_committed_inputs()` APIs) and that unit tests exercise the intended ordering semantics. 

### Testing
- Ran `cargo fmt --all` with no remaining formatting changes. (succeeded)
- Ran `cargo clippy --all-targets --all-features -- -D warnings` with no warnings (succeeded).
- Ran `cargo test --all` and all tests passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aff35e490083288ac735d044d729e7)