### PR TITLE
[codex] Document staged TSQ1 TMD scripting entry points

### DIFF
--- a/PRODUCTION_STRATEGY.md
+++ b/PRODUCTION_STRATEGY.md
@@ -3,6 +3,8 @@
 This document summarizes the foundational setup required to streamline ongoing development of the *kitu-logic-processor* repository.
 It serves as a reference for establishing consistent development environments, repository structure, and tooling.
 
+Status note: this is a bootstrap strategy document. Current implementation status and staged subsystem boundaries are tracked in `doc/architecture.md`.
+
 
 ## Table of Contents
 - [Repository Meta](#repository-meta)
@@ -194,4 +196,3 @@ To bootstrap the project efficiently, prioritize:
    (`src/lib.rs`, CLI entry, examples/)
 
 With this foundation prepared, subsequent implementation steps become significantly smoother.
-

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -217,6 +217,8 @@ The canonical per-tick order is:
 - Rhai script invocation occurs through runtime-owned APIs, not direct arbitrary host callbacks.
 - Data reload hooks (TMD/SQLite) must be scheduled at explicit safe points, not asynchronously mutating world state mid-phase.
 
+These are staged extension points, not claims of complete subsystem implementation.
+
 ## Tick and event flow
 
 The per-tick order must remain explicit and stable, because replay/debug tools depend on it.
@@ -404,6 +406,16 @@ flowchart TD
 - TSQ1: timeline behavior represented as deterministic, tick-aligned steps.
 - Rhai: scripted behavior must execute through constrained host APIs.
 - Runtime: final authority deciding when and how loaded content affects simulation state.
+
+### Future subsystem entry points
+
+The following entry points define where staged subsystem work should connect when it becomes implementation work:
+
+- TSQ1 enters through deterministic tick scheduling in `kitu-runtime`; timeline playback must emit runtime-owned commands or OSC-IR messages rather than mutating presentation state directly.
+- TMD and SQLite enter through validation/loading boundaries; runtime consumes typed records or commands, not raw authoring files or SQL strings from clients.
+- Rhai enters through constrained host APIs; scripts may request runtime actions but must not receive direct ECS mutation access.
+
+These entry points are intentionally directional. They make future work visible without committing to a specific implementation order beyond the current MVP core.
 
 ## Deployment modes
 

--- a/doc/crates-overview.md
+++ b/doc/crates-overview.md
@@ -2,6 +2,8 @@
 
 This document summarizes the Rust crates under `crates/` in the `kitu-logic-processor` workspace. Use it as a quick reference for responsibilities, entry points, and how the crates compose the runtime.
 
+Status note: some data/content crates are staged entry points. Their responsibility descriptions define intended boundaries and should not be read as complete production implementations unless `doc/architecture.md` marks the related milestone as implemented.
+
 ## Quick map
 
 | Crate | Purpose | Key dependencies |
@@ -78,19 +80,19 @@ graph TD
 - Future extensions will plug in TSQ1 playback, scripting hooks, and data loaders via this crate.
 
 ### `kitu-scripting-rhai`
-- Builds the Rhai execution environment and exposes safe bindings for runtime state.
+- Staged entry point for building the Rhai execution environment and exposing safe bindings for runtime state.
 - Scripts should access gameplay data through APIs defined here instead of touching ECS internals directly.
 
 ### `kitu-data-tmd`
-- Parses TMD authoring assets into strongly typed structures ready for validation and loading.
+- Staged entry point for parsing TMD authoring assets into strongly typed structures ready for validation and loading.
 - Keep transformations and schema evolution logic here to isolate game/runtime code from raw TMD layout changes.
 
 ### `kitu-data-sqlite`
-- Encapsulates SQLite schema management, migrations, and query helpers.
+- Staged entry point for SQLite schema management, migrations, and query helpers.
 - Designed to be shared by build pipelines and runtime code that consume the same data store.
 
 ### `kitu-tsq1`
-- Implements the TSQ1 timeline model and playback helpers for driving presentation events.
+- Staged entry point for the TSQ1 timeline model and playback helpers for driving presentation events.
 - Should remain deterministic and testable, with output expressed as OSC/IR messages.
 
 ### `kitu-shell`


### PR DESCRIPTION
## Summary

- Add explicit future subsystem entry points for TSQ1, TMD/SQLite, and Rhai scripting.
- Mark these as staged extension points, not complete subsystem implementations.
- Add status notes to the crate overview and production strategy docs so staged content is not mistaken for implemented production behavior.

Closes #45.

## Dependency

This PR is based on #70 / `codex/issue-44-status-clarity-docs` because it uses the clarified status vocabulary from that PR.

## Verification

- `rg "Future subsystem entry points|staged entry point|not claims of complete|bootstrap strategy|implementation order" doc/architecture.md doc/crates-overview.md PRODUCTION_STRATEGY.md -n`
- `git diff --check`

Not run: `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, or `cargo test --all` because `cargo` is not installed in this environment (`command -v cargo` returned no path).