### PR TITLE
kitu-runtime: add player move vertical slice (/input/move -> /render/player/transform) and tests

### DIFF
--- a/PROJECT_TODO.md
+++ b/PROJECT_TODO.md
@@ -34,7 +34,7 @@ Remaining work:
 
 Status:
 
-- In progress: baseline implementation exists, but repository-wide validation is still incomplete.
+- In progress: first end-to-end gameplay slice validation and integration-level tests now exist; final completion review is pending.
 
 Repository state:
 
@@ -46,26 +46,26 @@ Repository state:
 
 Remaining work:
 
-- [ ] Validate the current runtime loop through the first real end-to-end gameplay slice.
-- [ ] Expand testing beyond `kitu-runtime` unit tests into integration-level validation.
+- [x] Validate the current runtime loop through the first real end-to-end gameplay slice.
+- [x] Expand testing beyond `kitu-runtime` unit tests into integration-level validation.
 - [ ] Re-evaluate whether P1 can be considered complete after the vertical slice and replay smoke path exist.
 
 ### P2 — Build the minimum vertical slice
 
 Status:
 
-- In progress: slice contract is defined; implementation is still pending.
+- In progress: the player move slice is now implemented in runtime, while Unity/host boundary work is still pending.
 
 Repository state:
 
 - [x] `specs/vertical-slice-player-move.md` defines `/input/move` -> authoritative state update -> `/render/player/transform`.
-- [ ] The slice is not implemented end-to-end in code yet.
+- [x] `kitu-runtime` processes `/input/move` into authoritative position updates and emits `/render/player/transform`.
 
 Remaining work:
 
-- [ ] Implement the minimum input payload handling for `/input/move`.
-- [ ] Implement deterministic authoritative state update for the player move slice.
-- [ ] Emit `/render/player/transform` from the runtime-owned output path.
+- [x] Implement the minimum input payload handling for `/input/move`.
+- [x] Implement deterministic authoritative state update for the player move slice.
+- [x] Emit `/render/player/transform` from the runtime-owned output path.
 - [ ] Define and implement the minimum boundary between runtime and Unity / host.
 - [ ] Extend `kitu-unity-ffi` only as much as needed for the slice.
 

--- a/crates/kitu-osc-ir/src/lib.rs
+++ b/crates/kitu-osc-ir/src/lib.rs
@@ -17,6 +17,7 @@ use kitu_core::Result;
 #[derive(Debug, Clone, PartialEq)]
 pub enum OscArg {
     Int(i32),
+    Int64(i64),
     Float(f32),
     Str(String),
     Bool(bool),
@@ -55,6 +56,7 @@ impl OscMessage {
             }
             match arg {
                 OscArg::Int(v) => write!(&mut buf, "{v}").unwrap(),
+                OscArg::Int64(v) => write!(&mut buf, "{v}").unwrap(),
                 OscArg::Float(v) => write!(&mut buf, "{v}").unwrap(),
                 OscArg::Str(v) => write!(&mut buf, "\"{v}\"").unwrap(),
                 OscArg::Bool(v) => write!(&mut buf, "{v}").unwrap(),

--- a/crates/kitu-runtime/README.md
+++ b/crates/kitu-runtime/README.md
@@ -7,6 +7,7 @@ Tick-based orchestrator that wires Kitu ECS, transports, and future scripting/ti
 - Run `update(dt)` with a fixed-timestep accumulator.
 - Apply transport input on the next tick (`N` receive -> `N+1` apply).
 - Emit staged runtime output after ECS dispatch and before transport polling.
+- Implement the minimum player move vertical slice (`/input/move` -> `/render/player/transform`).
 - Bridge transports, scripting, and data playback while keeping the loop embeddable.
 
 ## Publish readiness

--- a/crates/kitu-runtime/src/lib.rs
+++ b/crates/kitu-runtime/src/lib.rs
@@ -10,7 +10,10 @@
 //! (`kitu-osc-ir`), and future data or scripting layers. See `doc/crates-overview.md` for how the
 //! runtime coordinates the workspace crates.
 
-use std::{collections::VecDeque, time::Duration};
+use std::{
+    collections::{HashMap, VecDeque},
+    time::Duration,
+};
 
 use kitu_core::{KituError, Result, Tick};
 use kitu_ecs::EcsWorld;
@@ -50,7 +53,6 @@ struct OutputBuffer {
 
 #[derive(Debug, Clone, PartialEq)]
 struct PlayerTransform {
-    entity_id: String,
     x: f32,
     y: f32,
     z: f32,
@@ -59,7 +61,6 @@ struct PlayerTransform {
 impl Default for PlayerTransform {
     fn default() -> Self {
         Self {
-            entity_id: "player:local".to_string(),
             x: 0.0,
             y: 0.0,
             z: 0.0,
@@ -116,7 +117,7 @@ pub struct Runtime<T: Transport> {
     inputs: AuthoritativeInputQueue,
     committed_input_tick: Option<Tick>,
     outputs: OutputBuffer,
-    player_transform: PlayerTransform,
+    player_transforms: HashMap<String, PlayerTransform>,
 }
 
 impl<T: Transport> Runtime<T> {
@@ -142,7 +143,7 @@ impl<T: Transport> Runtime<T> {
             inputs: AuthoritativeInputQueue::default(),
             committed_input_tick: None,
             outputs: OutputBuffer::default(),
-            player_transform: PlayerTransform::default(),
+            player_transforms: HashMap::new(),
         }
     }
 
@@ -244,8 +245,9 @@ impl<T: Transport> Runtime<T> {
             self.committed_input_tick = Some(self.tick);
         }
 
+        let parsed_moves = self.collect_move_inputs()?;
         self.world.dispatch(self.tick)?;
-        self.apply_player_move_slice()?;
+        self.apply_player_move_slice(parsed_moves)?;
 
         self.outputs.emit_staged();
 
@@ -259,7 +261,7 @@ impl<T: Transport> Runtime<T> {
         Ok(())
     }
 
-    fn apply_player_move_slice(&mut self) -> Result<()> {
+    fn collect_move_inputs(&self) -> Result<Vec<(String, f32, f32)>> {
         let committed = self.inputs.committed_snapshot();
         let mut parsed_moves = Vec::new();
 
@@ -274,11 +276,15 @@ impl<T: Transport> Runtime<T> {
             }
         }
 
+        Ok(parsed_moves)
+    }
+
+    fn apply_player_move_slice(&mut self, parsed_moves: Vec<(String, f32, f32)>) -> Result<()> {
         for (entity_id, x, y) in parsed_moves {
-            self.player_transform.entity_id = entity_id;
-            self.player_transform.x += x;
-            self.player_transform.y += y;
-            let output = render_player_transform_message(self.tick, &self.player_transform)?;
+            let transform = self.player_transforms.entry(entity_id.clone()).or_default();
+            transform.x += x;
+            transform.y += y;
+            let output = render_player_transform_message(self.tick, &entity_id, transform)?;
             self.queue_output(output);
         }
 
@@ -344,9 +350,13 @@ fn parse_move_input(message: &OscMessage) -> Result<(String, f32, f32)> {
     Ok((entity_id, x, y))
 }
 
-fn render_player_transform_message(tick: Tick, transform: &PlayerTransform) -> Result<OscBundle> {
+fn render_player_transform_message(
+    tick: Tick,
+    entity_id: &str,
+    transform: &PlayerTransform,
+) -> Result<OscBundle> {
     let mut message = OscMessage::new("/render/player/transform");
-    message.push_arg(OscArg::Str(transform.entity_id.clone()));
+    message.push_arg(OscArg::Str(entity_id.to_string()));
     let tick_i64 = i64::try_from(tick.get())
         .map_err(|_| KituError::InvalidInput("tick is too large to encode"))?;
     message.push_arg(OscArg::Int64(tick_i64));
@@ -775,6 +785,80 @@ mod tests {
                 OscArg::Str("player:local".to_string()),
                 OscArg::Int64(0),
                 OscArg::Float(1.0),
+                OscArg::Float(2.0),
+                OscArg::Float(0.0),
+            ]
+        );
+    }
+
+    #[test]
+    fn invalid_move_input_is_rejected_before_dispatch_runs() {
+        struct CounterSystem {
+            runs: Arc<Mutex<u32>>,
+        }
+
+        impl kitu_ecs::System for CounterSystem {
+            fn run(&mut self, _world: &mut EcsWorld, _tick: Tick) -> Result<()> {
+                *self.runs.lock().unwrap() += 1;
+                Ok(())
+            }
+        }
+
+        let mut runtime = build_runtime(LocalChannel::default());
+        let runs = Arc::new(Mutex::new(0));
+        runtime.world_mut().schedule_system(CounterSystem {
+            runs: Arc::clone(&runs),
+        });
+
+        let mut invalid = OscMessage::new("/input/move");
+        invalid.push_arg(OscArg::Str("player:local".to_string()));
+        invalid.push_arg(OscArg::Float(1.0));
+        let mut batch = OscBundle::new();
+        batch.push(invalid);
+        runtime.enqueue_input(batch);
+
+        assert!(runtime.tick_once().is_err());
+        assert_eq!(*runs.lock().unwrap(), 0);
+    }
+
+    #[test]
+    fn move_slice_keeps_entity_transforms_isolated() {
+        let mut runtime = build_runtime(LocalChannel::default());
+
+        let mut p1 = OscMessage::new("/input/move");
+        p1.push_arg(OscArg::Str("player:one".to_string()));
+        p1.push_arg(OscArg::Float(1.0));
+        p1.push_arg(OscArg::Float(0.0));
+
+        let mut p2 = OscMessage::new("/input/move");
+        p2.push_arg(OscArg::Str("player:two".to_string()));
+        p2.push_arg(OscArg::Float(0.0));
+        p2.push_arg(OscArg::Float(2.0));
+
+        let mut batch = OscBundle::new();
+        batch.push(p1);
+        batch.push(p2);
+        runtime.enqueue_input(batch);
+
+        runtime.tick_once().unwrap();
+        let outputs = runtime.drain_output_buffer();
+        assert_eq!(outputs.len(), 2);
+        assert_eq!(
+            outputs[0].messages[0].args,
+            vec![
+                OscArg::Str("player:one".to_string()),
+                OscArg::Int64(0),
+                OscArg::Float(1.0),
+                OscArg::Float(0.0),
+                OscArg::Float(0.0),
+            ]
+        );
+        assert_eq!(
+            outputs[1].messages[0].args,
+            vec![
+                OscArg::Str("player:two".to_string()),
+                OscArg::Int64(0),
+                OscArg::Float(0.0),
                 OscArg::Float(2.0),
                 OscArg::Float(0.0),
             ]

--- a/crates/kitu-runtime/src/lib.rs
+++ b/crates/kitu-runtime/src/lib.rs
@@ -252,6 +252,8 @@ impl<T: Transport> Runtime<T> {
 
     fn apply_player_move_slice(&mut self) -> Result<()> {
         let committed = self.inputs.committed_snapshot();
+        let mut parsed_moves = Vec::new();
+
         for bundle in committed {
             for message in bundle.messages {
                 if message.address != "/input/move" {
@@ -259,15 +261,16 @@ impl<T: Transport> Runtime<T> {
                 }
 
                 let (entity_id, x, y) = parse_move_input(&message)?;
-                self.player_transform.entity_id = entity_id;
-                self.player_transform.x += x;
-                self.player_transform.y += y;
-
-                self.queue_output(render_player_transform_message(
-                    self.tick,
-                    &self.player_transform,
-                ));
+                parsed_moves.push((entity_id, x, y));
             }
+        }
+
+        for (entity_id, x, y) in parsed_moves {
+            self.player_transform.entity_id = entity_id;
+            self.player_transform.x += x;
+            self.player_transform.y += y;
+            let output = render_player_transform_message(self.tick, &self.player_transform)?;
+            self.queue_output(output);
         }
 
         Ok(())
@@ -332,17 +335,19 @@ fn parse_move_input(message: &OscMessage) -> Result<(String, f32, f32)> {
     Ok((entity_id, x, y))
 }
 
-fn render_player_transform_message(tick: Tick, transform: &PlayerTransform) -> OscBundle {
+fn render_player_transform_message(tick: Tick, transform: &PlayerTransform) -> Result<OscBundle> {
     let mut message = OscMessage::new("/render/player/transform");
     message.push_arg(OscArg::Str(transform.entity_id.clone()));
-    message.push_arg(OscArg::Int(tick.get() as i32));
+    let tick_i64 = i64::try_from(tick.get())
+        .map_err(|_| KituError::InvalidInput("tick is too large to encode"))?;
+    message.push_arg(OscArg::Int64(tick_i64));
     message.push_arg(OscArg::Float(transform.x));
     message.push_arg(OscArg::Float(transform.y));
     message.push_arg(OscArg::Float(transform.z));
 
     let mut bundle = OscBundle::new();
     bundle.push(message);
-    bundle
+    Ok(bundle)
 }
 
 /// Convenience helper for building a runtime with default configuration.
@@ -627,7 +632,7 @@ mod tests {
             render.args,
             vec![
                 OscArg::Str("player:local".to_string()),
-                OscArg::Int(0),
+                OscArg::Int64(0),
                 OscArg::Float(1.0),
                 OscArg::Float(-0.25),
                 OscArg::Float(0.0),
@@ -670,5 +675,50 @@ mod tests {
         let outputs = runtime.drain_output_buffer();
         assert_eq!(outputs.len(), 1);
         assert_eq!(outputs[0].messages[0].address, "/render/player/transform");
+    }
+
+    #[test]
+    fn invalid_move_batch_does_not_partially_apply_state_or_output() {
+        let mut runtime = build_runtime(LocalChannel::default());
+
+        let mut valid = OscMessage::new("/input/move");
+        valid.push_arg(OscArg::Str("player:local".to_string()));
+        valid.push_arg(OscArg::Float(1.0));
+        valid.push_arg(OscArg::Float(0.0));
+
+        let mut invalid = OscMessage::new("/input/move");
+        invalid.push_arg(OscArg::Str("player:local".to_string()));
+        invalid.push_arg(OscArg::Float(0.0));
+
+        let mut mixed_batch = OscBundle::new();
+        mixed_batch.push(valid);
+        mixed_batch.push(invalid);
+        runtime.enqueue_input(mixed_batch);
+
+        assert!(runtime.tick_once().is_err());
+        assert_eq!(runtime.current_tick().get(), 0);
+        assert!(runtime.drain_output_buffer().is_empty());
+
+        let mut recovery = OscMessage::new("/input/move");
+        recovery.push_arg(OscArg::Str("player:local".to_string()));
+        recovery.push_arg(OscArg::Float(0.5));
+        recovery.push_arg(OscArg::Float(0.0));
+        let mut recovery_batch = OscBundle::new();
+        recovery_batch.push(recovery);
+        runtime.enqueue_input(recovery_batch);
+
+        runtime.tick_once().unwrap();
+        let outputs = runtime.drain_output_buffer();
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(
+            outputs[0].messages[0].args,
+            vec![
+                OscArg::Str("player:local".to_string()),
+                OscArg::Int64(0),
+                OscArg::Float(0.5),
+                OscArg::Float(0.0),
+                OscArg::Float(0.0),
+            ]
+        );
     }
 }

--- a/crates/kitu-runtime/src/lib.rs
+++ b/crates/kitu-runtime/src/lib.rs
@@ -245,7 +245,14 @@ impl<T: Transport> Runtime<T> {
             self.committed_input_tick = Some(self.tick);
         }
 
-        let parsed_moves = self.collect_move_inputs()?;
+        let parsed_moves = match self.collect_move_inputs() {
+            Ok(parsed) => parsed,
+            Err(error) => {
+                self.inputs.drain_committed();
+                self.committed_input_tick = None;
+                return Err(error);
+            }
+        };
         self.world.dispatch(self.tick)?;
         self.apply_player_move_slice(parsed_moves)?;
 
@@ -337,17 +344,19 @@ fn parse_move_input(message: &OscMessage) -> Result<(String, f32, f32)> {
         }
     };
 
-    let x = match message.args[1] {
-        OscArg::Float(value) => value,
-        _ => return Err(KituError::InvalidInput("/input/move x must be a float")),
-    };
-
-    let y = match message.args[2] {
-        OscArg::Float(value) => value,
-        _ => return Err(KituError::InvalidInput("/input/move y must be a float")),
-    };
+    let x = parse_move_component(&message.args[1], "/input/move x must be numeric")?;
+    let y = parse_move_component(&message.args[2], "/input/move y must be numeric")?;
 
     Ok((entity_id, x, y))
+}
+
+fn parse_move_component(arg: &OscArg, error_message: &'static str) -> Result<f32> {
+    match arg {
+        OscArg::Float(value) => Ok(*value),
+        OscArg::Int(value) => Ok(*value as f32),
+        OscArg::Int64(value) => Ok(*value as f32),
+        _ => Err(KituError::InvalidInput(error_message)),
+    }
 }
 
 fn render_player_transform_message(
@@ -717,7 +726,7 @@ mod tests {
         assert!(runtime.tick_once().is_err());
         assert_eq!(runtime.current_tick().get(), 0);
         assert!(runtime.drain_output_buffer().is_empty());
-        assert_eq!(runtime.drain_committed_inputs().len(), 1);
+        assert!(runtime.drain_committed_inputs().is_empty());
 
         let mut recovery = OscMessage::new("/input/move");
         recovery.push_arg(OscArg::Str("player:local".to_string()));
@@ -859,6 +868,61 @@ mod tests {
                 OscArg::Str("player:two".to_string()),
                 OscArg::Int64(0),
                 OscArg::Float(0.0),
+                OscArg::Float(2.0),
+                OscArg::Float(0.0),
+            ]
+        );
+    }
+
+    #[test]
+    fn invalid_move_batch_is_dropped_and_does_not_stick_runtime() {
+        let mut runtime = build_runtime(LocalChannel::default());
+
+        let mut invalid = OscMessage::new("/input/move");
+        invalid.push_arg(OscArg::Str("player:local".to_string()));
+        invalid.push_arg(OscArg::Float(0.0));
+        let mut invalid_batch = OscBundle::new();
+        invalid_batch.push(invalid);
+        runtime.enqueue_input(invalid_batch);
+
+        assert!(runtime.tick_once().is_err());
+        assert_eq!(runtime.current_tick().get(), 0);
+        assert!(runtime.drain_committed_inputs().is_empty());
+
+        let mut valid = OscMessage::new("/input/move");
+        valid.push_arg(OscArg::Str("player:local".to_string()));
+        valid.push_arg(OscArg::Float(1.0));
+        valid.push_arg(OscArg::Float(0.0));
+        let mut valid_batch = OscBundle::new();
+        valid_batch.push(valid);
+        runtime.enqueue_input(valid_batch);
+
+        runtime.tick_once().unwrap();
+        let outputs = runtime.drain_output_buffer();
+        assert_eq!(outputs.len(), 1);
+    }
+
+    #[test]
+    fn move_parser_accepts_integer_components() {
+        let mut runtime = build_runtime(LocalChannel::default());
+
+        let mut int_move = OscMessage::new("/input/move");
+        int_move.push_arg(OscArg::Str("player:local".to_string()));
+        int_move.push_arg(OscArg::Int(1));
+        int_move.push_arg(OscArg::Int64(2));
+        let mut batch = OscBundle::new();
+        batch.push(int_move);
+        runtime.enqueue_input(batch);
+
+        runtime.tick_once().unwrap();
+        let outputs = runtime.drain_output_buffer();
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(
+            outputs[0].messages[0].args,
+            vec![
+                OscArg::Str("player:local".to_string()),
+                OscArg::Int64(0),
+                OscArg::Float(1.0),
                 OscArg::Float(2.0),
                 OscArg::Float(0.0),
             ]

--- a/crates/kitu-runtime/src/lib.rs
+++ b/crates/kitu-runtime/src/lib.rs
@@ -114,6 +114,7 @@ pub struct Runtime<T: Transport> {
     transport: T,
     world: EcsWorld,
     inputs: AuthoritativeInputQueue,
+    committed_input_tick: Option<Tick>,
     outputs: OutputBuffer,
     player_transform: PlayerTransform,
 }
@@ -139,6 +140,7 @@ impl<T: Transport> Runtime<T> {
             transport,
             world: EcsWorld::default(),
             inputs: AuthoritativeInputQueue::default(),
+            committed_input_tick: None,
             outputs: OutputBuffer::default(),
             player_transform: PlayerTransform::default(),
         }
@@ -170,7 +172,11 @@ impl<T: Transport> Runtime<T> {
     /// tick. Inputs that arrive while a tick executes are queued for the next
     /// tick and do not mutate this committed batch.
     pub fn drain_committed_inputs(&mut self) -> Vec<OscBundle> {
-        self.inputs.drain_committed()
+        let drained = self.inputs.drain_committed();
+        if self.inputs.committed_batch.is_empty() {
+            self.committed_input_tick = None;
+        }
+        drained
     }
 
     /// Processes as many fixed ticks as `dt` allows.
@@ -233,10 +239,13 @@ impl<T: Transport> Runtime<T> {
     /// assert_eq!(runtime.current_tick().get(), 1);
     /// ```
     pub fn tick_once(&mut self) -> Result<()> {
-        self.inputs.commit_next_tick_batch();
-        self.apply_player_move_slice()?;
+        if self.committed_input_tick != Some(self.tick) {
+            self.inputs.commit_next_tick_batch();
+            self.committed_input_tick = Some(self.tick);
+        }
 
         self.world.dispatch(self.tick)?;
+        self.apply_player_move_slice()?;
 
         self.outputs.emit_staged();
 
@@ -698,6 +707,7 @@ mod tests {
         assert!(runtime.tick_once().is_err());
         assert_eq!(runtime.current_tick().get(), 0);
         assert!(runtime.drain_output_buffer().is_empty());
+        assert_eq!(runtime.drain_committed_inputs().len(), 1);
 
         let mut recovery = OscMessage::new("/input/move");
         recovery.push_arg(OscArg::Str("player:local".to_string()));
@@ -717,6 +727,55 @@ mod tests {
                 OscArg::Int64(0),
                 OscArg::Float(0.5),
                 OscArg::Float(0.0),
+                OscArg::Float(0.0),
+            ]
+        );
+    }
+
+    #[test]
+    fn move_slice_is_not_applied_when_dispatch_fails() {
+        struct FailsOnceSystem {
+            has_failed: bool,
+        }
+
+        impl kitu_ecs::System for FailsOnceSystem {
+            fn run(&mut self, _world: &mut EcsWorld, _tick: Tick) -> Result<()> {
+                if self.has_failed {
+                    Ok(())
+                } else {
+                    self.has_failed = true;
+                    Err(KituError::InvalidInput("dispatch failure"))
+                }
+            }
+        }
+
+        let mut runtime = build_runtime(LocalChannel::default());
+        runtime
+            .world_mut()
+            .schedule_system(FailsOnceSystem { has_failed: false });
+
+        let mut move_message = OscMessage::new("/input/move");
+        move_message.push_arg(OscArg::Str("player:local".to_string()));
+        move_message.push_arg(OscArg::Float(1.0));
+        move_message.push_arg(OscArg::Float(2.0));
+        let mut input = OscBundle::new();
+        input.push(move_message);
+        runtime.enqueue_input(input);
+
+        assert!(runtime.tick_once().is_err());
+        assert!(runtime.drain_output_buffer().is_empty());
+        assert_eq!(runtime.current_tick().get(), 0);
+
+        runtime.tick_once().unwrap();
+        let outputs = runtime.drain_output_buffer();
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(
+            outputs[0].messages[0].args,
+            vec![
+                OscArg::Str("player:local".to_string()),
+                OscArg::Int64(0),
+                OscArg::Float(1.0),
+                OscArg::Float(2.0),
                 OscArg::Float(0.0),
             ]
         );

--- a/crates/kitu-runtime/src/lib.rs
+++ b/crates/kitu-runtime/src/lib.rs
@@ -14,7 +14,7 @@ use std::{collections::VecDeque, time::Duration};
 
 use kitu_core::{KituError, Result, Tick};
 use kitu_ecs::EcsWorld;
-use kitu_osc_ir::OscBundle;
+use kitu_osc_ir::{OscArg, OscBundle, OscMessage};
 use kitu_transport::{Transport, TransportEvent};
 
 #[derive(Default)]
@@ -36,12 +36,35 @@ impl AuthoritativeInputQueue {
     fn drain_committed(&mut self) -> Vec<OscBundle> {
         self.committed_batch.drain(..).collect()
     }
+
+    fn committed_snapshot(&self) -> Vec<OscBundle> {
+        self.committed_batch.iter().cloned().collect()
+    }
 }
 
 #[derive(Default)]
 struct OutputBuffer {
     staged: VecDeque<OscBundle>,
     visible: VecDeque<OscBundle>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct PlayerTransform {
+    entity_id: String,
+    x: f32,
+    y: f32,
+    z: f32,
+}
+
+impl Default for PlayerTransform {
+    fn default() -> Self {
+        Self {
+            entity_id: "player:local".to_string(),
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        }
+    }
 }
 
 impl OutputBuffer {
@@ -92,6 +115,7 @@ pub struct Runtime<T: Transport> {
     world: EcsWorld,
     inputs: AuthoritativeInputQueue,
     outputs: OutputBuffer,
+    player_transform: PlayerTransform,
 }
 
 impl<T: Transport> Runtime<T> {
@@ -116,6 +140,7 @@ impl<T: Transport> Runtime<T> {
             world: EcsWorld::default(),
             inputs: AuthoritativeInputQueue::default(),
             outputs: OutputBuffer::default(),
+            player_transform: PlayerTransform::default(),
         }
     }
 
@@ -209,6 +234,7 @@ impl<T: Transport> Runtime<T> {
     /// ```
     pub fn tick_once(&mut self) -> Result<()> {
         self.inputs.commit_next_tick_batch();
+        self.apply_player_move_slice()?;
 
         self.world.dispatch(self.tick)?;
 
@@ -221,6 +247,29 @@ impl<T: Transport> Runtime<T> {
         }
 
         self.tick = self.tick.next();
+        Ok(())
+    }
+
+    fn apply_player_move_slice(&mut self) -> Result<()> {
+        let committed = self.inputs.committed_snapshot();
+        for bundle in committed {
+            for message in bundle.messages {
+                if message.address != "/input/move" {
+                    continue;
+                }
+
+                let (entity_id, x, y) = parse_move_input(&message)?;
+                self.player_transform.entity_id = entity_id;
+                self.player_transform.x += x;
+                self.player_transform.y += y;
+
+                self.queue_output(render_player_transform_message(
+                    self.tick,
+                    &self.player_transform,
+                ));
+            }
+        }
+
         Ok(())
     }
 
@@ -252,6 +301,48 @@ impl<T: Transport> Runtime<T> {
         }
         Ok(())
     }
+}
+
+fn parse_move_input(message: &OscMessage) -> Result<(String, f32, f32)> {
+    if message.args.len() != 3 {
+        return Err(KituError::InvalidInput(
+            "/input/move expects [entity_id, x, y]",
+        ));
+    }
+
+    let entity_id = match &message.args[0] {
+        OscArg::Str(id) if !id.is_empty() => id.clone(),
+        _ => {
+            return Err(KituError::InvalidInput(
+                "/input/move entity_id must be a non-empty string",
+            ));
+        }
+    };
+
+    let x = match message.args[1] {
+        OscArg::Float(value) => value,
+        _ => return Err(KituError::InvalidInput("/input/move x must be a float")),
+    };
+
+    let y = match message.args[2] {
+        OscArg::Float(value) => value,
+        _ => return Err(KituError::InvalidInput("/input/move y must be a float")),
+    };
+
+    Ok((entity_id, x, y))
+}
+
+fn render_player_transform_message(tick: Tick, transform: &PlayerTransform) -> OscBundle {
+    let mut message = OscMessage::new("/render/player/transform");
+    message.push_arg(OscArg::Str(transform.entity_id.clone()));
+    message.push_arg(OscArg::Int(tick.get() as i32));
+    message.push_arg(OscArg::Float(transform.x));
+    message.push_arg(OscArg::Float(transform.y));
+    message.push_arg(OscArg::Float(transform.z));
+
+    let mut bundle = OscBundle::new();
+    bundle.push(message);
+    bundle
 }
 
 /// Convenience helper for building a runtime with default configuration.
@@ -368,7 +459,7 @@ mod tests {
         }
 
         let mut bundle = OscBundle::new();
-        bundle.push(kitu_osc_ir::OscMessage::new("/input/move"));
+        bundle.push(kitu_osc_ir::OscMessage::new("/input/ping"));
 
         let transport = ScriptedTransport {
             events: VecDeque::from([TransportEvent::Message(bundle)]),
@@ -512,5 +603,72 @@ mod tests {
         runtime.tick_once().unwrap();
         let drained = runtime.drain_output_buffer();
         assert_eq!(drained, vec![output]);
+    }
+
+    #[test]
+    fn move_input_updates_transform_and_emits_render_message() {
+        let mut runtime = build_runtime(LocalChannel::default());
+
+        let mut message = OscMessage::new("/input/move");
+        message.push_arg(OscArg::Str("player:local".to_string()));
+        message.push_arg(OscArg::Float(1.0));
+        message.push_arg(OscArg::Float(-0.25));
+
+        let mut input = OscBundle::new();
+        input.push(message);
+        runtime.enqueue_input(input);
+
+        runtime.tick_once().unwrap();
+        let outputs = runtime.drain_output_buffer();
+        assert_eq!(outputs.len(), 1);
+        let render = &outputs[0].messages[0];
+        assert_eq!(render.address, "/render/player/transform");
+        assert_eq!(
+            render.args,
+            vec![
+                OscArg::Str("player:local".to_string()),
+                OscArg::Int(0),
+                OscArg::Float(1.0),
+                OscArg::Float(-0.25),
+                OscArg::Float(0.0),
+            ]
+        );
+    }
+
+    #[test]
+    fn move_input_received_during_tick_is_applied_next_tick() {
+        struct ScriptedTransport {
+            events: VecDeque<TransportEvent>,
+        }
+
+        impl Transport for ScriptedTransport {
+            fn send(&mut self, _message: OscMessage) -> Result<()> {
+                Ok(())
+            }
+
+            fn poll_event(&mut self) -> Option<TransportEvent> {
+                self.events.pop_front()
+            }
+        }
+
+        let mut move_message = OscMessage::new("/input/move");
+        move_message.push_arg(OscArg::Str("player:local".to_string()));
+        move_message.push_arg(OscArg::Float(0.0));
+        move_message.push_arg(OscArg::Float(1.0));
+
+        let mut bundle = OscBundle::new();
+        bundle.push(move_message);
+        let transport = ScriptedTransport {
+            events: VecDeque::from([TransportEvent::Message(bundle)]),
+        };
+        let mut runtime = build_runtime(transport);
+
+        runtime.tick_once().unwrap();
+        assert!(runtime.drain_output_buffer().is_empty());
+
+        runtime.tick_once().unwrap();
+        let outputs = runtime.drain_output_buffer();
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0].messages[0].address, "/render/player/transform");
     }
 }

--- a/crates/kitu-runtime/tests/player_move_slice.rs
+++ b/crates/kitu-runtime/tests/player_move_slice.rs
@@ -26,7 +26,7 @@ fn player_move_slice_runs_end_to_end() {
         render.args,
         vec![
             OscArg::Str("player:local".to_string()),
-            OscArg::Int(0),
+            OscArg::Int64(0),
             OscArg::Float(1.5),
             OscArg::Float(2.0),
             OscArg::Float(0.0),
@@ -66,7 +66,7 @@ fn player_move_slice_accumulates_over_multiple_ticks() {
         second_render.args,
         vec![
             OscArg::Str("player:local".to_string()),
-            OscArg::Int(1),
+            OscArg::Int64(1),
             OscArg::Float(0.5),
             OscArg::Float(3.0),
             OscArg::Float(0.0),

--- a/crates/kitu-runtime/tests/player_move_slice.rs
+++ b/crates/kitu-runtime/tests/player_move_slice.rs
@@ -1,0 +1,75 @@
+use kitu_osc_ir::{OscArg, OscBundle, OscMessage};
+use kitu_runtime::build_runtime;
+use kitu_transport::LocalChannel;
+
+#[test]
+fn player_move_slice_runs_end_to_end() {
+    let mut runtime = build_runtime(LocalChannel::default());
+
+    let mut move_message = OscMessage::new("/input/move");
+    move_message.push_arg(OscArg::Str("player:local".to_string()));
+    move_message.push_arg(OscArg::Float(1.5));
+    move_message.push_arg(OscArg::Float(2.0));
+
+    let mut input = OscBundle::new();
+    input.push(move_message);
+    runtime.enqueue_input(input);
+
+    runtime.tick_once().expect("tick should succeed");
+
+    let outputs = runtime.drain_output_buffer();
+    assert_eq!(outputs.len(), 1);
+
+    let render = &outputs[0].messages[0];
+    assert_eq!(render.address, "/render/player/transform");
+    assert_eq!(
+        render.args,
+        vec![
+            OscArg::Str("player:local".to_string()),
+            OscArg::Int(0),
+            OscArg::Float(1.5),
+            OscArg::Float(2.0),
+            OscArg::Float(0.0),
+        ]
+    );
+}
+
+#[test]
+fn player_move_slice_accumulates_over_multiple_ticks() {
+    let mut runtime = build_runtime(LocalChannel::default());
+
+    let mut first = OscMessage::new("/input/move");
+    first.push_arg(OscArg::Str("player:local".to_string()));
+    first.push_arg(OscArg::Float(1.0));
+    first.push_arg(OscArg::Float(0.0));
+
+    let mut second = OscMessage::new("/input/move");
+    second.push_arg(OscArg::Str("player:local".to_string()));
+    second.push_arg(OscArg::Float(-0.5));
+    second.push_arg(OscArg::Float(3.0));
+
+    let mut first_bundle = OscBundle::new();
+    first_bundle.push(first);
+    runtime.enqueue_input(first_bundle);
+    runtime.tick_once().expect("first tick should succeed");
+
+    let mut second_bundle = OscBundle::new();
+    second_bundle.push(second);
+    runtime.enqueue_input(second_bundle);
+    runtime.tick_once().expect("second tick should succeed");
+
+    let outputs = runtime.drain_output_buffer();
+    assert_eq!(outputs.len(), 2);
+
+    let second_render = &outputs[1].messages[0];
+    assert_eq!(
+        second_render.args,
+        vec![
+            OscArg::Str("player:local".to_string()),
+            OscArg::Int(1),
+            OscArg::Float(0.5),
+            OscArg::Float(3.0),
+            OscArg::Float(0.0),
+        ]
+    );
+}


### PR DESCRIPTION
### Motivation

- Implement the minimum vertical slice for player movement so the runtime can process `/input/move` and emit `/render/player/transform` without depending on host bindings.

### Description

- Add `PlayerTransform` state and apply a player-move slice in `Runtime::tick_once` that parses committed `/input/move` messages and updates transform state.
- Introduce `parse_move_input` and `render_player_transform_message` helpers and expose a `committed_snapshot` accessor on `AuthoritativeInputQueue` to iterate frozen per-tick inputs.
- Wire outputs into the existing `OutputBuffer` so render messages are staged and emitted in the normal tick lifecycle. 
- Update docs (`PROJECT_TODO.md`, `crates/kitu-runtime/README.md`) and add unit/integration tests for the new slice in `crates/kitu-runtime` and `crates/kitu-runtime/tests/player_move_slice.rs`.

### Testing

- Ran the crate tests with `cargo test` for `kitu-runtime`, which include the new unit tests `move_input_updates_transform_and_emits_render_message` and `move_input_received_during_tick_is_applied_next_tick`, and they passed.
- Ran the added integration tests in `crates/kitu-runtime/tests/player_move_slice.rs`, which exercise the end-to-end slice and accumulation across ticks, and they passed.
- Verified existing tick/order tests (e.g. `tick_applies_transport_input_on_next_tick`, `outputs_are_emitted_after_tick`) continue to pass after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf655f639883289db3c21c450c3790)