### PR TITLE
[codex] Share OSC-IR with Web Admin via WASM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +339,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "kitu-cli"
 version = "0.1.0"
 dependencies = [
@@ -372,6 +387,17 @@ name = "kitu-osc-ir"
 version = "0.1.0"
 dependencies = [
  "kitu-core",
+]
+
+[[package]]
+name = "kitu-osc-ir-wasm"
+version = "0.1.0"
+dependencies = [
+ "kitu-osc-ir",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -678,6 +704,17 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1031,6 +1068,61 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/kitu-core",
     "crates/kitu-ecs",
     "crates/kitu-osc-ir",
+    "crates/kitu-osc-ir-wasm",
     "crates/kitu-transport",
     "crates/kitu-runtime",
     "crates/kitu-scripting-rhai",

--- a/crates/kitu-osc-ir-wasm/Cargo.toml
+++ b/crates/kitu-osc-ir-wasm/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "kitu-osc-ir-wasm"
+edition.workspace = true
+version.workspace = true
+authors.workspace = true
+publish.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+kitu-osc-ir = { path = "../kitu-osc-ir" }
+serde = { version = "1", features = ["derive"] }
+serde-wasm-bindgen = "0.6"
+wasm-bindgen = "=0.2.95"
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/kitu-osc-ir-wasm/README.md
+++ b/crates/kitu-osc-ir-wasm/README.md
@@ -1,0 +1,17 @@
+# kitu-osc-ir-wasm
+
+WASM bindings for the shared `kitu-osc-ir` message model.
+
+The crate exposes browser-facing builders for the Web Admin's JSON WebSocket
+transport while keeping the canonical message construction in Rust. Generate the
+frontend package with:
+
+```sh
+wasm-pack build crates/kitu-osc-ir-wasm \
+  --target web \
+  --out-dir ../../tools/kitu-web-admin/frontend/static/kitu-osc-ir-wasm \
+  --out-name kitu_osc_ir_wasm
+```
+
+The generated package is intentionally not committed. The Web Admin loads it
+from `/kitu-osc-ir-wasm/kitu_osc_ir_wasm.js` at runtime.

--- a/crates/kitu-osc-ir-wasm/src/lib.rs
+++ b/crates/kitu-osc-ir-wasm/src/lib.rs
@@ -1,0 +1,174 @@
+//! WASM bindings for browser-side OSC-IR message construction.
+
+use kitu_osc_ir::{OscArg, OscMessage};
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct JsonOscMessage {
+    pub address: String,
+    #[serde(default)]
+    pub args: Vec<JsonOscArg>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", content = "value", rename_all = "lowercase")]
+pub enum JsonOscArg {
+    Int(i32),
+    Int64(i64),
+    Float(f32),
+    Str(String),
+    Bool(bool),
+}
+
+impl From<&OscMessage> for JsonOscMessage {
+    fn from(message: &OscMessage) -> Self {
+        Self {
+            address: message.address.clone(),
+            args: message.args.iter().map(JsonOscArg::from).collect(),
+        }
+    }
+}
+
+impl From<&OscArg> for JsonOscArg {
+    fn from(value: &OscArg) -> Self {
+        match value {
+            OscArg::Int(value) => JsonOscArg::Int(*value),
+            OscArg::Int64(value) => JsonOscArg::Int64(*value),
+            OscArg::Float(value) => JsonOscArg::Float(*value),
+            OscArg::Str(value) => JsonOscArg::Str(value.clone()),
+            OscArg::Bool(value) => JsonOscArg::Bool(*value),
+        }
+    }
+}
+
+impl From<JsonOscArg> for OscArg {
+    fn from(value: JsonOscArg) -> Self {
+        match value {
+            JsonOscArg::Int(value) => OscArg::Int(value),
+            JsonOscArg::Int64(value) => OscArg::Int64(value),
+            JsonOscArg::Float(value) => OscArg::Float(value),
+            JsonOscArg::Str(value) => OscArg::Str(value),
+            JsonOscArg::Bool(value) => OscArg::Bool(value),
+        }
+    }
+}
+
+impl From<JsonOscMessage> for OscMessage {
+    fn from(value: JsonOscMessage) -> Self {
+        let mut message = OscMessage::new(value.address);
+        for arg in value.args {
+            message.push_arg(arg.into());
+        }
+        message
+    }
+}
+
+#[wasm_bindgen]
+pub struct OscMessageBuilder {
+    inner: OscMessage,
+}
+
+#[wasm_bindgen]
+impl OscMessageBuilder {
+    #[wasm_bindgen(constructor)]
+    pub fn new(address: String) -> Self {
+        Self {
+            inner: OscMessage::new(address),
+        }
+    }
+
+    pub fn push_int(&mut self, value: i32) {
+        self.inner.push_arg(OscArg::Int(value));
+    }
+
+    pub fn push_int64(&mut self, value: i64) {
+        self.inner.push_arg(OscArg::Int64(value));
+    }
+
+    pub fn push_float(&mut self, value: f32) {
+        self.inner.push_arg(OscArg::Float(value));
+    }
+
+    pub fn push_str(&mut self, value: String) {
+        self.inner.push_arg(OscArg::Str(value));
+    }
+
+    pub fn push_bool(&mut self, value: bool) {
+        self.inner.push_arg(OscArg::Bool(value));
+    }
+
+    pub fn build_json(&self) -> Result<JsValue, JsValue> {
+        to_js_message(&self.inner)
+    }
+}
+
+#[wasm_bindgen]
+pub fn admin_world_spawn(kind: String, x: f32, y: f32, z: f32) -> Result<JsValue, JsValue> {
+    let mut message = OscMessage::new("/admin/world/spawn");
+    message.push_arg(OscArg::Str(kind));
+    message.push_arg(OscArg::Float(x));
+    message.push_arg(OscArg::Float(y));
+    message.push_arg(OscArg::Float(z));
+    to_js_message(&message)
+}
+
+#[wasm_bindgen]
+pub fn admin_world_move(id: String, x: f32, y: f32, z: f32) -> Result<JsValue, JsValue> {
+    let mut message = OscMessage::new("/admin/world/move");
+    message.push_arg(OscArg::Str(id));
+    message.push_arg(OscArg::Float(x));
+    message.push_arg(OscArg::Float(y));
+    message.push_arg(OscArg::Float(z));
+    to_js_message(&message)
+}
+
+#[wasm_bindgen]
+pub fn admin_world_reset() -> Result<JsValue, JsValue> {
+    to_js_message(&OscMessage::new("/admin/world/reset"))
+}
+
+fn to_js_message(message: &OscMessage) -> Result<JsValue, JsValue> {
+    serde_wasm_bindgen::to_value(&JsonOscMessage::from(message))
+        .map_err(|error| JsValue::from_str(&error.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_message_round_trips_into_osc_ir() {
+        let json = JsonOscMessage {
+            address: "/admin/world/spawn".to_string(),
+            args: vec![
+                JsonOscArg::Str("enemy".to_string()),
+                JsonOscArg::Float(1.0),
+                JsonOscArg::Float(2.0),
+                JsonOscArg::Float(3.0),
+            ],
+        };
+
+        let osc = OscMessage::from(json.clone());
+        assert_eq!(osc.address, "/admin/world/spawn");
+        assert_eq!(osc.args[0], OscArg::Str("enemy".to_string()));
+        assert_eq!(JsonOscMessage::from(&osc), json);
+    }
+
+    #[test]
+    fn admin_builders_create_backend_compatible_shapes() {
+        let mut message = OscMessage::new("/admin/world/move");
+        message.push_arg(OscArg::Str("obj-1".to_string()));
+        message.push_arg(OscArg::Float(4.0));
+        message.push_arg(OscArg::Float(5.0));
+        message.push_arg(OscArg::Float(6.0));
+
+        let json = JsonOscMessage::from(&message);
+        let serialized = serde_json::to_string(&json).unwrap();
+        let decoded: JsonOscMessage = serde_json::from_str(&serialized).unwrap();
+        let osc = OscMessage::from(decoded);
+
+        assert_eq!(osc, message);
+    }
+}

--- a/tools/kitu-web-admin/README.md
+++ b/tools/kitu-web-admin/README.md
@@ -10,6 +10,22 @@ Initial browser admin vertical slice for organizing and debugging a Kitu logic p
 
 ## Run
 
+The frontend uses the shared Rust OSC-IR model through a generated WASM package.
+Local development requires Rust, the `wasm32-unknown-unknown` target, and the
+frontend npm dependencies before Vite starts:
+
+```sh
+rustup target add wasm32-unknown-unknown
+cd tools/kitu-web-admin/frontend
+npm install
+npm run wasm
+npm run dev
+```
+
+`npm run dev` and `npm run build` both run the WASM generation step first. The
+generated package is written to `frontend/static/kitu-osc-ir-wasm/` and is not
+committed.
+
 ```sh
 docker compose -f tools/kitu-web-admin/docker-compose.yml up --build
 ```
@@ -20,3 +36,6 @@ Then open:
 - Backend health: http://localhost:8787/health
 
 The Web Admin sends JSON-wrapped OSC-IR messages over WebSocket to create and move logical world objects. The backend logs inbound admin commands, ticks the Kitu runtime, and broadcasts world snapshots and debug logs back to the browser.
+In Docker Compose, the frontend image includes Node 22 and Rust 1.82 with the
+WASM target. The frontend service runs `npm install` and `npm run dev`; the
+`predev` script generates the OSC-IR WASM package before Vite starts.

--- a/tools/kitu-web-admin/docker-compose.yml
+++ b/tools/kitu-web-admin/docker-compose.yml
@@ -14,7 +14,9 @@ services:
       - target-cache:/workspace/target
 
   frontend:
-    image: node:22-alpine
+    build:
+      context: ../..
+      dockerfile: tools/kitu-web-admin/frontend/Dockerfile
     working_dir: /workspace/tools/kitu-web-admin/frontend
     command: sh -c "npm install && npm run dev -- --host 0.0.0.0"
     environment:
@@ -24,6 +26,7 @@ services:
       - "5173:5173"
     volumes:
       - ../..:/workspace
+      - cargo-cache:/usr/local/cargo/registry
       - web-admin-node-modules:/workspace/tools/kitu-web-admin/frontend/node_modules
     depends_on:
       - backend

--- a/tools/kitu-web-admin/frontend/.gitignore
+++ b/tools/kitu-web-admin/frontend/.gitignore
@@ -1,6 +1,7 @@
 .svelte-kit
 build
 node_modules
+static/kitu-osc-ir-wasm
 dist
 .env
 .env.*

--- a/tools/kitu-web-admin/frontend/Dockerfile
+++ b/tools/kitu-web-admin/frontend/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:22-bookworm
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        build-essential \
+        pkg-config \
+        libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV CARGO_HOME=/usr/local/cargo
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV PATH=/usr/local/cargo/bin:${PATH}
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --profile minimal --default-toolchain 1.82.0 --target wasm32-unknown-unknown \
+    && chmod -R a+w ${CARGO_HOME} ${RUSTUP_HOME}

--- a/tools/kitu-web-admin/frontend/eslint.config.js
+++ b/tools/kitu-web-admin/frontend/eslint.config.js
@@ -27,7 +27,13 @@ export default ts.config(
     },
   },
   {
-    ignores: ["build/", ".svelte-kit/", "dist/", "node_modules/"],
+    ignores: [
+      "build/",
+      ".svelte-kit/",
+      "dist/",
+      "node_modules/",
+      "static/kitu-osc-ir-wasm/",
+    ],
   },
   {
     rules: {

--- a/tools/kitu-web-admin/frontend/package-lock.json
+++ b/tools/kitu-web-admin/frontend/package-lock.json
@@ -33,7 +33,8 @@
         "tailwindcss": "^3.4.17",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.18.2",
-        "vite": "^8.0.16"
+        "vite": "^8.0.16",
+        "wasm-pack": "^0.15.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -338,6 +339,19 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2029,6 +2043,16 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -3317,6 +3341,29 @@
         "node": "*"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -4497,6 +4544,23 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -4796,6 +4860,23 @@
         }
       }
     },
+    "node_modules/wasm-pack": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/wasm-pack/-/wasm-pack-0.15.0.tgz",
+      "integrity": "sha512-DdqtGWc3+iFx+7lL7QU5LBWs7qMnwQSWxF0htSfE15sNa3roVwHjAkTm2JXgueU2GGfSwNqbq2EzyC2b/biKDA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "tar": "^7.5.3"
+      },
+      "bin": {
+        "wasm-pack": "run.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4820,6 +4901,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/yocto-queue": {

--- a/tools/kitu-web-admin/frontend/package.json
+++ b/tools/kitu-web-admin/frontend/package.json
@@ -4,7 +4,10 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
+    "wasm": "wasm-pack build ../../../crates/kitu-osc-ir-wasm --target web --out-dir ../../tools/kitu-web-admin/frontend/static/kitu-osc-ir-wasm --out-name kitu_osc_ir_wasm",
+    "predev": "npm run wasm",
     "dev": "vite",
+    "prebuild": "npm run wasm",
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
@@ -37,7 +40,8 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.18.2",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "wasm-pack": "^0.15.0"
   },
   "overrides": {
     "cookie": "^1.1.1"

--- a/tools/kitu-web-admin/frontend/src/lib/admin-client.ts
+++ b/tools/kitu-web-admin/frontend/src/lib/admin-client.ts
@@ -4,10 +4,15 @@ import { derived, get, writable } from "svelte/store";
 import type {
   ClientOscMessage,
   DebugLogEntry,
-  JsonOscArg,
   ServerEvent,
   WorldSnapshot,
 } from "./types";
+import {
+  buildAdminWorldMove,
+  buildAdminWorldReset,
+  buildAdminWorldSpawn,
+  initializeOscIr,
+} from "./osc-ir";
 
 type ConnectionState = "idle" | "connecting" | "open" | "closed" | "error";
 
@@ -47,6 +52,9 @@ export function connectAdminSocket() {
   socket.addEventListener("open", () => {
     connectionState.set("open");
     lastError.set(null);
+    initializeOscIr().catch((error: unknown) => {
+      lastError.set(error instanceof Error ? error.message : String(error));
+    });
   });
 
   socket.addEventListener("message", (event) => {
@@ -66,9 +74,7 @@ export function connectAdminSocket() {
   });
 }
 
-export function sendOsc(address: string, args: JsonOscArg[] = []) {
-  const payload: ClientOscMessage = { address, args };
-
+export function sendOsc(payload: ClientOscMessage) {
   if (!socket || socket.readyState !== WebSocket.OPEN) {
     lastError.set("WebSocket is not connected");
     return false;
@@ -78,26 +84,31 @@ export function sendOsc(address: string, args: JsonOscArg[] = []) {
   return true;
 }
 
-export function spawnObject(kind: string, x: number, y: number, z: number) {
-  return sendOsc("/admin/world/spawn", [
-    { type: "str", value: kind },
-    { type: "float", value: x },
-    { type: "float", value: y },
-    { type: "float", value: z },
-  ]);
+export async function spawnObject(
+  kind: string,
+  x: number,
+  y: number,
+  z: number,
+) {
+  return sendBuiltMessage(() => buildAdminWorldSpawn(kind, x, y, z));
 }
 
-export function moveObject(id: string, x: number, y: number, z: number) {
-  return sendOsc("/admin/world/move", [
-    { type: "str", value: id },
-    { type: "float", value: x },
-    { type: "float", value: y },
-    { type: "float", value: z },
-  ]);
+export async function moveObject(id: string, x: number, y: number, z: number) {
+  return sendBuiltMessage(() => buildAdminWorldMove(id, x, y, z));
 }
 
-export function resetWorld() {
-  return sendOsc("/admin/world/reset");
+export async function resetWorld() {
+  return sendBuiltMessage(buildAdminWorldReset);
+}
+
+async function sendBuiltMessage(build: () => Promise<ClientOscMessage>) {
+  try {
+    const payload = await build();
+    return sendOsc(payload);
+  } catch (error) {
+    lastError.set(error instanceof Error ? error.message : String(error));
+    return false;
+  }
 }
 
 function applyServerEvent(event: ServerEvent) {

--- a/tools/kitu-web-admin/frontend/src/lib/osc-ir.ts
+++ b/tools/kitu-web-admin/frontend/src/lib/osc-ir.ts
@@ -1,0 +1,103 @@
+import { browser } from "$app/environment";
+import type { ClientOscMessage, JsonOscArg } from "./types";
+
+type OscIrWasmModule = {
+  default: () => Promise<unknown>;
+  admin_world_spawn: (kind: string, x: number, y: number, z: number) => unknown;
+  admin_world_move: (id: string, x: number, y: number, z: number) => unknown;
+  admin_world_reset: () => unknown;
+};
+
+let wasmModule: Promise<OscIrWasmModule> | null = null;
+const importRuntimeModule = new Function(
+  "specifier",
+  "return import(specifier)",
+) as (specifier: string) => Promise<unknown>;
+
+export async function initializeOscIr() {
+  await loadOscIrWasm();
+}
+
+export async function buildAdminWorldSpawn(
+  kind: string,
+  x: number,
+  y: number,
+  z: number,
+) {
+  const wasm = await loadOscIrWasm();
+  return assertClientOscMessage(wasm.admin_world_spawn(kind, x, y, z));
+}
+
+export async function buildAdminWorldMove(
+  id: string,
+  x: number,
+  y: number,
+  z: number,
+) {
+  const wasm = await loadOscIrWasm();
+  return assertClientOscMessage(wasm.admin_world_move(id, x, y, z));
+}
+
+export async function buildAdminWorldReset() {
+  const wasm = await loadOscIrWasm();
+  return assertClientOscMessage(wasm.admin_world_reset());
+}
+
+async function loadOscIrWasm() {
+  if (!browser) {
+    throw new Error("OSC-IR WASM bindings can only be loaded in the browser");
+  }
+
+  wasmModule ??= importRuntimeModule("/kitu-osc-ir-wasm/kitu_osc_ir_wasm.js")
+    .then(async (module) => {
+      const wasm = module as OscIrWasmModule;
+      await wasm.default();
+      return wasm;
+    })
+    .catch((error: unknown) => {
+      wasmModule = null;
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `OSC-IR WASM bindings are not available. Run \`npm run wasm\` before starting Web Admin. ${detail}`,
+      );
+    });
+
+  return wasmModule;
+}
+
+function assertClientOscMessage(value: unknown): ClientOscMessage {
+  if (!isRecord(value) || typeof value.address !== "string") {
+    throw new Error("OSC-IR WASM returned an invalid message");
+  }
+
+  const args = Array.isArray(value.args) ? value.args : [];
+  if (!args.every(isJsonOscArg)) {
+    throw new Error("OSC-IR WASM returned invalid message arguments");
+  }
+
+  return {
+    address: value.address,
+    args,
+  };
+}
+
+function isJsonOscArg(value: unknown): value is JsonOscArg {
+  if (!isRecord(value) || typeof value.type !== "string") return false;
+
+  switch (value.type) {
+    case "int":
+    case "int64":
+    case "float":
+      return typeof value.value === "number";
+    case "str":
+      return typeof value.value === "string";
+    case "bool":
+      return typeof value.value === "boolean";
+    default:
+      return false;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}


### PR DESCRIPTION
## Summary
- Add a `kitu-osc-ir-wasm` wrapper crate with wasm-bindgen builders for generic OSC messages and Web Admin world commands.
- Update the Web Admin frontend so spawn, move, and reset commands are built through the generated OSC-IR WASM bindings before being sent over the existing JSON WebSocket contract.
- Add npm/Compose WASM generation flow, frontend Docker image support for Rust + wasm target, and build instructions.

Closes #56.

## Validation
- `docker exec kitu-web-admin-backend-1 cargo fmt --all --check`
- `docker exec kitu-web-admin-backend-1 cargo test -p kitu-osc-ir-wasm`
- `docker exec kitu-web-admin-backend-1 cargo build -p kitu-osc-ir-wasm --target wasm32-unknown-unknown`
- `docker exec kitu-web-admin-frontend-1 npm run check`
- `docker exec kitu-web-admin-frontend-1 npm run lint`
- `docker compose -f tools/kitu-web-admin/docker-compose.yml build frontend`
- `docker compose -f tools/kitu-web-admin/docker-compose.yml run --rm frontend npm run wasm`
- `docker compose -f tools/kitu-web-admin/docker-compose.yml run --rm frontend npm run build`
- `git diff --check`