### PR TITLE
[codex] Sync P2 docs with implemented FFI slice

### DIFF
--- a/PROJECT_TODO.md
+++ b/PROJECT_TODO.md
@@ -181,7 +181,7 @@ files_expected_to_change:
 
 ## P2 — Build the Minimum Vertical Slice
 
-status: partial
+status: implemented
 
 goal:
 Deliver the minimum end-to-end gameplay slice for player movement from input to authoritative state update to render event.
@@ -197,10 +197,15 @@ definition_of_done:
 repository_state:
 - `specs/vertical-slice-player-move.md` defines `/input/move` -> authoritative state update -> `/render/player/transform`
 - `kitu-runtime` processes `/input/move` into authoritative position updates and emits `/render/player/transform`
+- `kitu-unity-ffi` exposes the minimal movement-slice boundary:
+  - `kitu_submit_move_input`
+  - `kitu_tick`
+  - `kitu_pop_render_transform`
+- `kitu-runtime` and `kitu-unity-ffi` tests cover the movement slice and FFI boundary smoke path
 
 remaining_work:
-- Define and implement the minimum boundary between runtime and Unity / host
-- Extend `kitu-unity-ffi` only as much as needed for the slice
+- No remaining core work for the current movement slice
+- Keep the Unity / host boundary minimal as future slices expand beyond movement
 
 ### Task: Implement the minimum input payload handling for `/input/move`
 
@@ -276,7 +281,7 @@ files_expected_to_change:
 status: implemented
 
 context:
-- runtime behavior exists, but boundary ownership and minimal host contract remain incomplete
+- runtime behavior exists, and boundary ownership plus the minimal host contract are documented and implemented
 
 input:
 - current vertical slice behavior
@@ -299,16 +304,17 @@ files_expected_to_change:
 
 ### Task: Extend `kitu-unity-ffi` only as much as needed for the slice
 
-status: spec_only
+status: implemented
 
 context:
-- FFI should remain minimal and presentation-oriented
+- FFI remains minimal and presentation-oriented for the current movement slice
 
 input:
 - minimum vertical slice boundary
 
 output:
 - smallest FFI surface needed for movement slice execution
+- implemented C ABI calls for submitting movement input, ticking the runtime, and polling render transforms
 
 definition_of_done:
 - only slice-required FFI APIs are added or updated

--- a/crates/kitu-unity-ffi/README.md
+++ b/crates/kitu-unity-ffi/README.md
@@ -7,6 +7,14 @@ C ABI bindings that expose the Kitu runtime to Unity hosts.
 - Provide a stable ABI surface appropriate for a `cdylib` target.
 - Keep Unity-facing details isolated from core runtime logic.
 
+## Current MVP surface
+- `kitu_init` creates a runtime handle for an embedding host.
+- `kitu_submit_move_input` submits one `/input/move` intent into runtime-owned processing.
+- `kitu_tick` advances the runtime by one authoritative tick.
+- `kitu_pop_render_transform` drains one `/render/player/transform` event for presentation consumers.
+
+The crate intentionally keeps gameplay rules inside `kitu-runtime`; this boundary only translates host calls into runtime input/output.
+
 ## Publish readiness
 - Status: internal (`publish = false`), but metadata and README prepare the crate for crates.io packaging.
 - Run the gate before enabling publication:

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -64,20 +64,23 @@ exists:
 - first slice and integration-level validation exist in baseline form
 
 missing:
-- explicit closure decision after replay smoke path and boundary-level validation are in place
+- explicit closure decision after the replay smoke path is in place
 - stronger proof that runtime baseline is ready to be treated as complete MVP core
 
 ### P2 — Minimum Vertical Slice
 
-status: partial
+status: implemented
 
 exists:
 - `/input/move` slice is specified
 - runtime processes movement input into authoritative state updates
 - runtime emits `/render/player/transform`
+- minimal `kitu-unity-ffi` boundary exposes movement input, tick advancement, and render transform polling
+- boundary smoke tests cover the movement slice through the FFI path
 
 missing:
-- keep the Unity boundary minimal as future slices expand beyond movement
+- no remaining core work for the current movement slice
+- future slices must keep the Unity boundary minimal and presentation-oriented
 
 ### P3 — Integration and Replay Foundation
 

--- a/doc/architecture_JP.md
+++ b/doc/architecture_JP.md
@@ -87,7 +87,7 @@ kitu/
 - **kitu-tsq1**: TSQ1 の AST / 再生エンジン
 - **kitu-shell**: CLI シェル（/debug 用イベント発火など）
 - **kitu-web-admin-backend**: Web Admin のバックエンド（HTTP + WS）
-- **kitu-unity-ffi**: Unity 組み込み cdylib 用の C API
+- **kitu-unity-ffi**: Unity 組み込み cdylib 用の C API。現在の MVP surface はプレイヤー移動 slice に限定し、初期化、移動入力送信、tick 実行、`/render/player/transform` の取得を扱う。
 
 ### Unity 検証アプリ（kitu-integration-runner 配下）
 

--- a/doc/crates-overview.md
+++ b/doc/crates-overview.md
@@ -104,3 +104,5 @@ graph TD
 ### `kitu-unity-ffi`
 - Exposes a stable C ABI for embedding the runtime in Unity as a `cdylib`.
 - Responsible for marshalling between Unity types/buffers and the Rust runtime API.
+- Current MVP surface covers the player-move slice only: initialize a runtime handle, submit movement intent, tick the runtime, and poll render transform output.
+- Must remain a presentation/input adapter; gameplay rules stay in `kitu-runtime`.

--- a/specs/integration-replay-framework.md
+++ b/specs/integration-replay-framework.md
@@ -188,11 +188,10 @@ These files are optional in the framework phase and must not be required for the
 
 ## Relationship to implementation work
 
-This framework is intentionally ready before:
+This framework is intentionally transport- and host-neutral. Current movement-slice runtime and Unity FFI work should plug into these scenario and report contracts rather than redefining them.
+
+Still-pending implementation work:
 
 - deterministic replay executor implementation
-- authoritative queue internals
-- Unity FFI expansion
+- checked-in movement-slice smoke scenario and expected output fixtures
 - transport backend finalization
-
-Those implementations should plug into this framework rather than redefining scenario or report contracts.

--- a/specs/vertical-slice-player-move.md
+++ b/specs/vertical-slice-player-move.md
@@ -1,6 +1,6 @@
 # Vertical Slice Specification: Player Move (P2 MVP)
 
-This document defines the minimum vertical slice contract for player movement without requiring the full end-to-end runtime implementation yet.
+This document defines the implemented minimum vertical slice contract for player movement.
 It covers:
 
 - `/input/move`
@@ -10,7 +10,8 @@ It covers:
 ## Status
 
 - Normative for boundary contracts and responsibility separation.
-- Intentionally leaves runtime internals and full ECS implementation open.
+- Implemented in `kitu-runtime` and exposed through the minimal `kitu-unity-ffi` movement boundary.
+- Runtime internals and future ECS expansion remain intentionally narrow for this slice.
 - Depends on `doc/architecture.md` and the runtime timing rules in `specs/runtime-execution-contract.md`.
 
 ## Slice purpose
@@ -22,7 +23,7 @@ The slice exists to validate the smallest authoritative path:
 3. authoritative state updates player transform
 4. runtime emits a render-facing transform message
 
-This is a contract-first slice, not the full implementation milestone.
+This is the first implemented gameplay slice, not a complete gameplay framework.
 
 ## Responsibility split
 
@@ -40,6 +41,12 @@ Does not own:
 - simulation authority
 - movement resolution
 - authoritative position state
+
+Current minimal FFI surface:
+
+- `kitu_submit_move_input(handle, entity_id, x, y)` submits movement intent into the runtime-owned input queue.
+- `kitu_tick(handle)` advances the runtime by one authoritative tick.
+- `kitu_pop_render_transform(handle, out_event)` drains one runtime-owned render transform event for presentation consumption.
 
 ### `kitu-runtime`
 


### PR DESCRIPTION
## Summary

- Mark P2 as implemented now that the movement slice and minimal Unity FFI boundary exist.
- Document the current `kitu-unity-ffi` MVP surface for movement input, tick advancement, and render transform polling.
- Update architecture, specs, crate overview, and Japanese architecture notes so roadmap status matches the code.

## Why

The code already contains the minimal movement-slice FFI path and smoke tests, but some roadmap/spec text still treated that work as pending. This PR makes documentation reflect the implemented state and leaves the remaining work focused on replay smoke scenarios and fixtures.

## Validation

- `docker exec 1451520c68ef sh -lc 'cd /workspaces/kitu-logic-processor && cargo test --workspace'`
- `git diff --check`