### PR TITLE
[codex] Move Web Admin world state to runtime/ECS

### DIFF
--- a/crates/kitu-ecs/src/lib.rs
+++ b/crates/kitu-ecs/src/lib.rs
@@ -19,14 +19,67 @@ pub trait System: Send + Sync + 'static {
     fn run(&mut self, world: &mut EcsWorld, tick: Tick) -> Result<()>;
 }
 
+/// Position for an object in the authoritative world state.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct WorldTransform {
+    /// X coordinate in world space.
+    pub x: f32,
+    /// Y coordinate in world space.
+    pub y: f32,
+    /// Z coordinate in world space.
+    pub z: f32,
+}
+
+impl WorldTransform {
+    /// Creates a transform from world-space coordinates.
+    pub const fn new(x: f32, y: f32, z: f32) -> Self {
+        Self { x, y, z }
+    }
+}
+
+/// Object tracked by the ECS-backed world state.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WorldObject {
+    /// Stable object identifier assigned by the ECS world.
+    pub id: String,
+    /// Application-level object category.
+    pub kind: String,
+    /// Current object transform.
+    pub transform: WorldTransform,
+}
+
+/// Serializable-style snapshot of the ECS-backed world state.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct WorldSnapshot {
+    /// Objects currently present in the world.
+    pub objects: Vec<WorldObject>,
+}
+
 /// Minimal world representation for registering components and systems.
-#[derive(Default)]
 pub struct EcsWorld {
     components: Vec<String>,
     scheduled: VecDeque<Box<dyn System>>,
+    next_world_object_id: u64,
+    world_objects: Vec<WorldObject>,
+}
+
+impl Default for EcsWorld {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl EcsWorld {
+    /// Creates an empty ECS world.
+    pub fn new() -> Self {
+        Self {
+            components: Vec::new(),
+            scheduled: VecDeque::new(),
+            next_world_object_id: 1,
+            world_objects: Vec::new(),
+        }
+    }
+
     /// Registers a component type by name. The concrete storage will be wired later.
     pub fn register_component(&mut self, name: impl Into<String>) -> Result<()> {
         let name = name.into();
@@ -53,6 +106,60 @@ impl EcsWorld {
     /// Returns a snapshot of registered component names.
     pub fn registered_components(&self) -> Vec<String> {
         self.components.clone()
+    }
+
+    /// Spawns an object into the authoritative world state.
+    pub fn spawn_world_object(
+        &mut self,
+        kind: impl Into<String>,
+        transform: WorldTransform,
+    ) -> Result<WorldObject> {
+        let kind = kind.into();
+        if kind.is_empty() {
+            return Err(KituError::InvalidInput("world object kind cannot be empty"));
+        }
+
+        let id = format!("obj-{}", self.next_world_object_id);
+        self.next_world_object_id += 1;
+        let object = WorldObject {
+            id,
+            kind,
+            transform,
+        };
+        self.world_objects.push(object.clone());
+        Ok(object)
+    }
+
+    /// Moves an existing world object to an absolute transform.
+    pub fn move_world_object(
+        &mut self,
+        id: &str,
+        transform: WorldTransform,
+    ) -> Result<WorldObject> {
+        let object = self
+            .world_objects
+            .iter_mut()
+            .find(|object| object.id == id)
+            .ok_or(KituError::InvalidInput("unknown world object"))?;
+        object.transform = transform;
+        Ok(object.clone())
+    }
+
+    /// Returns a single object by id.
+    pub fn world_object(&self, id: &str) -> Option<&WorldObject> {
+        self.world_objects.iter().find(|object| object.id == id)
+    }
+
+    /// Removes all authoritative world objects.
+    pub fn reset_world_objects(&mut self) {
+        self.world_objects.clear();
+    }
+
+    /// Returns a stable snapshot of the authoritative world state.
+    pub fn world_snapshot(&self) -> WorldSnapshot {
+        WorldSnapshot {
+            objects: self.world_objects.clone(),
+        }
     }
 }
 
@@ -104,5 +211,26 @@ mod tests {
         system.run(&mut world, tick).unwrap();
         system.run(&mut world, tick).unwrap();
         assert_eq!(system.runs.get(&tick.get()), Some(&2));
+    }
+
+    #[test]
+    fn world_objects_spawn_move_and_snapshot() {
+        let mut world = EcsWorld::new();
+
+        let spawned = world
+            .spawn_world_object("enemy", WorldTransform::new(1.0, 2.0, 3.0))
+            .unwrap();
+        assert_eq!(spawned.id, "obj-1");
+
+        let moved = world
+            .move_world_object(&spawned.id, WorldTransform::new(4.0, 5.0, 6.0))
+            .unwrap();
+        assert_eq!(moved.transform, WorldTransform::new(4.0, 5.0, 6.0));
+
+        let snapshot = world.world_snapshot();
+        assert_eq!(snapshot.objects, vec![moved]);
+
+        world.reset_world_objects();
+        assert!(world.world_snapshot().objects.is_empty());
     }
 }

--- a/crates/kitu-runtime/src/lib.rs
+++ b/crates/kitu-runtime/src/lib.rs
@@ -17,6 +17,7 @@ use std::{
 
 use kitu_core::{KituError, Result, Tick};
 use kitu_ecs::EcsWorld;
+pub use kitu_ecs::{WorldObject, WorldSnapshot, WorldTransform};
 use kitu_osc_ir::{OscArg, OscBundle, OscMessage};
 use kitu_transport::{Transport, TransportEvent};
 
@@ -42,6 +43,11 @@ impl AuthoritativeInputQueue {
 
     fn committed_snapshot(&self) -> Vec<OscBundle> {
         self.committed_batch.iter().cloned().collect()
+    }
+
+    fn clear(&mut self) {
+        self.committed_batch.clear();
+        self.pending_queue.clear();
     }
 }
 
@@ -79,6 +85,11 @@ impl OutputBuffer {
 
     fn drain_visible(&mut self) -> Vec<OscBundle> {
         self.visible.drain(..).collect()
+    }
+
+    fn clear(&mut self) {
+        self.staged.clear();
+        self.visible.clear();
     }
 }
 
@@ -152,6 +163,49 @@ impl<T: Transport> Runtime<T> {
         &mut self.world
     }
 
+    /// Spawns an object into the authoritative runtime/ECS world state.
+    pub fn spawn_world_object(
+        &mut self,
+        kind: impl Into<String>,
+        x: f32,
+        y: f32,
+        z: f32,
+    ) -> Result<WorldObject> {
+        let object = self
+            .world
+            .spawn_world_object(kind, WorldTransform::new(x, y, z))?;
+        self.enqueue_player_move(&object.id, x, z);
+        Ok(object)
+    }
+
+    /// Moves an existing object in the authoritative runtime/ECS world state.
+    pub fn move_world_object(&mut self, id: &str, x: f32, y: f32, z: f32) -> Result<WorldObject> {
+        let previous = self
+            .world
+            .world_object(id)
+            .ok_or(KituError::InvalidInput("unknown world object"))?
+            .clone();
+        let moved = self
+            .world
+            .move_world_object(id, WorldTransform::new(x, y, z))?;
+        self.enqueue_player_move(id, x - previous.transform.x, z - previous.transform.z);
+        Ok(moved)
+    }
+
+    /// Clears all objects from the authoritative runtime/ECS world state.
+    pub fn reset_world_objects(&mut self) {
+        self.world.reset_world_objects();
+        self.player_transforms.clear();
+        self.inputs.clear();
+        self.committed_input_tick = None;
+        self.outputs.clear();
+    }
+
+    /// Returns the authoritative runtime/ECS world snapshot.
+    pub fn inspect_world_state(&self) -> WorldSnapshot {
+        self.world.world_snapshot()
+    }
+
     /// Enqueues an input bundle for the next tick.
     pub fn enqueue_input(&mut self, input: OscBundle) {
         self.inputs.enqueue_pending(input);
@@ -178,6 +232,16 @@ impl<T: Transport> Runtime<T> {
             self.committed_input_tick = None;
         }
         drained
+    }
+
+    fn enqueue_player_move(&mut self, entity_id: &str, x: f32, z: f32) {
+        let mut message = OscMessage::new("/input/move");
+        message.push_arg(OscArg::Str(entity_id.to_string()));
+        message.push_arg(OscArg::Float(x));
+        message.push_arg(OscArg::Float(z));
+        let mut bundle = OscBundle::new();
+        bundle.push(message);
+        self.enqueue_input(bundle);
     }
 
     /// Processes as many fixed ticks as `dt` allows.
@@ -595,6 +659,40 @@ mod tests {
         runtime.tick_once().unwrap();
         let drained = runtime.drain_output_buffer();
         assert_eq!(drained, vec![first, second]);
+    }
+
+    #[test]
+    fn world_api_spawns_moves_and_snapshots_runtime_state() {
+        let mut runtime = build_runtime(LocalChannel::default());
+
+        let object = runtime.spawn_world_object("enemy", 1.0, 2.0, 3.0).unwrap();
+        assert_eq!(object.id, "obj-1");
+
+        runtime.tick_once().unwrap();
+        let outputs = runtime.drain_output_buffer();
+        assert_eq!(outputs.len(), 1);
+
+        let moved = runtime
+            .move_world_object(&object.id, 4.0, 5.0, 6.0)
+            .unwrap();
+        assert_eq!(moved.transform, WorldTransform::new(4.0, 5.0, 6.0));
+
+        let snapshot = runtime.inspect_world_state();
+        assert_eq!(snapshot.objects, vec![moved]);
+    }
+
+    #[test]
+    fn world_api_reset_clears_runtime_state() {
+        let mut runtime = build_runtime(LocalChannel::default());
+
+        runtime
+            .spawn_world_object("trigger", 0.0, 0.0, 0.0)
+            .unwrap();
+        runtime.reset_world_objects();
+
+        assert!(runtime.inspect_world_state().objects.is_empty());
+        runtime.tick_once().unwrap();
+        assert!(runtime.drain_output_buffer().is_empty());
     }
 
     #[test]

--- a/tools/kitu-web-admin/backend/src/main.rs
+++ b/tools/kitu-web-admin/backend/src/main.rs
@@ -15,7 +15,7 @@ use axum::{
     routing::get,
     Json, Router,
 };
-use kitu_osc_ir::{OscArg, OscBundle, OscMessage};
+use kitu_osc_ir::{OscArg, OscMessage};
 use kitu_runtime::{build_runtime, Runtime};
 use kitu_transport::LocalChannel;
 use serde::{Deserialize, Serialize};
@@ -33,9 +33,7 @@ struct AppState {
 
 struct GameState {
     runtime: Runtime<LocalChannel>,
-    next_object_id: u64,
     next_log_id: u64,
-    objects: Vec<WorldObject>,
     logs: Vec<DebugLogEntry>,
 }
 
@@ -43,9 +41,7 @@ impl Default for GameState {
     fn default() -> Self {
         Self {
             runtime: build_runtime(LocalChannel::connected()),
-            next_object_id: 1,
             next_log_id: 1,
-            objects: Vec::new(),
             logs: Vec::new(),
         }
     }
@@ -307,7 +303,7 @@ fn handle_client_osc(state: &AppState, client_message: ClientOscMessage) -> Resu
             });
         }
         "/admin/world/reset" => {
-            guard.objects.clear();
+            guard.runtime.reset_world_objects();
             outgoing_events.push(ServerEvent::Log {
                 entry: guard.push_log(
                     LogLevel::Warn,
@@ -349,21 +345,11 @@ fn spawn_object(state: &mut GameState, message: &OscMessage) -> Result<WorldObje
     let x = numeric_arg(message, 1).unwrap_or(0.0);
     let y = numeric_arg(message, 2).unwrap_or(0.0);
     let z = numeric_arg(message, 3).unwrap_or(0.0);
-    let id = format!("obj-{}", state.next_object_id);
-    state.next_object_id += 1;
-
-    let object = WorldObject {
-        id: id.clone(),
-        kind: kind.clone(),
-        x,
-        y,
-        z,
-        color: color_for_kind(&kind).to_string(),
-    };
-
-    state.objects.push(object.clone());
-    enqueue_runtime_move(&mut state.runtime, &id, x, z);
-    Ok(object)
+    let object = state
+        .runtime
+        .spawn_world_object(kind, x, y, z)
+        .context("spawn runtime world object")?;
+    Ok(WorldObject::from_runtime(&object))
 }
 
 fn move_object(state: &mut GameState, message: &OscMessage) -> Result<WorldObject> {
@@ -376,31 +362,11 @@ fn move_object(state: &mut GameState, message: &OscMessage) -> Result<WorldObjec
     let z =
         numeric_arg(message, 3).ok_or_else(|| anyhow::anyhow!("/admin/world/move expects z"))?;
 
-    let object = state
-        .objects
-        .iter_mut()
-        .find(|object| object.id == id)
-        .ok_or_else(|| anyhow::anyhow!("unknown world object: {id}"))?;
-
-    let delta_x = x - object.x;
-    let delta_z = z - object.z;
-    object.x = x;
-    object.y = y;
-    object.z = z;
-    let moved = object.clone();
-
-    enqueue_runtime_move(&mut state.runtime, id, delta_x, delta_z);
-    Ok(moved)
-}
-
-fn enqueue_runtime_move(runtime: &mut Runtime<LocalChannel>, entity_id: &str, x: f32, z: f32) {
-    let mut message = OscMessage::new("/input/move");
-    message.push_arg(OscArg::Str(entity_id.to_string()));
-    message.push_arg(OscArg::Float(x));
-    message.push_arg(OscArg::Float(z));
-    let mut bundle = OscBundle::new();
-    bundle.push(message);
-    runtime.enqueue_input(bundle);
+    let moved = state
+        .runtime
+        .move_world_object(id, x, y, z)
+        .with_context(|| format!("move runtime world object: {id}"))?;
+    Ok(WorldObject::from_runtime(&moved))
 }
 
 fn numeric_arg(message: &OscMessage, index: usize) -> Option<f32> {
@@ -443,9 +409,14 @@ fn broadcast_error(state: &AppState, message: String) {
 
 impl GameState {
     fn snapshot(&self) -> WorldSnapshot {
+        let runtime_snapshot = self.runtime.inspect_world_state();
         WorldSnapshot {
             tick: self.runtime.current_tick().get(),
-            objects: self.objects.clone(),
+            objects: runtime_snapshot
+                .objects
+                .iter()
+                .map(WorldObject::from_runtime)
+                .collect(),
         }
     }
 
@@ -468,6 +439,19 @@ impl GameState {
             self.logs.remove(0);
         }
         entry
+    }
+}
+
+impl WorldObject {
+    fn from_runtime(object: &kitu_runtime::WorldObject) -> Self {
+        Self {
+            id: object.id.clone(),
+            kind: object.kind.clone(),
+            x: object.transform.x,
+            y: object.transform.y,
+            z: object.transform.z,
+            color: color_for_kind(&object.kind).to_string(),
+        }
     }
 }
 
@@ -558,7 +542,7 @@ mod tests {
 
         let object = spawn_object(&mut state, &spawn).unwrap();
         assert_eq!(object.id, "obj-1");
-        assert_eq!(state.objects.len(), 1);
+        assert_eq!(state.runtime.inspect_world_state().objects.len(), 1);
 
         let mut move_message = OscMessage::new("/admin/world/move");
         move_message.push_arg(OscArg::Str(object.id));
@@ -570,5 +554,8 @@ mod tests {
         assert_eq!(moved.x, 4.0);
         assert_eq!(moved.y, 0.5);
         assert_eq!(moved.z, 6.0);
+
+        let snapshot = state.snapshot();
+        assert_eq!(snapshot.objects, vec![moved]);
     }
 }


### PR DESCRIPTION
## Summary
- Add ECS-backed world object storage and snapshots.
- Expose runtime-level spawn, move, reset, and inspect APIs for Web Admin world state.
- Update the Web Admin backend so snapshots are derived from runtime/ECS state instead of backend-only `GameState.objects`.

Closes #55.

## Validation
- `git diff --check`
- Not run: `cargo fmt --all --check` and targeted `cargo test` because `cargo` is not available in this execution environment.