### PR TITLE
[codex] Sync runtime execution docs with current tick order

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -197,10 +197,12 @@ The runtime model is **authoritative, tick-driven, and deterministic-first**.
 The canonical per-tick order is:
 
 1. **Freeze committed input batch for current tick**: clear previous committed inputs, then move `pending_inputs` into the committed batch for tick `N`.
-2. **ECS dispatch / simulation**: run deterministic ECS systems for tick `N` against that frozen batch.
-3. **Output emission**: move staged outputs produced during tick `N` into the externally visible output buffer.
-4. **Transport poll for next tick input**: drain transport events and enqueue received messages into `pending_inputs` for tick `N+1`.
-5. **Tick increment**: advance `tick` from `N` to `N+1` as the final phase.
+2. **Runtime-boundary input collection**: validate and snapshot committed messages owned directly by the MVP runtime, currently `/input/move`.
+3. **ECS dispatch / simulation**: run deterministic ECS systems for tick `N`.
+4. **Runtime-owned MVP slice update**: apply collected movement intents and stage `/render/player/transform` outputs.
+5. **Output emission**: move staged outputs produced during tick `N` into the externally visible output buffer.
+6. **Transport poll for next tick input**: drain transport events and enqueue received messages into `pending_inputs` for tick `N+1`.
+7. **Tick increment**: advance `tick` from `N` to `N+1` as the final phase.
 
 ### Runtime extension points (planned but bounded by this architecture)
 
@@ -222,8 +224,10 @@ sequenceDiagram
 
     Host->>Runtime: tick_once()
     Runtime->>Runtime: commit pending_inputs as tick N inputs
+    Runtime->>Runtime: collect runtime-owned input messages
     Runtime->>ECS: dispatch systems at tick N
     ECS-->>Runtime: deterministic state updates
+    Runtime->>Runtime: apply MVP movement slice and stage outputs
     Runtime->>Runtime: emit staged outputs to output_buffer
     Runtime->>Transport: poll_event() until empty
     Transport-->>Runtime: Message events for tick N+1
@@ -243,7 +247,7 @@ This timing rule supports deterministic replay, stable network synchronization, 
 
 ### Tick-based processing order requirements
 
-- Input intake for tick `N` must be applied in a deterministic order before advancing to `N+1`.
+- Input intake for tick `N` must be collected and applied in a deterministic order before advancing to `N+1`.
 - ECS dispatch ordering must be stable for a given build/configuration.
 - Tick increment is the final phase of `tick_once`.
 - Tooling-triggered operations (shell/admin/replay) must enter the same message/event queue path as gameplay input.

--- a/doc/detailed-flows.md
+++ b/doc/detailed-flows.md
@@ -206,14 +206,16 @@ Accumulates deltaTime, runs as many ticks as needed, and keeps the simulation on
 The authoritative runtime contract for tick `N` is fixed as the following canonical ordered phases (same contract as `doc/architecture.md`):
 
 1. **Freeze committed input batch for current tick**: clear the previous committed batch, then move `pending_inputs` into the committed input batch for tick `N`.
-2. **ECS dispatch / simulation**: run deterministic systems for tick `N` (input processing, AI/scripts, physics/movement, combat/damage, death handling, render-data collection).
-3. **Output emission**: move staged runtime outputs for tick `N` into the externally visible output buffer.
-4. **Transport poll for next tick input**: drain transport events and queue received messages into `pending_inputs` for tick `N+1`.
-5. **Tick increment**: advance from tick `N` to `N+1` as the final phase.
+2. **Runtime-boundary input collection**: validate and snapshot committed messages owned directly by the current MVP runtime, including `/input/move`.
+3. **ECS dispatch / simulation**: run deterministic systems for tick `N` in scheduled FIFO order.
+4. **Runtime-owned MVP slice update**: apply collected movement intents and stage `/render/player/transform` outputs.
+5. **Output emission**: move staged runtime outputs for tick `N` into the externally visible output buffer.
+6. **Transport poll for next tick input**: drain transport events and queue received messages into `pending_inputs` for tick `N+1`.
+7. **Tick increment**: advance from tick `N` to `N+1` as the final phase.
 
 Important timing rule: **input received during tick `N` is applied on tick `N+1`**. Inputs received while tick `N` is running are never applied in tick `N`; they are first eligible in tick `N+1` when that tick starts and freezes its committed batch. Transport polling alone must not directly mutate authoritative world state.
 
-Crates: `kitu-ecs`, `game-ecs-features`, `game-logic`, `kitu-tsq1` (when skills present), `kitu-runtime` (authoritative phase orchestration and buffers).
+Crates: `kitu-ecs`, `game-ecs-features`, `game-logic`, `kitu-tsq1` (when skills present), `kitu-runtime` (authoritative phase orchestration, current MVP movement slice, and buffers).
 
 ### Output events `/render/*` `/ui/*` `/debug/*`
 

--- a/doc/detailed-flows.md
+++ b/doc/detailed-flows.md
@@ -256,8 +256,8 @@ All share the same `KituRuntime` tick path, preserving consistent behavior.
 ### Architectural checkpoints
 
 - Keep **input interpretation in Unity** and **movement logic in Rust** for clear separation.
-- Reuse a simple pattern `/input/move` → ECS → `/render/player/transform`.
-- Ensure the Kitu ECS abstraction can extend to collisions/terrain later.
+- Reuse a simple pattern `/input/move` → runtime-owned MVP movement slice → `/render/player/transform`.
+- Keep the current movement slice narrow while leaving room to move richer collision/terrain systems into ECS later.
 
 ### Overview
 
@@ -290,45 +290,38 @@ args: { x: 0.5, y: 1.0 }
 
 Crates: `kitu-unity-ffi` (C API → `OscEvent`), `kitu-runtime` (input queue), `kitu-osc-ir` (`OscEvent`). Flow: convert to `OscEvent`, call `KituRuntime::enqueue_input`, defer processing until the next tick’s input phase.
 
-### ECS phase 1: update velocity
+### Runtime-boundary input collection
 
-Crates: `kitu-ecs`, `game-ecs-features` (`InputMove`, `Velocity`), `game-logic` (speed constants).
+Crates: `kitu-runtime`, `kitu-osc-ir`.
+
+At tick `N`, the runtime freezes pending inputs into the committed batch, validates `/input/move`, and snapshots the movement intents before ECS dispatch. Invalid movement messages fail the tick before any state mutation.
 
 ```rust
-fn input_movement_system(world: &mut World) {
-    let move_input = world.resource::<InputMoveState>();
-
-    for (_player, mut velocity) in world.query_mut::<(&PlayerTag, &mut Velocity)>() {
-        velocity.x = move_input.x * MOVE_SPEED;
-        velocity.y = move_input.y * MOVE_SPEED;
-    }
+fn collect_move_inputs(committed: &[OscBundle]) -> Result<Vec<(String, f32, f32)>> {
+    // Current MVP shape:
+    // /input/move(entity_id, x, y)
+    parse_runtime_owned_move_messages(committed)
 }
 ```
 
-### ECS phase 3: update position
+### ECS dispatch
 
-```rust
-fn movement_system(world: &mut World) {
-    for (_player, mut pos, vel) in world.query_mut::<(&PlayerTag, &mut Position, &Velocity)>() {
-        pos.x += vel.x;
-        pos.y += vel.y;
-    }
-}
-```
+The runtime dispatches scheduled ECS systems for tick `N` after input collection. The current MVP player-move slice does not require ECS systems to consume `InputMoveState`, but future richer movement systems may be introduced here if they preserve the same runtime authority and timing rules.
 
-### ECS phase 6: emit `/render/player/transform`
+### Runtime-owned MVP slice update and output staging
 
 Crates: `kitu-runtime`, `kitu-osc-ir`.
 
 ```rust
-fn gather_player_render_events(world: &World, out_events: &mut Vec<OscEvent>) {
-    for (_player, pos) in world.query::<(&PlayerTag, &Position)>() {
-        out_events.push(OscEvent::render_player_transform(1, pos));
+fn apply_player_move_slice(moves: Vec<(String, f32, f32)>, out: &mut OutputBuffer) {
+    for (entity_id, x, y) in moves {
+        let transform = update_runtime_owned_player_transform(entity_id, x, y);
+        out.stage(render_player_transform_message(transform));
     }
 }
 ```
 
-Resulting event contains entity id and position.
+The staged `/render/player/transform` output becomes externally visible during the output emission phase of the same tick. The resulting event contains entity id, authoritative tick, and position.
 
 ### Unity view applies transform
 

--- a/doc/specs/runtime-execution-contract.md
+++ b/doc/specs/runtime-execution-contract.md
@@ -31,14 +31,19 @@ For tick `N`, execution order is fixed as follows:
 
 1. **Commit input batch for tick `N`**
    - Clear previous committed inputs, then move `pending_inputs` into `committed_inputs` for tick `N`.
-2. **Dispatch ECS systems for tick `N`**
-   - Authoritative state update phase.
-3. **Emit outputs for tick `N`**
+2. **Collect runtime-boundary inputs for tick `N`**
+   - Validate and snapshot committed messages that the current runtime owns directly.
+   - Current MVP behavior collects `/input/move` before ECS dispatch so invalid movement input fails the tick before state mutation.
+3. **Dispatch ECS systems for tick `N`**
+   - Run scheduled ECS systems in deterministic order.
+4. **Apply runtime-owned MVP slice updates**
+   - Current MVP behavior applies collected `/input/move` intents after ECS dispatch and stages `/render/player/transform`.
+5. **Emit outputs for tick `N`**
    - Move staged outputs into externally visible `output_buffer`.
-4. **Poll transport for next tick input**
+6. **Poll transport for next tick input**
    - Drain `poll_event()` until empty.
    - Any received `TransportEvent::Message` is enqueued into `pending_inputs`.
-5. **Advance tick**
+7. **Advance tick**
    - `tick = tick.next()`.
 
 ## Input timing rule (normative)
@@ -50,7 +55,7 @@ This rule is mandatory for deterministic replay and transport-timing independenc
 
 ## Output timing rule
 
-Outputs generated during tick `N` are staged during execution and only become externally visible in the output buffer at phase 3 of tick `N`.
+Outputs generated during tick `N` are staged during execution and only become externally visible in the output buffer at the output emission phase of tick `N`.
 Hosts should poll outputs after `update()`/`tick_once()` returns.
 
 ## Minimal API surface (MVP)
@@ -58,7 +63,7 @@ Hosts should poll outputs after `update()`/`tick_once()` returns.
 - `update(dt: f32) -> Result<u32>`: advance fixed ticks from an accumulator.
 - `tick_once() -> Result<()>`: execute exactly one authoritative tick with the fixed phase order.
 - `enqueue_input(bundle)`: queue host-provided input for a future tick.
-- `queue_output(bundle)`: stage runtime outputs for emission at phase 3.
+- `queue_output(bundle)`: stage runtime outputs for the output emission phase.
 - `drain_output_buffer()`: read emitted outputs in FIFO order.
 - `drain_committed_inputs()`: consume the committed input batch in FIFO order.
 


### PR DESCRIPTION
## Summary

- Update runtime execution docs to match the current `tick_once()` ordering.
- Explicitly document runtime-boundary input collection before ECS dispatch and the current MVP movement slice update after dispatch.
- Remove stale phase-number wording from output emission API text.

Closes #37.

## Verification

- `rg "phase 3|Runtime-boundary input collection|Runtime-owned MVP slice|output emission phase" doc/specs/runtime-execution-contract.md doc/architecture.md doc/detailed-flows.md -n`
- `git diff --check`

Not run: `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, or `cargo test --all` because `cargo` is not installed in this environment (`command -v cargo` returned no path).