### PR TITLE
[codex] Add deterministic replay summary test

### DIFF
--- a/tools/kitu-replay-runner/src/main.rs
+++ b/tools/kitu-replay-runner/src/main.rs
@@ -464,4 +464,20 @@ mod tests {
 
         assert!(outputs_match(&expected, &observed));
     }
+
+    #[test]
+    fn replay_summary_is_deterministic_for_checked_in_smoke_fixture() {
+        let fixture_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../kitu-integration-runner/scenarios/smoke/player-move-basic");
+        let scenario = fixture_root.join("scenario.json");
+        let expected = fixture_root.join("expected.json");
+
+        let first = run_replay(&scenario, &expected).unwrap();
+        let second = run_replay(&scenario, &expected).unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(first.status, "pass");
+        assert_eq!(first.observed.output_count, 1);
+        assert_eq!(first.observed.mismatch_count, 0);
+    }
 }


### PR DESCRIPTION
## Summary

- Add replay runner coverage that executes the checked-in smoke fixture twice.
- Assert the two `ReplaySummary` values are identical and pass with one observed output and zero mismatches.

Closes #48.

## Dependency

This PR is based on #64 / `codex/issue-41-replay-runner` because it tests the runner introduced there. It does not depend on the #42 documentation-only PR.

## Verification

- `jq . kitu-integration-runner/scenarios/smoke/player-move-basic/scenario.json`
- `jq . kitu-integration-runner/scenarios/smoke/player-move-basic/expected.json`
- `git diff --check`

Not run: `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all`, or the runner test itself because `cargo`, `rustc`, and `rustfmt` are not installed in this environment (`command -v` returned no path).