### PR TITLE
[codex] Fill wasm package metadata

### DIFF
--- a/crates/kitu-osc-ir-wasm/Cargo.toml
+++ b/crates/kitu-osc-ir-wasm/Cargo.toml
@@ -4,6 +4,13 @@ edition.workspace = true
 version.workspace = true
 authors.workspace = true
 publish.workspace = true
+description = "WASM bindings for Kitu OSC/IR message conversion."
+license = "MIT"
+repository = "https://github.com/Nagitch/kitu-logic-processor"
+readme = "README.md"
+keywords = ["kitu", "osc", "wasm"]
+categories = ["wasm", "game-development"]
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/doc/publish-readiness.md
+++ b/doc/publish-readiness.md
@@ -23,7 +23,7 @@ Current future-publication candidates are the reusable crates under `crates/`.
 | `kitu-transport` | yes | present | present | present | pending package list |
 | `kitu-runtime` | yes | present | present | present | pending package list |
 | `kitu-app-actions` | yes | present | present | present | pending package list |
-| `kitu-osc-ir-wasm` | yes | pending #50 | pending #50 | present | pending package list |
+| `kitu-osc-ir-wasm` | yes | present | present | present | pending package list |
 | `kitu-scripting-rhai` | yes | present | present | present | pending package list |
 | `kitu-data-tmd` | yes | present | present | present | pending package list |
 | `kitu-data-sqlite` | yes | present | present | present | pending package list |


### PR DESCRIPTION
## Summary

- Add package metadata and an explicit `include` directive for `kitu-osc-ir-wasm`.
- Update the publish-readiness checklist so `kitu-osc-ir-wasm` no longer shows metadata/include as pending.

Closes #50.

## Dependency

This PR is based on #72 / `codex/issue-49-publish-readiness-checklist` because it updates the checklist introduced there.

## Verification

- `sed -n '1,40p' crates/kitu-osc-ir-wasm/Cargo.toml`
- `rg "kitu-osc-ir-wasm|pending #50" doc/publish-readiness.md -n`
- `git diff --check`

Not run: `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all`, or `cargo publish --dry-run` because `cargo` is not installed in this environment (`command -v cargo` returned no path). Dry-run validation remains tracked by #51.