### PR TITLE
[codex] Split demo game into app package

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,12 @@
   "build": {
     "dockerfile": "Dockerfile"
   },
-  "postCreateCommand": "rustup show && cargo --version",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22"
+    }
+  },
+  "postCreateCommand": "rustup show && cargo --version && node --version && npm --version",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -91,6 +91,9 @@ jobs:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Run demo-game scenario tests
+        run: cargo test -p kitu-demo-game --test scenarios
+
       - name: Run tests
         run: cargo test --all
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -131,6 +131,36 @@ AI assistants may create missing parts if intent is clear.
 
 CI should mirror the same checks.
 
+### 6.1 Dev Container rule for AI assistants
+
+AI assistants must treat the Dev Container as the authoritative development
+environment for this repository.
+
+- Do not assume Rust, Cargo, rustfmt, Clippy, Node, or other build tools are
+  installed on the host.
+- Prefer running build, test, lint, format, and documentation commands inside
+  the Dev Container.
+- If the `devcontainer` CLI is available, use it to execute repository commands
+  in the configured container.
+- If the `devcontainer` CLI is unavailable but Docker is available, use a
+  materially equivalent container based on `.devcontainer/Dockerfile` or an
+  existing project Compose service that provides the same toolchain.
+- If neither path is available, do not silently skip validation. Report that the
+  command could not be run because the Dev Container execution path is
+  unavailable.
+- Keep `.devcontainer/devcontainer.json` and `.devcontainer/Dockerfile` updated
+  whenever required development tools change.
+
+Examples:
+
+```bash
+devcontainer exec --workspace-folder . cargo test --all
+devcontainer exec --workspace-folder . cargo fmt --all --check
+```
+
+When using Docker directly instead of the Dev Container CLI, the command must
+mount the repository as the workspace and run from the repository root.
+
 ---
 
 ## 7. How AI should apply changes
@@ -148,6 +178,11 @@ Project-level tasks are maintained as **GitHub Issues**.
 AI assistants must:
 
 - Use `.github/ISSUE_TEMPLATE/work-item.md` when creating new work items.
+- Before opening a PR for implementation work, ensure a corresponding GitHub
+  Issue exists.
+- If no corresponding branch exists, create one from `origin/develop`.
+- Prefer branch names that include the issue number, for example
+  `codex/issue-76-demo-game-app-split`.
 - Update related Issues or PR descriptions when work progresses.
 - Close Issues only when their definition of done is satisfied.
 - Keep task management out of standalone Markdown TODO files unless the user explicitly asks for a temporary planning document.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "kitu-demo-game"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "kitu-app-actions",
+ "kitu-osc-ir",
+ "kitu-runtime",
+ "kitu-transport",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "kitu-ecs"
 version = "0.1.0"
 dependencies = [
@@ -480,24 +498,6 @@ name = "kitu-web-admin-backend"
 version = "0.1.0"
 dependencies = [
  "kitu-core",
-]
-
-[[package]]
-name = "kitu-web-admin-demo-backend"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "axum",
- "kitu-app-actions",
- "kitu-osc-ir",
- "kitu-runtime",
- "kitu-transport",
- "serde",
- "serde_json",
- "tokio",
- "tower-http",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ members = [
     "crates/kitu-shell",
     "crates/kitu-web-admin-backend",
     "crates/kitu-unity-ffi",
+    "apps/demo-game",
     "tools/kitu-cli",
     "tools/kitu-replay-runner",
-    "tools/kitu-web-admin/backend",
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -64,12 +64,21 @@ At a high level, Kitu consists of:
   - Kitu Shell (CLI console)
   - Web Admin (browser UI)
   - CI/replay, automation scripts
+- **Applications**
+  - `apps/demo-game` is the reference application built on the Kitu framework
+  - It hosts the current Web Admin vertical slice and app-level scenario tests
 
 The guiding principles are: separation of concerns, determinism, data‑driven design, and event‑based communication.
 
 ## Crates overview
 
 For a quick map of the Rust crates that make up the backend, see [doc/crates-overview.md](doc/crates-overview.md).
+
+## Applications
+
+Applications live under `apps/` and consume the reusable framework crates. The
+current reference app is `apps/demo-game`, which owns its project action
+manifest, admin host service, Docker Compose stack, and scenario tests.
 
 
 ## Backend Game Logic (Rust)
@@ -219,6 +228,9 @@ Web Admin turns the backend into an observable, controllable system without need
 
 Kitu’s workflow focuses on **fast iteration and strong separation**:
 
+- Development should run inside the Dev Container in `.devcontainer/`.
+- Host machines are not expected to have Rust/Cargo or frontend tooling
+  installed directly.
 - Backend developers work in Rust and Rhai, testing logic headlessly.
 - Unity developers focus on visuals, UI, asset setup, and Addressables.
 - Designers edit TMD, TSQ1, and DB content, often without touching code.

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,18 @@
+# Kitu applications
+
+`apps/` contains applications built with the reusable Kitu framework crates.
+Code here may depend on `crates/`, but framework crates should not depend on app
+packages.
+
+## Current apps
+
+- `demo-game/`: reference application for vertical-slice development, Web Admin
+  hosting, and CI scenario tests.
+
+## Conventions
+
+- Put app-specific manifests, scenarios, data, and host binaries under the app
+  directory.
+- Keep reusable engine/runtime/tooling code under `crates/` or `tools/`.
+- Prefer app-owned scenario tests when a fixture depends on project actions or
+  content.

--- a/apps/demo-game/Cargo.toml
+++ b/apps/demo-game/Cargo.toml
@@ -1,16 +1,24 @@
 [package]
-name = "kitu-web-admin-demo-backend"
+name = "kitu-demo-game"
 version = "0.1.0"
 edition = "2021"
 publish = false
 
+[lib]
+name = "kitu_demo_game"
+path = "src/lib.rs"
+
+[[bin]]
+name = "kitu-demo-game-admin-host"
+path = "src/bin/admin_host.rs"
+
 [dependencies]
 anyhow = { workspace = true }
 axum = { version = "0.7", features = ["ws"] }
-kitu-app-actions = { path = "../../../crates/kitu-app-actions" }
-kitu-osc-ir = { path = "../../../crates/kitu-osc-ir" }
-kitu-runtime = { path = "../../../crates/kitu-runtime" }
-kitu-transport = { path = "../../../crates/kitu-transport" }
+kitu-app-actions = { path = "../../crates/kitu-app-actions" }
+kitu-osc-ir = { path = "../../crates/kitu-osc-ir" }
+kitu-runtime = { path = "../../crates/kitu-runtime" }
+kitu-transport = { path = "../../crates/kitu-transport" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/apps/demo-game/README.md
+++ b/apps/demo-game/README.md
@@ -1,0 +1,41 @@
+# Kitu Demo Game
+
+`apps/demo-game` is a small application built on top of the Kitu framework crates.
+It exists for vertical-slice development, Web Admin hosting, and CI scenario tests.
+
+## Layout
+
+- `src/lib.rs`: app-level runtime construction and project action loading.
+- `src/bin/admin_host.rs`: local HTTP/WebSocket host used by Web Admin.
+- `kitu-app-actions.toml`: project-owned app action manifest.
+- `scenarios/`: checked-in scenario fixtures for CI.
+- `tests/`: scenario test harnesses that execute fixtures against the Kitu runtime.
+- `docker-compose.yml`: standalone app host plus Web Admin frontend.
+
+## Run
+
+From the repository root:
+
+```sh
+cargo run -p kitu-demo-game --bin kitu-demo-game-admin-host
+```
+
+Then open the Web Admin frontend separately, or use the app compose file:
+
+```sh
+docker compose -f apps/demo-game/docker-compose.yml up --build
+```
+
+Endpoints:
+
+- Web Admin: http://localhost:5173
+- Demo game admin host: http://localhost:8787
+- Health: http://localhost:8787/health
+
+## Scenario tests
+
+The app scenarios are ordinary Rust tests and run in the workspace CI:
+
+```sh
+cargo test -p kitu-demo-game
+```

--- a/apps/demo-game/docker-compose.yml
+++ b/apps/demo-game/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - cargo-cache:/usr/local/cargo/registry
       - target-cache:/workspace/target
 
-  frontend:
+  web-admin:
     build:
       context: ../..
       dockerfile: tools/kitu-web-admin/frontend/Dockerfile

--- a/apps/demo-game/scenarios/admin-world-basic/expected.json
+++ b/apps/demo-game/scenarios/admin-world-basic/expected.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "scenarioId": "admin-world-basic",
+  "expectedTick": 2,
+  "expectedObjects": [
+    {
+      "kind": "enemy",
+      "x": 4.0,
+      "y": 5.0,
+      "z": 6.0
+    }
+  ]
+}

--- a/apps/demo-game/scenarios/admin-world-basic/scenario.json
+++ b/apps/demo-game/scenarios/admin-world-basic/scenario.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": 1,
+  "scenarioId": "admin-world-basic",
+  "steps": [
+    {
+      "actionId": "spawn-object",
+      "inputs": {
+        "kind": { "type": "string", "value": "enemy" },
+        "x": { "type": "float", "value": 1.0 },
+        "y": { "type": "float", "value": 2.0 },
+        "z": { "type": "float", "value": 3.0 }
+      }
+    },
+    {
+      "actionId": "move-last-object",
+      "inputs": {
+        "x": { "type": "float", "value": 4.0 },
+        "y": { "type": "float", "value": 5.0 },
+        "z": { "type": "float", "value": 6.0 }
+      }
+    }
+  ]
+}

--- a/apps/demo-game/src/bin/admin_host.rs
+++ b/apps/demo-game/src/bin/admin_host.rs
@@ -17,16 +17,14 @@ use axum::{
     Json, Router,
 };
 use kitu_app_actions::{ActionValue, AppActionCatalog, AppActionDefinition};
+use kitu_demo_game::{build_demo_runtime, DemoRuntime};
 use kitu_osc_ir::{OscArg, OscMessage};
-use kitu_runtime::{build_runtime, Runtime};
-use kitu_transport::LocalChannel;
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 use tower_http::cors::CorsLayer;
 use tracing::{error, info};
 
 const DEFAULT_BIND: &str = "127.0.0.1:8787";
-const DEMO_PROJECT_ACTIONS: &str = include_str!("../../../../apps/demo-game/kitu-app-actions.toml");
 
 #[derive(Clone)]
 struct AppState {
@@ -35,22 +33,51 @@ struct AppState {
 }
 
 struct GameState {
-    runtime: Runtime<LocalChannel>,
+    runtime: DemoRuntime,
     next_log_id: u64,
     logs: Vec<DebugLogEntry>,
 }
 
-impl Default for GameState {
-    fn default() -> Self {
-        let mut runtime = build_runtime(LocalChannel::connected());
-        runtime
-            .load_project_app_actions_from_toml("demo-game", DEMO_PROJECT_ACTIONS)
-            .expect("demo project app action manifest is valid");
-        Self {
-            runtime,
+impl GameState {
+    fn new() -> Result<Self> {
+        Ok(Self {
+            runtime: build_demo_runtime()?,
             next_log_id: 1,
             logs: Vec::new(),
+        })
+    }
+
+    fn snapshot(&self) -> WorldSnapshot {
+        let runtime_snapshot = self.runtime.inspect_world_state();
+        WorldSnapshot {
+            tick: self.runtime.current_tick().get(),
+            objects: runtime_snapshot
+                .objects
+                .iter()
+                .map(WorldObject::from_runtime)
+                .collect(),
         }
+    }
+
+    fn push_log(
+        &mut self,
+        level: LogLevel,
+        message: impl Into<String>,
+        osc_address: Option<String>,
+    ) -> DebugLogEntry {
+        let entry = DebugLogEntry {
+            id: self.next_log_id,
+            level,
+            message: message.into(),
+            osc_address,
+            tick: self.runtime.current_tick().get(),
+        };
+        self.next_log_id += 1;
+        self.logs.push(entry.clone());
+        if self.logs.len() > 500 {
+            self.logs.remove(0);
+        }
+        entry
     }
 }
 
@@ -153,7 +180,7 @@ async fn main() -> Result<()> {
 
     let (events, _) = broadcast::channel(256);
     let state = AppState {
-        inner: Arc::new(Mutex::new(GameState::default())),
+        inner: Arc::new(Mutex::new(GameState::new()?)),
         events,
     };
 
@@ -168,12 +195,14 @@ async fn main() -> Result<()> {
         .layer(CorsLayer::permissive())
         .with_state(state);
 
-    let bind = env::var("KITU_WEB_ADMIN_BIND").unwrap_or_else(|_| DEFAULT_BIND.to_string());
+    let bind = env::var("KITU_DEMO_GAME_BIND")
+        .or_else(|_| env::var("KITU_WEB_ADMIN_BIND"))
+        .unwrap_or_else(|_| DEFAULT_BIND.to_string());
     let addr: SocketAddr = bind
         .parse()
-        .with_context(|| format!("invalid KITU_WEB_ADMIN_BIND address: {bind}"))?;
+        .with_context(|| format!("invalid bind address: {bind}"))?;
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    info!("kitu web admin demo backend listening on http://{addr}");
+    info!("kitu demo game admin host listening on http://{addr}");
     axum::serve(listener, app).await?;
     Ok(())
 }
@@ -181,7 +210,7 @@ async fn main() -> Result<()> {
 async fn health() -> Json<serde_json::Value> {
     Json(serde_json::json!({
         "status": "ok",
-        "service": "kitu-web-admin-demo-backend"
+        "service": "kitu-demo-game-admin-host"
     }))
 }
 
@@ -392,15 +421,6 @@ fn run_app_action_request(
     Ok(response)
 }
 
-fn numeric_arg(message: &OscMessage, index: usize) -> Option<f32> {
-    match message.args.get(index) {
-        Some(OscArg::Float(value)) => Some(*value),
-        Some(OscArg::Int(value)) => Some(*value as f32),
-        Some(OscArg::Int64(value)) => Some(*value as f32),
-        _ => None,
-    }
-}
-
 fn action_request_from_osc_message(
     message: &OscMessage,
 ) -> Result<(String, HashMap<String, ActionValue>)> {
@@ -450,6 +470,15 @@ fn action_request_from_osc_message(
     }
 }
 
+fn numeric_arg(message: &OscMessage, index: usize) -> Option<f32> {
+    match message.args.get(index) {
+        Some(OscArg::Float(value)) => Some(*value),
+        Some(OscArg::Int(value)) => Some(*value as f32),
+        Some(OscArg::Int64(value)) => Some(*value as f32),
+        _ => None,
+    }
+}
+
 fn string_arg(message: &OscMessage, index: usize) -> Option<&str> {
     match message.args.get(index) {
         Some(OscArg::Str(value)) if !value.is_empty() => Some(value),
@@ -477,41 +506,6 @@ fn snapshot(state: &AppState) -> Result<WorldSnapshot> {
 
 fn broadcast_error(state: &AppState, message: String) {
     let _ = state.events.send(ServerEvent::Error { message });
-}
-
-impl GameState {
-    fn snapshot(&self) -> WorldSnapshot {
-        let runtime_snapshot = self.runtime.inspect_world_state();
-        WorldSnapshot {
-            tick: self.runtime.current_tick().get(),
-            objects: runtime_snapshot
-                .objects
-                .iter()
-                .map(WorldObject::from_runtime)
-                .collect(),
-        }
-    }
-
-    fn push_log(
-        &mut self,
-        level: LogLevel,
-        message: impl Into<String>,
-        osc_address: Option<String>,
-    ) -> DebugLogEntry {
-        let entry = DebugLogEntry {
-            id: self.next_log_id,
-            level,
-            message: message.into(),
-            osc_address,
-            tick: self.runtime.current_tick().get(),
-        };
-        self.next_log_id += 1;
-        self.logs.push(entry.clone());
-        if self.logs.len() > 500 {
-            self.logs.remove(0);
-        }
-        entry
-    }
 }
 
 impl WorldObject {
@@ -596,63 +590,5 @@ impl IntoResponse for ApiError {
 impl From<anyhow::Error> for ApiError {
     fn from(value: anyhow::Error) -> Self {
         Self(value)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn client_message_converts_to_osc_ir() {
-        let message = ClientOscMessage {
-            address: "/admin/world/spawn".to_string(),
-            args: vec![JsonOscArg::Str("enemy".to_string()), JsonOscArg::Float(3.0)],
-        };
-
-        let osc = message.to_osc_message();
-        assert_eq!(osc.address, "/admin/world/spawn");
-        assert_eq!(osc.args[0], OscArg::Str("enemy".to_string()));
-        assert_eq!(osc.args[1], OscArg::Float(3.0));
-    }
-
-    #[test]
-    fn spawn_and_move_update_world_objects() {
-        let mut state = GameState::default();
-        state
-            .runtime
-            .run_app_action(
-                "spawn-object",
-                &HashMap::from([
-                    ("kind".to_string(), ActionValue::String("enemy".to_string())),
-                    ("x".to_string(), ActionValue::Float(1.0)),
-                    ("y".to_string(), ActionValue::Float(0.0)),
-                    ("z".to_string(), ActionValue::Float(2.0)),
-                ]),
-            )
-            .unwrap();
-        let object = WorldObject::from_runtime(&state.runtime.inspect_world_state().objects[0]);
-        assert_eq!(object.id, "obj-1");
-        assert_eq!(state.runtime.inspect_world_state().objects.len(), 1);
-
-        state
-            .runtime
-            .run_app_action(
-                "move-object",
-                &HashMap::from([
-                    ("id".to_string(), ActionValue::String(object.id)),
-                    ("x".to_string(), ActionValue::Float(4.0)),
-                    ("y".to_string(), ActionValue::Float(0.5)),
-                    ("z".to_string(), ActionValue::Float(6.0)),
-                ]),
-            )
-            .unwrap();
-        let moved = WorldObject::from_runtime(&state.runtime.inspect_world_state().objects[0]);
-        assert_eq!(moved.x, 4.0);
-        assert_eq!(moved.y, 0.5);
-        assert_eq!(moved.z, 6.0);
-
-        let snapshot = state.snapshot();
-        assert_eq!(snapshot.objects, vec![moved]);
     }
 }

--- a/apps/demo-game/src/lib.rs
+++ b/apps/demo-game/src/lib.rs
@@ -1,0 +1,42 @@
+//! Demo game application wiring for the Kitu framework.
+//!
+//! This crate is intentionally outside `crates/`: it represents an application
+//! using the framework crates, not another reusable framework component.
+
+use anyhow::{Context, Result};
+use kitu_runtime::{build_runtime, Runtime};
+use kitu_transport::LocalChannel;
+
+/// Stable app identifier used in project-scoped app actions.
+pub const APP_ID: &str = "demo-game";
+
+/// Project-owned action manifest for the demo game.
+pub const APP_ACTIONS_TOML: &str = include_str!("../kitu-app-actions.toml");
+
+/// Runtime type used by the demo game host and scenario tests.
+pub type DemoRuntime = Runtime<LocalChannel>;
+
+/// Builds a demo-game runtime from Kitu framework crates.
+pub fn build_demo_runtime() -> Result<DemoRuntime> {
+    let mut runtime = build_runtime(LocalChannel::connected());
+    runtime
+        .load_project_app_actions_from_toml(APP_ID, APP_ACTIONS_TOML)
+        .context("load demo-game app actions")?;
+    Ok(runtime)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_loads_project_actions() {
+        let runtime = build_demo_runtime().unwrap();
+        let catalog = runtime.app_action_catalog();
+
+        assert!(catalog.action("spawn-object").is_some());
+        assert!(catalog.action("enemy.spawn").is_some());
+        assert!(catalog.action("player.godmode").is_some());
+        assert!(catalog.action("map.fast-travel").is_some());
+    }
+}

--- a/apps/demo-game/tests/scenarios.rs
+++ b/apps/demo-game/tests/scenarios.rs
@@ -1,0 +1,158 @@
+use std::{collections::HashMap, fs, path::Path};
+
+use anyhow::{bail, Context, Result};
+use kitu_app_actions::ActionValue;
+use kitu_demo_game::{build_demo_runtime, DemoRuntime};
+use serde::Deserialize;
+
+#[test]
+fn admin_world_basic_scenario() {
+    run_scenario(
+        &fixture_path("admin-world-basic/scenario.json"),
+        &fixture_path("admin-world-basic/expected.json"),
+    )
+    .unwrap();
+}
+
+fn fixture_path(relative: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("scenarios")
+        .join(relative)
+}
+
+fn run_scenario(scenario_path: &Path, expected_path: &Path) -> Result<()> {
+    let scenario: Scenario = read_json(scenario_path)?;
+    let expected: Expected = read_json(expected_path)?;
+    validate_pair(&scenario, &expected)?;
+
+    let mut runtime = build_demo_runtime()?;
+    execute_steps(&mut runtime, scenario.steps)?;
+    assert_expected_state(&runtime, &expected)
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T> {
+    let source = fs::read_to_string(path).with_context(|| format!("read `{}`", path.display()))?;
+    serde_json::from_str(&source).with_context(|| format!("parse `{}`", path.display()))
+}
+
+fn validate_pair(scenario: &Scenario, expected: &Expected) -> Result<()> {
+    if scenario.schema_version != 1 || expected.schema_version != 1 {
+        bail!("only schemaVersion 1 is supported");
+    }
+    if scenario.scenario_id != expected.scenario_id {
+        bail!(
+            "scenarioId mismatch: scenario `{}`, expected `{}`",
+            scenario.scenario_id,
+            expected.scenario_id
+        );
+    }
+    Ok(())
+}
+
+fn execute_steps(runtime: &mut DemoRuntime, steps: Vec<ScenarioStep>) -> Result<()> {
+    let mut last_object_id = None;
+
+    for step in steps {
+        let mut inputs = step.inputs;
+        let action_id = if step.action_id == "move-last-object" {
+            let id = last_object_id
+                .clone()
+                .context("move-last-object requires a previously spawned object")?;
+            inputs.insert("id".to_string(), ActionValue::String(id));
+            "move-object".to_string()
+        } else {
+            step.action_id
+        };
+
+        runtime
+            .run_app_action(&action_id, &inputs)
+            .with_context(|| format!("run app action `{action_id}`"))?;
+
+        if action_id == "spawn-object" {
+            last_object_id = runtime
+                .inspect_world_state()
+                .objects
+                .last()
+                .map(|object| object.id.clone());
+        }
+
+        runtime.tick_once().context("advance runtime tick")?;
+    }
+
+    Ok(())
+}
+
+fn assert_expected_state(runtime: &DemoRuntime, expected: &Expected) -> Result<()> {
+    let snapshot = runtime.inspect_world_state();
+    if runtime.current_tick().get() != expected.expected_tick {
+        bail!(
+            "tick mismatch: expected {}, observed {}",
+            expected.expected_tick,
+            runtime.current_tick().get()
+        );
+    }
+    if snapshot.objects.len() != expected.expected_objects.len() {
+        bail!(
+            "object count mismatch: expected {}, observed {}",
+            expected.expected_objects.len(),
+            snapshot.objects.len()
+        );
+    }
+
+    for (index, expected_object) in expected.expected_objects.iter().enumerate() {
+        let observed = &snapshot.objects[index];
+        if observed.kind != expected_object.kind {
+            bail!(
+                "object {index} kind mismatch: expected `{}`, observed `{}`",
+                expected_object.kind,
+                observed.kind
+            );
+        }
+        assert_close(index, "x", expected_object.x, observed.transform.x)?;
+        assert_close(index, "y", expected_object.y, observed.transform.y)?;
+        assert_close(index, "z", expected_object.z, observed.transform.z)?;
+    }
+
+    Ok(())
+}
+
+fn assert_close(index: usize, field: &str, expected: f32, observed: f32) -> Result<()> {
+    if (expected - observed).abs() > 0.00001 {
+        bail!("object {index} {field} mismatch: expected {expected}, observed {observed}");
+    }
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Scenario {
+    schema_version: u32,
+    scenario_id: String,
+    steps: Vec<ScenarioStep>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ScenarioStep {
+    action_id: String,
+    #[serde(default)]
+    inputs: HashMap<String, ActionValue>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Expected {
+    schema_version: u32,
+    scenario_id: String,
+    expected_tick: u64,
+    expected_objects: Vec<ExpectedObject>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ExpectedObject {
+    kind: String,
+    x: f32,
+    y: f32,
+    z: f32,
+}

--- a/doc/architecture_JP.md
+++ b/doc/architecture_JP.md
@@ -61,9 +61,12 @@ kitu/
     kitu-shell/
     kitu-web-admin-backend/
     kitu-unity-ffi/
+  apps/
+    demo-game/
   tools/
     kitu-cli/
     kitu-replay-runner/
+    kitu-web-admin/
   unity/
     com.kitu.runtime/
     com.kitu.transport/

--- a/doc/dev-workflow.md
+++ b/doc/dev-workflow.md
@@ -19,6 +19,14 @@ contributors and AI assistants.
 
 - Development is expected to run inside the Dev Container (`.devcontainer/devcontainer.json`).
 - Rust toolchain is pinned via `rust-toolchain.toml`.
+- Host machines are not required to have `cargo`, `rustfmt`, `clippy`, Node, or
+  other build tools installed directly.
+- AI assistants should run validation commands through the Dev Container. If the
+  `devcontainer` CLI is unavailable, they may use Docker with the same
+  `.devcontainer/Dockerfile` toolchain or an equivalent project Compose service.
+- If neither Dev Container execution nor an equivalent Docker path is available,
+  contributors should report the blocked validation instead of treating host
+  tool absence as a project failure.
 - Core tooling:
   - `cargo` (build, test, doc)
   - `clippy` (linting)
@@ -115,17 +123,33 @@ in `src/lib.rs` to ensure that:
 The standard workflow for making changes is:
 
 1. Open the repository in VSCode using the Dev Container.
-2. Implement or modify code and tests.
-3. Ensure everything passes locally:
+2. Ensure the work has a corresponding GitHub Issue.
+3. Create the work branch from `origin/develop` when a branch does not already
+   exist.
+4. Prefer issue-linked branch names such as
+   `codex/issue-76-demo-game-app-split`.
+5. Implement or modify code and tests.
+6. Ensure everything passes locally:
    - `cargo fmt --all`
    - `cargo clippy --all-targets --all-features -- -D warnings`
    - `cargo test --all`
-4. Update documentation where appropriate:
+7. Update documentation where appropriate:
    - Rust doc comments for public APIs.
    - Design and process docs under `doc/` (e.g., `architecture.md`, `crates-overview.md`, `detailed-flows.md`) and protocol/runtime contracts under `doc/specs/`.
 
 CI should run the same set of checks (fmt, clippy, tests), plus additional checks
 if needed (e.g., `cargo doc` for documentation builds).
+
+For command-line Dev Container execution, prefer:
+
+```bash
+devcontainer exec --workspace-folder . cargo fmt --all --check
+devcontainer exec --workspace-folder . cargo clippy --all-targets --all-features -- -D warnings
+devcontainer exec --workspace-folder . cargo test --all
+```
+
+If the Dev Container CLI is not installed, use Docker only when it provides the
+same repository mount and toolchain as `.devcontainer/Dockerfile`.
 
 
 ## Documents under `doc/`

--- a/doc/publish-readiness.md
+++ b/doc/publish-readiness.md
@@ -38,9 +38,9 @@ These packages are workspace utilities or demos and should remain `publish = fal
 
 - `tools/kitu-cli`
 - `tools/kitu-replay-runner`
-- `tools/kitu-web-admin/backend`
+- `apps/demo-game`
 
-If any tool becomes a future crates.io candidate, add full package metadata, add an explicit `include`, and move it into the candidate table above.
+If any tool or app becomes a future crates.io candidate, add full package metadata, add an explicit `include`, and move it into the candidate table above.
 
 ## Per-crate checklist
 

--- a/tools/kitu-web-admin/README.md
+++ b/tools/kitu-web-admin/README.md
@@ -5,14 +5,23 @@ Initial browser admin vertical slice for organizing and debugging a Kitu logic p
 ## Layout
 
 - `frontend/`: SvelteKit admin UI using local shadcn-svelte style components, Bits UI primitives, and Three.js.
-- `backend/`: Small Rust backend app using Kitu workspace crates and exposing OSC-IR style messages over WebSocket.
-- `docker-compose.yml`: Local development hosting for the admin UI and backend.
+- `docker-compose.yml`: Local development hosting for the admin UI and the `apps/demo-game` admin host.
+
+The demo backend is now owned by `apps/demo-game`, because it is an application
+that consumes the Kitu framework crates rather than a reusable Web Admin tool.
 
 ## Run
 
 The frontend uses the shared Rust OSC-IR model through a generated WASM package.
-Local development requires Rust, the `wasm32-unknown-unknown` target, and the
-frontend npm dependencies before Vite starts:
+Local development requires the demo-game admin host, Rust, the
+`wasm32-unknown-unknown` target, and the frontend npm dependencies before Vite
+starts:
+
+```sh
+cargo run -p kitu-demo-game --bin kitu-demo-game-admin-host
+```
+
+In another shell:
 
 ```sh
 rustup target add wasm32-unknown-unknown
@@ -33,7 +42,7 @@ docker compose -f tools/kitu-web-admin/docker-compose.yml up --build
 Then open:
 
 - Web Admin: http://localhost:5173
-- Backend health: http://localhost:8787/health
+- Demo game admin host health: http://localhost:8787/health
 
 The Web Admin sends JSON-wrapped OSC-IR messages over WebSocket to create and move logical world objects. The backend logs inbound admin commands, ticks the Kitu runtime, and broadcasts world snapshots and debug logs back to the browser.
 In Docker Compose, the frontend image includes Node 22 and Rust 1.82 with the


### PR DESCRIPTION
## Summary

Closes #76.

This PR separates `apps/demo-game` from the Web Admin tooling and makes it a first-class application package built on top of the Kitu framework crates.

## Changes

- Add `apps/demo-game` as a workspace package with a reusable runtime builder.
- Move the admin host service from `tools/kitu-web-admin/backend` into `apps/demo-game/src/bin/admin_host.rs`.
- Add app-owned Docker Compose hosting for demo-game plus Web Admin.
- Add `admin-world-basic` scenario fixtures and a Rust integration test for CI.
- Update Web Admin compose/docs to connect to the demo-game admin host.
- Document `apps/` conventions and Dev Container-based validation rules.
- Add CI coverage for demo-game scenario tests.

## Validation

Executed in the Dev Container:

- `devcontainer exec --workspace-folder . cargo fmt --all --check`
- `devcontainer exec --workspace-folder . cargo test -p kitu-demo-game --test scenarios`
- `devcontainer exec --workspace-folder . cargo clippy --all-targets --all-features -- -D warnings`
- `devcontainer exec --workspace-folder . cargo test --all`

## Notes

`gh` is installed locally but its GitHub token is invalid, so issue and PR creation used the GitHub connector. Branch creation, commit, and push used local git.