### PR TITLE
[codex] Add player move smoke scenario

### DIFF
--- a/kitu-integration-runner/scenarios/README.md
+++ b/kitu-integration-runner/scenarios/README.md
@@ -7,3 +7,4 @@ Use [`doc/specs/integration-replay-framework.md`](../../doc/specs/integration-re
 ## Smoke scenarios
 
 - [`smoke/player-move-basic/scenario.json`](smoke/player-move-basic/scenario.json): sends a single `/input/move` intent through the authoritative runtime boundary.
+  Expected output: [`smoke/player-move-basic/expected.json`](smoke/player-move-basic/expected.json).

--- a/kitu-integration-runner/scenarios/README.md
+++ b/kitu-integration-runner/scenarios/README.md
@@ -3,3 +3,7 @@
 Checked-in integration and replay scenario definitions live here.
 
 Use [`doc/specs/integration-replay-framework.md`](../../doc/specs/integration-replay-framework.md) for the canonical scenario and expected-output file formats.
+
+## Smoke scenarios
+
+- [`smoke/player-move-basic/scenario.json`](smoke/player-move-basic/scenario.json): sends a single `/input/move` intent through the authoritative runtime boundary.

--- a/kitu-integration-runner/scenarios/smoke/player-move-basic/expected.json
+++ b/kitu-integration-runner/scenarios/smoke/player-move-basic/expected.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "scenario_id": "player-move-basic",
+  "expected_outputs": [
+    {
+      "tick": 1,
+      "address": "/render/player/transform",
+      "args": {
+        "entity_id": "player:local",
+        "tick": 0,
+        "position": {
+          "x": 1.5,
+          "y": 2.0,
+          "z": 0.0
+        }
+      }
+    }
+  ],
+  "expected_summary": {
+    "status": "pass",
+    "output_count": 1
+  }
+}

--- a/kitu-integration-runner/scenarios/smoke/player-move-basic/scenario.json
+++ b/kitu-integration-runner/scenarios/smoke/player-move-basic/scenario.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "scenario_id": "player-move-basic",
+  "description": "single player move intent produces one transform output on the next tick",
+  "initial_state": {
+    "content_version": "dev",
+    "tick": 0
+  },
+  "steps": [
+    {
+      "at_tick": 0,
+      "inbound": [
+        {
+          "channel": "runtime",
+          "address": "/input/move",
+          "args": {
+            "entity_id": "player:local",
+            "x": 1.5,
+            "y": 2.0
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add the first checked-in smoke scenario under `kitu-integration-runner/scenarios/smoke/player-move-basic`.
- Document the scenario from `kitu-integration-runner/scenarios/README.md`.

Closes #39.

## Verification

- `jq . kitu-integration-runner/scenarios/smoke/player-move-basic/scenario.json`
- `git diff --check`

Not run: `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all` because `cargo` is not installed in this environment (`command -v cargo` returned no path).