### PR TITLE
Align runtime execution contract wording across architecture and detailed flows

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -124,10 +124,12 @@ The runtime model is **authoritative, tick-driven, and deterministic-first**.
 
 ### Per-tick execution phases (current MVP)
 
-1. **Current tick batch freeze**: clear previous committed inputs, then move `pending_inputs` into the committed batch for tick `N`.
-2. **ECS dispatch**: run deterministic ECS systems for tick `N` against that frozen batch.
+The canonical per-tick order is:
+
+1. **Freeze committed input batch for current tick**: clear previous committed inputs, then move `pending_inputs` into the committed batch for tick `N`.
+2. **ECS dispatch / simulation**: run deterministic ECS systems for tick `N` against that frozen batch.
 3. **Output emission**: move staged outputs produced during tick `N` into the externally visible output buffer.
-4. **Transport poll for next tick**: drain transport events and enqueue received messages into `pending_inputs` for tick `N+1`.
+4. **Transport poll for next tick input**: drain transport events and enqueue received messages into `pending_inputs` for tick `N+1`.
 5. **Tick increment**: advance `tick` from `N` to `N+1` as the final phase.
 
 ### Runtime extension points (planned but bounded by this architecture)
@@ -162,6 +164,7 @@ sequenceDiagram
 ### Input Application Timing
 
 Inputs received during tick `N` are not applied immediately to authoritative simulation state.
+**Input received during tick `N` is applied on tick `N+1`.**
 They are queued in `pending_inputs` during the transport-poll phase and only become the committed batch when tick `N+1` begins.
 Transport polling itself must not directly mutate world state.
 This keeps tick evaluation deterministic and independent from transport polling timing.

--- a/doc/detailed-flows.md
+++ b/doc/detailed-flows.md
@@ -193,15 +193,15 @@ Accumulates deltaTime, runs as many ticks as needed, and keeps the simulation on
 
 ### ECS scheduling per tick
 
-The authoritative runtime contract for tick `N` is fixed as the following ordered phases (same contract as `doc/architecture.md`):
+The authoritative runtime contract for tick `N` is fixed as the following canonical ordered phases (same contract as `doc/architecture.md`):
 
-1. **Current tick batch freeze**: clear the previous committed batch, then move `pending_inputs` into the committed input batch for tick `N`.
-2. **ECS dispatch**: run deterministic systems for tick `N` (input processing, AI/scripts, physics/movement, combat/damage, death handling, render-data collection).
+1. **Freeze committed input batch for current tick**: clear the previous committed batch, then move `pending_inputs` into the committed input batch for tick `N`.
+2. **ECS dispatch / simulation**: run deterministic systems for tick `N` (input processing, AI/scripts, physics/movement, combat/damage, death handling, render-data collection).
 3. **Output emission**: move staged runtime outputs for tick `N` into the externally visible output buffer.
 4. **Transport poll for next tick input**: drain transport events and queue received messages into `pending_inputs` for tick `N+1`.
 5. **Tick increment**: advance from tick `N` to `N+1` as the final phase.
 
-Important timing rule: inputs received while tick `N` is running are never applied in tick `N`; they are first eligible in tick `N+1` when that tick starts and freezes its committed batch. Transport polling alone must not directly mutate authoritative world state.
+Important timing rule: **input received during tick `N` is applied on tick `N+1`**. Inputs received while tick `N` is running are never applied in tick `N`; they are first eligible in tick `N+1` when that tick starts and freezes its committed batch. Transport polling alone must not directly mutate authoritative world state.
 
 Crates: `kitu-ecs`, `game-ecs-features`, `game-logic`, `kitu-tsq1` (when skills present), `kitu-runtime` (authoritative phase orchestration and buffers).
 


### PR DESCRIPTION
### Motivation
- Clarify and remove ambiguity between high-level architecture and per-use-case detailed flows about tick phases and input timing.
- Ensure documentation language matches the authoritative runtime semantics so tooling, replay, and integration teams have a single canonical contract to follow.

### Description
- Synchronized wording and ordering in `doc/architecture.md` and `doc/detailed-flows.md` to the canonical five phases: `freeze committed input batch for current tick`, `ECS dispatch / simulation`, `output emission`, `transport poll for next tick input`, and `tick increment`.
- Explicitly stated the timing rule: `input received during tick N is applied on tick N+1` and reiterated that transport polling must not directly mutate authoritative world state.
- No runtime code changes were required because `crates/kitu-runtime` already implements a fixed-timestep `update(dt)` accumulator, `tick_once()` primitive, separated `committed_inputs`/`pending_inputs`, staged output buffering/drain API, and ordering semantics; this change updates the docs to reflect that contract.

### Testing
- Ran `cargo test --all`, which completed successfully for the workspace (all crates tests passed). 
- Verified `crates/kitu-runtime` unit tests covering ordering semantics (input N→N+1, transport poll behavior, output emission timing, accumulator multi-tick behavior, and final-phase tick increment) ran and passed as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8108848dc8328a8d22ae924db29a5)