### PR TITLE
kitu-unity-ffi: implement minimal runtime↔Unity FFI boundary, move input and render event ABI

### DIFF
--- a/PROJECT_TODO.md
+++ b/PROJECT_TODO.md
@@ -273,7 +273,7 @@ files_expected_to_change:
 
 ### Task: Define and implement the minimum boundary between runtime and Unity / host
 
-status: spec_only
+status: implemented
 
 context:
 - runtime behavior exists, but boundary ownership and minimal host contract remain incomplete

--- a/crates/kitu-unity-ffi/Cargo.toml
+++ b/crates/kitu-unity-ffi/Cargo.toml
@@ -13,5 +13,6 @@ include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 kitu-core = { path = "../kitu-core" }
+kitu-osc-ir = { path = "../kitu-osc-ir" }
 kitu-runtime = { path = "../kitu-runtime" }
 kitu-transport = { path = "../kitu-transport" }

--- a/crates/kitu-unity-ffi/src/lib.rs
+++ b/crates/kitu-unity-ffi/src/lib.rs
@@ -9,16 +9,65 @@
 //! This crate wraps the runtime (`kitu-runtime`) and transports (`kitu-transport`) behind a
 //! Unity-friendly API. See `doc/crates-overview.md` for how the FFI sits atop the core runtime.
 
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::VecDeque,
+    ffi::CStr,
+    os::raw::c_char,
+    sync::{Arc, Mutex},
+};
 
-use kitu_core::Result;
+use kitu_core::{KituError, Result};
+use kitu_osc_ir::{OscArg, OscBundle, OscMessage};
 use kitu_runtime::{build_runtime, Runtime};
 use kitu_transport::LocalChannel;
+
+const MAX_ENTITY_ID_BYTES: usize = 64;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RenderTransformEvent {
+    pub entity_id: String,
+    pub tick: u64,
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct KituRenderTransformEvent {
+    pub entity_id_len: u32,
+    pub entity_id: [u8; MAX_ENTITY_ID_BYTES],
+    pub tick: u64,
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+}
+
+impl KituRenderTransformEvent {
+    fn from_event(event: &RenderTransformEvent) -> Option<Self> {
+        let bytes = event.entity_id.as_bytes();
+        if bytes.len() > MAX_ENTITY_ID_BYTES {
+            return None;
+        }
+
+        let mut entity_id = [0_u8; MAX_ENTITY_ID_BYTES];
+        entity_id[..bytes.len()].copy_from_slice(bytes);
+        Some(Self {
+            entity_id_len: u32::try_from(bytes.len()).ok()?,
+            entity_id,
+            tick: event.tick,
+            x: event.x,
+            y: event.y,
+            z: event.z,
+        })
+    }
+}
 
 /// Managed handle exposed to Unity.
 #[derive(Clone)]
 pub struct UnityHandle {
     runtime: Arc<Mutex<Runtime<LocalChannel>>>,
+    pending_render_events: Arc<Mutex<VecDeque<RenderTransformEvent>>>,
 }
 
 impl UnityHandle {
@@ -27,7 +76,34 @@ impl UnityHandle {
         let runtime = build_runtime(LocalChannel::connected());
         Self {
             runtime: Arc::new(Mutex::new(runtime)),
+            pending_render_events: Arc::new(Mutex::new(VecDeque::new())),
         }
+    }
+
+    /// Queues one `/input/move` command for runtime-owned processing on the next tick.
+    pub fn submit_move_input(&self, entity_id: &str, x: f32, y: f32) -> Result<()> {
+        if entity_id.is_empty() {
+            return Err(KituError::InvalidInput(
+                "entity_id must be non-empty at FFI boundary",
+            ));
+        }
+        if entity_id.len() > MAX_ENTITY_ID_BYTES {
+            return Err(KituError::InvalidInput(
+                "entity_id exceeds FFI boundary maximum length",
+            ));
+        }
+
+        let mut message = OscMessage::new("/input/move");
+        message.push_arg(OscArg::Str(entity_id.to_string()));
+        message.push_arg(OscArg::Float(x));
+        message.push_arg(OscArg::Float(y));
+
+        let mut bundle = OscBundle::new();
+        bundle.push(message);
+
+        let mut guard = self.runtime.lock().expect("runtime mutex poisoned");
+        guard.enqueue_input(bundle);
+        Ok(())
     }
 
     /// Advances the runtime by one tick.
@@ -35,12 +111,53 @@ impl UnityHandle {
         let mut guard = self.runtime.lock().expect("runtime mutex poisoned");
         guard.tick_once()
     }
+
+    /// Pops one `/render/player/transform` event emitted by the runtime output path.
+    pub fn pop_render_transform(&self) -> Option<RenderTransformEvent> {
+        if let Some(event) = self
+            .pending_render_events
+            .lock()
+            .expect("render queue mutex poisoned")
+            .pop_front()
+        {
+            return Some(event);
+        }
+
+        let mut runtime = self.runtime.lock().expect("runtime mutex poisoned");
+        let outputs = runtime.drain_output_buffer();
+        drop(runtime);
+
+        let mut pending = self
+            .pending_render_events
+            .lock()
+            .expect("render queue mutex poisoned");
+        for bundle in outputs {
+            if let Some(event) = parse_render_transform(bundle) {
+                pending.push_back(event);
+            }
+        }
+        pending.pop_front()
+    }
 }
 
 /// C ABI entry point to create a new runtime handle.
 #[no_mangle]
 pub extern "C" fn kitu_init() -> *mut UnityHandle {
     Box::into_raw(Box::new(UnityHandle::initialize()))
+}
+
+/// C ABI entry point to dispose a runtime handle created by [`kitu_init`].
+///
+/// # Safety
+///
+/// - `handle` must either be null or a pointer returned by [`kitu_init`].
+/// - The pointer must not be used again after this call.
+#[no_mangle]
+pub unsafe extern "C" fn kitu_shutdown(handle: *mut UnityHandle) {
+    if handle.is_null() {
+        return;
+    }
+    drop(Box::from_raw(handle));
 }
 
 /// C ABI entry point to advance the runtime.
@@ -53,7 +170,7 @@ pub extern "C" fn kitu_init() -> *mut UnityHandle {
 ///   external synchronization.
 #[no_mangle]
 pub unsafe extern "C" fn kitu_tick(handle: *mut UnityHandle) -> i32 {
-    let Some(handle) = handle.as_mut() else {
+    let Some(handle) = handle.as_ref() else {
         return -1;
     };
     match handle.tick() {
@@ -62,9 +179,109 @@ pub unsafe extern "C" fn kitu_tick(handle: *mut UnityHandle) -> i32 {
     }
 }
 
+/// C ABI entry point to submit one move input.
+///
+/// # Safety
+///
+/// - `handle` must be a valid pointer created by [`kitu_init`].
+/// - `entity_id` must be a valid, NUL-terminated C string.
+#[no_mangle]
+pub unsafe extern "C" fn kitu_submit_move_input(
+    handle: *mut UnityHandle,
+    entity_id: *const c_char,
+    x: f32,
+    y: f32,
+) -> i32 {
+    let Some(handle) = handle.as_ref() else {
+        return -1;
+    };
+    if entity_id.is_null() {
+        return -2;
+    }
+    let Ok(entity_id) = CStr::from_ptr(entity_id).to_str() else {
+        return -3;
+    };
+    match handle.submit_move_input(entity_id, x, y) {
+        Ok(()) => 0,
+        Err(_) => -4,
+    }
+}
+
+/// C ABI entry point to pop one render transform event.
+///
+/// Returns:
+/// - `1` when an event is written to `out_event`
+/// - `0` when no event is available
+/// - negative values on invalid pointers or encoding failures
+///
+/// # Safety
+///
+/// - `handle` must be a valid pointer created by [`kitu_init`].
+/// - `out_event` must be valid for writes.
+#[no_mangle]
+pub unsafe extern "C" fn kitu_pop_render_transform(
+    handle: *mut UnityHandle,
+    out_event: *mut KituRenderTransformEvent,
+) -> i32 {
+    let Some(handle) = handle.as_ref() else {
+        return -1;
+    };
+    let Some(out_event) = out_event.as_mut() else {
+        return -2;
+    };
+    let Some(event) = handle.pop_render_transform() else {
+        return 0;
+    };
+    let Some(encoded) = KituRenderTransformEvent::from_event(&event) else {
+        return -3;
+    };
+    *out_event = encoded;
+    1
+}
+
+fn parse_render_transform(bundle: OscBundle) -> Option<RenderTransformEvent> {
+    let message = bundle
+        .messages
+        .into_iter()
+        .find(|m| m.address == "/render/player/transform")?;
+    if message.args.len() != 5 {
+        return None;
+    }
+    let entity_id = match &message.args[0] {
+        OscArg::Str(value) => value.clone(),
+        _ => return None,
+    };
+    let tick = match message.args[1] {
+        OscArg::Int(value) => u64::try_from(value).ok()?,
+        OscArg::Int64(value) => u64::try_from(value).ok()?,
+        _ => return None,
+    };
+    let x = match message.args[2] {
+        OscArg::Float(value) => value,
+        _ => return None,
+    };
+    let y = match message.args[3] {
+        OscArg::Float(value) => value,
+        _ => return None,
+    };
+    let z = match message.args[4] {
+        OscArg::Float(value) => value,
+        _ => return None,
+    };
+
+    Some(RenderTransformEvent {
+        entity_id,
+        tick,
+        x,
+        y,
+        z,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::CString;
 
     #[test]
     fn handle_advances_runtime() {
@@ -80,6 +297,67 @@ mod tests {
         let ptr = kitu_init();
         let status = unsafe { kitu_tick(ptr) };
         assert_eq!(status, 0);
-        unsafe { drop(Box::from_raw(ptr)) };
+        unsafe { kitu_shutdown(ptr) };
+    }
+
+    #[test]
+    fn boundary_smoke_executes_move_slice() {
+        let handle = UnityHandle::initialize();
+        handle.submit_move_input("player-1", 1.5, -2.0).unwrap();
+        handle.tick().unwrap();
+
+        let event = handle
+            .pop_render_transform()
+            .expect("expected render event");
+        assert_eq!(event.entity_id, "player-1");
+        assert_eq!(event.tick, 0);
+        assert_eq!(event.x, 1.5);
+        assert_eq!(event.y, -2.0);
+        assert_eq!(event.z, 0.0);
+    }
+
+    #[test]
+    fn ffi_boundary_smoke_executes_move_slice() {
+        let ptr = kitu_init();
+        let entity_id = CString::new("ffi-player").unwrap();
+        let submit_status = unsafe { kitu_submit_move_input(ptr, entity_id.as_ptr(), 2.0, 3.0) };
+        assert_eq!(submit_status, 0);
+        assert_eq!(unsafe { kitu_tick(ptr) }, 0);
+
+        let mut out = KituRenderTransformEvent {
+            entity_id_len: 0,
+            entity_id: [0; MAX_ENTITY_ID_BYTES],
+            tick: 0,
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        };
+        let pop_status = unsafe { kitu_pop_render_transform(ptr, &mut out as *mut _) };
+        assert_eq!(pop_status, 1);
+        assert_eq!(out.tick, 0);
+        assert_eq!(out.x, 2.0);
+        assert_eq!(out.y, 3.0);
+        assert_eq!(out.z, 0.0);
+        assert_eq!(
+            std::str::from_utf8(&out.entity_id[..out.entity_id_len as usize]).unwrap(),
+            "ffi-player"
+        );
+
+        unsafe { kitu_shutdown(ptr) };
+    }
+
+    #[test]
+    fn ffi_shutdown_accepts_null_pointer() {
+        unsafe { kitu_shutdown(std::ptr::null_mut()) };
+    }
+
+    #[test]
+    fn ffi_rejects_too_long_entity_id() {
+        let ptr = kitu_init();
+        let too_long = "x".repeat(MAX_ENTITY_ID_BYTES + 1);
+        let entity_id = CString::new(too_long).unwrap();
+        let status = unsafe { kitu_submit_move_input(ptr, entity_id.as_ptr(), 1.0, 1.0) };
+        assert_eq!(status, -4);
+        unsafe { kitu_shutdown(ptr) };
     }
 }

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -77,8 +77,7 @@ exists:
 - runtime emits `/render/player/transform`
 
 missing:
-- minimum runtime-to-host boundary is not fully defined and implemented
-- minimal `kitu-unity-ffi` slice support is still pending
+- keep the Unity boundary minimal as future slices expand beyond movement
 
 ### P3 — Integration and Replay Foundation
 
@@ -322,6 +321,37 @@ graph TD
 - Unity sends input intents and receives runtime output events.
 - `kitu-unity-ffi` must provide a stable ABI and deterministic handoff into runtime-owned processing.
 - Client-side prediction, if introduced later, must be explicitly documented as non-authoritative.
+
+#### Minimum runtime ↔ host boundary for the player-move slice (implemented)
+
+Boundary ownership for the current vertical slice is explicit:
+
+- Runtime owns authoritative gameplay state and tick progression.
+- Host/Unity owns player-facing input collection and render consumption only.
+- `kitu-unity-ffi` owns translation between host ABI calls and runtime OSC-IR bundles/events.
+
+Runtime responsibilities in this slice:
+
+- Accept `/input/move` payloads only through runtime input queue ingestion.
+- Apply deterministic state updates on runtime tick execution.
+- Emit `/render/player/transform` via runtime output buffer.
+
+Host/Unity responsibilities in this slice:
+
+- Submit movement intent (`entity_id`, `x`, `y`) through `kitu-unity-ffi`.
+- Drive runtime advancement via explicit tick calls.
+- Poll emitted render transforms and apply them to presentation objects.
+
+Current minimal FFI surface for this boundary:
+
+- `kitu_init` / `kitu_shutdown`: host owns runtime handle lifecycle.
+- `kitu_submit_move_input`: host submits one movement intent into runtime-owned input path (entity id must be non-empty and fit the current FFI max byte length).
+- `kitu_tick`: host advances runtime by one tick.
+- `kitu_pop_render_transform`: host drains runtime-owned render events from output path.
+
+Boundary smoke check:
+
+- `crates/kitu-unity-ffi` includes an FFI-level smoke test that submits move input, executes one tick, and validates `/render/player/transform` output through the boundary API.
 
 ### Shell / admin / tooling boundary
 


### PR DESCRIPTION
### Motivation
- Provide a minimal, explicit runtime↔host boundary so Unity can submit movement intents and consume runtime-owned `/render/player/transform` events. 
- Stabilize and document a small C ABI surface for the player-move vertical slice and add smoke checks to validate the handoff.

### Description
- Added `kitu-osc-ir` dependency to `Cargo.toml` to decode/encode OSC-IR bundles at the FFI boundary. 
- Extended `crates/kitu-unity-ffi/src/lib.rs` with `RenderTransformEvent` and `KituRenderTransformEvent` types, a pending render queue on `UnityHandle`, and a `parse_render_transform` helper to extract `/render/player/transform` outputs. 
- Implemented runtime-facing helpers and FFI functions: `submit_move_input` and C wrappers `kitu_submit_move_input`, `kitu_pop_render_transform`, `kitu_shutdown`, updated `kitu_tick`, and lifecycle entry `kitu_init`, plus encoding/decoding between Rust types and the C ABI buffer. 
- Added unit-level smoke tests that exercise the boundary end-to-end via both Rust API and C ABI (`submit_move_input` → `tick` → `pop_render_transform`) and validation for edge cases like oversized entity ids.

### Testing
- Ran `cargo test -p kitu-unity-ffi` which executed the added unit tests including `boundary_smoke_executes_move_slice`, `ffi_boundary_smoke_executes_move_slice`, and other FFI checks, and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d24bb2ebf083289b086317d91aa308)