### PR TITLE
[codex] Add player move replay fixtures

### DIFF
--- a/kitu-integration-runner/scenarios/smoke/player-move-basic/notes.md
+++ b/kitu-integration-runner/scenarios/smoke/player-move-basic/notes.md
@@ -1,0 +1,6 @@
+# Player Move Basic
+
+This smoke fixture sends one runtime-boundary `/input/move` intent for `player:local`.
+
+The expected output is the runtime-owned `/render/player/transform` message emitted after one tick.
+The fixture does not patch ECS state directly.


### PR DESCRIPTION
## Summary

- Add `expected.json` for the `player-move-basic` smoke scenario.
- Add scenario notes that clarify the fixture uses runtime-boundary input, not direct ECS state patching.
- Link the expected output from the scenarios README.

Closes #40.

## Dependency

This PR is based on #62 / `codex/issue-39-smoke-scenario` because the expected fixture belongs to the scenario introduced there. After #62 merges into `develop`, this PR can be retargeted to `develop` without changing its diff.

## Verification

- `jq . kitu-integration-runner/scenarios/smoke/player-move-basic/scenario.json`
- `jq . kitu-integration-runner/scenarios/smoke/player-move-basic/expected.json`
- `git diff --check`

Not run: `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all` because `cargo` is not installed in this environment (`command -v cargo` returned no path).