### PR TITLE
[codex] Align replay docs with runtime boundary

### DIFF
--- a/doc/specs/integration-replay-framework.md
+++ b/doc/specs/integration-replay-framework.md
@@ -119,7 +119,7 @@ Minimal shape:
       "address": "/render/player/transform",
       "args": {
         "entity_id": "player:local",
-        "source_tick": 0,
+        "tick": 0,
         "position": { "x": 1.5, "y": 2.0, "z": 0.0 }
       }
     }
@@ -135,7 +135,7 @@ Rules:
 
 - compare logical message content, not concrete wire bytes
 - assert only the stable fields required by the scenario
-- `expected_outputs[].tick` is the externally visible output tick; `args.source_tick` is the authoritative tick that produced the transform.
+- `expected_outputs[].tick` is the externally visible output tick; `args.tick` is the authoritative tick that produced the transform.
 - leave room for future partial-match or ignore-field semantics without changing the overall structure
 
 ## Run summary / report format

--- a/doc/specs/integration-replay-framework.md
+++ b/doc/specs/integration-replay-framework.md
@@ -1,12 +1,12 @@
 # Integration / Replay Framework Specification (P3 MVP)
 
 This document defines the planning framework for integration runs and replay-oriented artifacts.
-It establishes the directory layout and file contracts needed before implementing deterministic replay itself.
+It establishes the directory layout and file contracts used by the minimal replay runner and future replay expansion.
 
 ## Status
 
 - Normative for repository layout and artifact shapes.
-- Intentionally does not require a finished replay engine.
+- Intentionally does not require a full replay engine beyond the current smoke runner.
 - Compatible with `doc/architecture.md`, where replay consumes event streams instead of patching ECS state directly.
 
 ## Goals
@@ -82,12 +82,12 @@ Minimal shape:
       "at_tick": 0,
       "inbound": [
         {
-          "channel": "unity",
+          "channel": "runtime",
           "address": "/input/move",
           "args": {
             "entity_id": "player:local",
-            "x": 0.0,
-            "y": 1.0
+            "x": 1.5,
+            "y": 2.0
           }
         }
       ]
@@ -100,6 +100,7 @@ Rules:
 
 - `steps` are ordered and tick-indexed.
 - inbound messages describe intents/envelopes, never direct state patches.
+- `channel` identifies the boundary origin class; smoke replay uses `runtime` to mean direct runtime-boundary input.
 - scenario files may later grow setup fields, but the ordered input stream remains the core contract.
 
 ## Expected output format
@@ -118,7 +119,8 @@ Minimal shape:
       "address": "/render/player/transform",
       "args": {
         "entity_id": "player:local",
-        "position": { "x": 0.0, "y": 1.0, "z": 0.0 }
+        "source_tick": 0,
+        "position": { "x": 1.5, "y": 2.0, "z": 0.0 }
       }
     }
   ],
@@ -133,6 +135,7 @@ Rules:
 
 - compare logical message content, not concrete wire bytes
 - assert only the stable fields required by the scenario
+- `expected_outputs[].tick` is the externally visible output tick; `args.source_tick` is the authoritative tick that produced the transform.
 - leave room for future partial-match or ignore-field semantics without changing the overall structure
 
 ## Run summary / report format
@@ -146,12 +149,12 @@ Minimal shape:
 ```json
 {
   "schema_version": 1,
-  "run_id": "20260323T120000Z-player-move-basic",
+  "run_id": "player-move-basic-pass",
   "scenario_id": "player-move-basic",
   "mode": "integration",
   "status": "pass",
-  "started_at": "2026-03-23T12:00:00Z",
-  "finished_at": "2026-03-23T12:00:01Z",
+  "started_at": "1970-01-01T00:00:00Z",
+  "finished_at": "1970-01-01T00:00:00Z",
   "observed": {
     "output_count": 1,
     "mismatch_count": 0
@@ -168,6 +171,7 @@ Required meanings:
 - `status`: overall result such as `pass`, `fail`, or `error`
 - `observed.output_count`: number of logical outbound messages observed
 - `observed.mismatch_count`: number of assertion mismatches
+- `started_at` and `finished_at` may be deterministic sentinel timestamps for smoke replay summaries where wall-clock time is intentionally excluded.
 
 ### Optional detailed reports
 
@@ -190,8 +194,13 @@ These files are optional in the framework phase and must not be required for the
 
 This framework is intentionally transport- and host-neutral. Current movement-slice runtime and Unity FFI work should plug into these scenario and report contracts rather than redefining them.
 
+Implemented smoke path:
+
+- checked-in movement-slice smoke scenario and expected output fixtures
+- minimal replay runner that reads the fixture pair and writes `summary.json`
+
 Still-pending implementation work:
 
-- deterministic replay executor implementation
-- checked-in movement-slice smoke scenario and expected output fixtures
+- broader deterministic replay executor capabilities beyond the first smoke path
+- richer mismatch reports such as `diff.json`
 - transport backend finalization

--- a/kitu-integration-runner/README.md
+++ b/kitu-integration-runner/README.md
@@ -1,13 +1,14 @@
 # Kitu Integration Runner
 
-This directory holds the framework definition for future integration and replay execution.
-At the current stage, the repository defines the checked-in scenario and report contracts first, while deterministic replay implementation remains deferred.
+This directory holds integration and replay scenarios plus the framework definition for replay execution.
+At the current stage, the repository includes the first smoke fixture pair and a minimal replay runner for that contract.
 
 ## Current status
 
-- Framework/design phase only.
-- Deterministic replay executor is not implemented yet.
-- The authoritative runtime loop baseline exists in `kitu-runtime`, but replay integration on top of it is not implemented yet.
+- Framework contract is defined.
+- `scenarios/smoke/player-move-basic/` contains the first runtime-boundary smoke fixture.
+- `tools/kitu-replay-runner` can run the smoke fixture pair and produce `summary.json`.
+- Broader replay coverage, richer reports, and Unity verification remain staged work.
 
 ## Normative spec
 
@@ -29,7 +30,7 @@ kitu-integration-runner/
   unity-app/
 ```
 
-Generated run artifacts should be emitted outside the checked-in scenario files, for example under a future `artifacts/` directory.
+Generated run artifacts should be emitted outside the checked-in scenario files, for example through the replay runner's `--output-dir`.
 
 ## Unity verification app (`unity-app/`)
 


### PR DESCRIPTION
## Summary

- Align the replay framework examples with the checked-in smoke fixture and runner behavior.
- Document visible output tick versus authoritative `source_tick`.
- Update `kitu-integration-runner/README.md` so it no longer describes the replay path as design-only or unimplemented.

Closes #42.

## Dependency

This PR is based on #64 / `codex/issue-41-replay-runner` because it documents the minimal runner and fixture behavior introduced in the preceding replay PRs.

## Verification

- `rg "not implemented yet|Framework/design phase only|source_tick|1970-01-01" doc/specs/integration-replay-framework.md kitu-integration-runner/README.md -n`
- `git diff --check`

Not run: `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, or `cargo test --all` because `cargo` is not installed in this environment (`command -v cargo` returned no path).