### PR TITLE
[codex] Mark runtime MVP core status after replay smoke path

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -54,7 +54,7 @@ missing:
 
 ### P1 — Runtime Core Viability
 
-status: partial
+status: implemented for MVP core
 
 exists:
 - fixed-timestep `update(dt)` baseline exists
@@ -62,10 +62,10 @@ exists:
 - output drain path exists
 - `tick_once()` ordering is implemented and unit-tested
 - first slice and integration-level validation exist in baseline form
+- replay smoke path exists through checked-in fixture contracts and the minimal replay runner
 
 missing:
-- explicit closure decision after the replay smoke path is in place
-- stronger proof that runtime baseline is ready to be treated as complete MVP core
+- broader runtime features beyond the MVP core remain tracked as staged work, not P1 blockers
 
 ### P2 — Minimum Vertical Slice
 
@@ -89,11 +89,13 @@ status: partial
 exists:
 - framework contract is defined
 - runner directory structure exists
+- first checked-in smoke scenario exists
+- initial `scenario.json` and `expected.json` fixture pair exists
+- minimal replay runner can produce `summary.json`
 
 missing:
-- checked-in smoke scenario
-- initial `scenario.json` and `expected.json`
-- minimal replay runner that produces `summary.json`
+- broader deterministic replay coverage beyond the first smoke path
+- richer failure reports and scenario expansion
 
 ### P4 — Documentation and Maintenance Alignment
 


### PR DESCRIPTION
## Summary

- Record the P1 closure decision in `doc/architecture.md`.
- Mark `kitu-runtime` MVP core viability as implemented for the MVP core after the replay smoke path exists.
- Move remaining replay expansion into P3 staged work instead of leaving it as a P1 blocker.

Closes #38.

## Dependency

This PR is based on #65 / `codex/issue-42-replay-boundary`, which itself stacks on the smoke scenario, fixtures, and minimal runner PRs (#62, #63, #64). It also assumes #66 provides the deterministic replay coverage proof for the same smoke path.

## Verification

- `sed -n '48,110p' doc/architecture.md`
- `git diff --check`
- Confirmed `PROJECT_TODO.md` is no longer present in this checkout.

Not run: `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, or `cargo test --all` because `cargo` is not installed in this environment (`command -v cargo` returned no path).