### PR TITLE
[codex] Clarify project implementation status wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Goals:
 - Strong tooling (Shell, Web Admin, CI/replay)
 - Minimal coupling between teams (logic / art / design / QA)
 
+Implementation status:
+
+- The current repository contains the MVP runtime core, the player-move vertical slice, and early replay/tooling foundations.
+- Several data/content and tooling sections below describe target architecture rather than finished production features.
+- For the current implemented/partial/staged breakdown, use [doc/architecture.md](doc/architecture.md#current-implementation-staging).
+
 
 ## High-Level Architecture
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -40,6 +40,13 @@ Kitu separates **authoritative runtime logic** (Rust) from **presentation and pl
 
 ## Current Implementation Staging
 
+Status terms in this section are used as follows:
+
+- `implemented`: code, tests, and docs exist for the stated MVP scope.
+- `implemented for MVP core`: the MVP core contract is complete, while broader feature expansion remains tracked separately.
+- `partial`: repository support exists, but explicit missing work remains listed below.
+- `staged work`: planned or future work that must not be read as implemented.
+
 ### P0 — Execution Semantics
 
 status: implemented

--- a/doc/specs/runtime-execution.md
+++ b/doc/specs/runtime-execution.md
@@ -7,7 +7,7 @@ It complements `runtime-execution-contract.md` by describing the runtime respons
 
 - Normative for execution phase boundaries and timing rules.
 - Intentionally non-prescriptive about concrete scheduler, queue, and buffer data structures.
-- Compatible with the current architecture in `doc/architecture.md`, where P1 remains partial / frozen.
+- Compatible with the current architecture in `doc/architecture.md`, where P1 is implemented for the MVP core and broader expansion is staged separately.
 
 ## Scope
 
@@ -17,10 +17,10 @@ It complements `runtime-execution-contract.md` by describing the runtime respons
 
 ## Non-goals
 
-- Final implementation of `Runtime::update(dt)`.
-- Final internal queue structures for committed/pending inputs.
+- Redesigning the implemented `Runtime::update(dt)` fixed-timestep behavior.
+- Freezing final internal queue structures beyond the documented committed/pending input contract.
 - Final ECS scheduler details.
-- Final replay execution engine.
+- Full replay execution engine beyond the current smoke path.
 
 ## Execution ownership
 


### PR DESCRIPTION
## Summary

- Add explicit status vocabulary to the implementation staging section.
- Add a README implementation-status note so target architecture text is not mistaken for finished production behavior.
- Replace stale `P1 remains partial / frozen` wording in `runtime-execution.md` with the current MVP-core status.

Closes #44.

## Dependency

This PR is based on #69 / `codex/issue-38-runtime-mvp-status` because it clarifies the status terms introduced by that staging update.

## Verification

- `rg "P1 remains partial|partial / frozen|Status terms|Implementation status|target architecture|implemented for the MVP core" README.md doc/architecture.md doc/specs/runtime-execution.md -n`
- `git diff --check`

Not run: `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, or `cargo test --all` because `cargo` is not installed in this environment (`command -v cargo` returned no path).