### PR TITLE
[codex] Expose runtime player in Web Admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.idea/
 .DS_Store
 /.tmp/
+/.pnpm-store/

--- a/apps/demo-game/README.md
+++ b/apps/demo-game/README.md
@@ -31,6 +31,14 @@ Endpoints:
 - Web Admin: http://localhost:5173
 - Demo game admin host: http://localhost:8787
 - Health: http://localhost:8787/health
+- Web Admin WebSocket: ws://localhost:8787/ws
+- Unity/runtime WebSocket: ws://localhost:8787/ws/runtime
+
+The `/ws/runtime` endpoint is the development-time Unity vertical slice. It
+accepts OSC-IR JSON messages directly, including `/input/move`, advances the
+same runtime used by the embedded path, and broadcasts `/render/player/transform`
+responses for presentation clients. It also forwards world `state` snapshots so
+Unity can mirror Web Admin object spawn/move/reset actions.
 
 ## Scenario tests
 

--- a/apps/demo-game/docker-compose.yml
+++ b/apps/demo-game/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       context: ../..
       dockerfile: tools/kitu-web-admin/frontend/Dockerfile
     working_dir: /workspace/tools/kitu-web-admin/frontend
-    command: sh -c "pnpm install && pnpm run dev -- --host 0.0.0.0"
+    command: sh -c "pnpm install && pnpm run dev --host 0.0.0.0"
     environment:
       PUBLIC_KITU_ADMIN_WS_URL: ws://localhost:8787/ws
       PUBLIC_KITU_ADMIN_API_URL: http://localhost:8787

--- a/apps/demo-game/src/bin/admin_host.rs
+++ b/apps/demo-game/src/bin/admin_host.rs
@@ -192,6 +192,7 @@ async fn main() -> Result<()> {
         .route("/app-actions/:id", get(app_action_definition))
         .route("/app-actions/:id/run", post(run_app_action))
         .route("/ws", get(ws_upgrade))
+        .route("/ws/runtime", get(runtime_ws_upgrade))
         .layer(CorsLayer::permissive())
         .with_state(state);
 
@@ -262,6 +263,13 @@ async fn ws_upgrade(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl
     ws.on_upgrade(move |socket| ws_loop(socket, state))
 }
 
+async fn runtime_ws_upgrade(
+    ws: WebSocketUpgrade,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| runtime_ws_loop(socket, state))
+}
+
 async fn ws_loop(mut socket: WebSocket, state: AppState) {
     if let Err(err) = send_initial_state(&mut socket, &state).await {
         error!("failed to send initial state: {err}");
@@ -312,6 +320,56 @@ async fn ws_loop(mut socket: WebSocket, state: AppState) {
     }
 }
 
+async fn runtime_ws_loop(mut socket: WebSocket, state: AppState) {
+    if let Err(err) = send_initial_runtime_state(&mut socket, &state).await {
+        error!("failed to send initial runtime state: {err}");
+        return;
+    }
+
+    let mut receiver = state.events.subscribe();
+
+    loop {
+        tokio::select! {
+            maybe_message = socket.recv() => {
+                match maybe_message {
+                    Some(Ok(Message::Text(text))) => {
+                        match serde_json::from_str::<ClientOscMessage>(&text) {
+                            Ok(message) => {
+                                if let Err(err) = handle_runtime_osc(&state, message) {
+                                    broadcast_error(&state, err.to_string());
+                                }
+                            }
+                            Err(err) => broadcast_error(&state, format!("invalid runtime client message: {err}")),
+                        }
+                    }
+                    Some(Ok(Message::Close(_))) | None => break,
+                    Some(Ok(_)) => {}
+                    Some(Err(err)) => {
+                        error!("runtime websocket receive error: {err}");
+                        break;
+                    }
+                }
+            }
+            event = receiver.recv() => {
+                match event {
+                    Ok(event) => {
+                        if let Err(err) = send_event(&mut socket, &event).await {
+                            error!("runtime websocket send error: {err}");
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => {
+                        if let Ok(snapshot) = snapshot(&state) {
+                            let _ = send_event(&mut socket, &ServerEvent::State { snapshot }).await;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        }
+    }
+}
+
 async fn send_initial_state(socket: &mut WebSocket, state: &AppState) -> Result<()> {
     let (tick, logs) = {
         let guard = state
@@ -344,6 +402,34 @@ async fn send_initial_state(socket: &mut WebSocket, state: &AppState) -> Result<
     Ok(())
 }
 
+async fn send_initial_runtime_state(socket: &mut WebSocket, state: &AppState) -> Result<()> {
+    let tick = {
+        let guard = state
+            .inner
+            .lock()
+            .map_err(|_| anyhow::anyhow!("state lock poisoned"))?;
+        guard.runtime.current_tick().get()
+    };
+
+    send_event(
+        socket,
+        &ServerEvent::Connected {
+            protocol: "kitu-runtime-osc-ir-json-v1",
+            tick,
+        },
+    )
+    .await?;
+    send_event(
+        socket,
+        &ServerEvent::State {
+            snapshot: snapshot(state)?,
+        },
+    )
+    .await?;
+
+    Ok(())
+}
+
 async fn send_event(socket: &mut WebSocket, event: &ServerEvent) -> Result<()> {
     socket
         .send(Message::Text(serde_json::to_string(event)?))
@@ -356,6 +442,54 @@ fn handle_client_osc(state: &AppState, client_message: ClientOscMessage) -> Resu
     let (action_id, inputs) = action_request_from_osc_message(&osc_message)?;
     run_app_action_request(state, action_id, inputs)?;
     Ok(())
+}
+
+fn handle_runtime_osc(state: &AppState, client_message: ClientOscMessage) -> Result<()> {
+    let events = run_runtime_osc_request(state, client_message)?;
+    for event in events {
+        let _ = state.events.send(event);
+    }
+    Ok(())
+}
+
+fn run_runtime_osc_request(
+    state: &AppState,
+    client_message: ClientOscMessage,
+) -> Result<Vec<ServerEvent>> {
+    let osc_message = client_message.to_osc_message();
+    let mut bundle = kitu_osc_ir::OscBundle::new();
+    bundle.push(osc_message.clone());
+
+    let mut guard = state
+        .inner
+        .lock()
+        .map_err(|_| anyhow::anyhow!("state lock poisoned"))?;
+    let mut outgoing_events = Vec::new();
+
+    guard.runtime.enqueue_input(bundle);
+    outgoing_events.push(ServerEvent::Log {
+        entry: guard.push_log(
+            LogLevel::Info,
+            format!("runtime input {}", osc_message.to_debug_string()?),
+            Some(osc_message.address),
+        ),
+    });
+
+    guard.runtime.tick_once().context("tick Kitu runtime")?;
+    for bundle in guard.runtime.drain_output_buffer() {
+        for message in bundle.messages {
+            outgoing_events.push(ServerEvent::Osc {
+                address: message.address.clone(),
+                args: message.args.into_iter().map(JsonOscArg::from).collect(),
+            });
+        }
+    }
+
+    outgoing_events.push(ServerEvent::State {
+        snapshot: guard.snapshot(),
+    });
+
+    Ok(outgoing_events)
 }
 
 fn run_app_action_request(
@@ -488,6 +622,7 @@ fn string_arg(message: &OscMessage, index: usize) -> Option<&str> {
 
 fn color_for_kind(kind: &str) -> &'static str {
     match kind {
+        "player" => "#38bdf8",
         "spawn-point" => "#2dd4bf",
         "enemy" => "#fb7185",
         "treasure" => "#facc15",
@@ -590,5 +725,116 @@ impl IntoResponse for ApiError {
 impl From<anyhow::Error> for ApiError {
     fn from(value: anyhow::Error) -> Self {
         Self(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_state() -> AppState {
+        let (events, _) = broadcast::channel(16);
+        AppState {
+            inner: Arc::new(Mutex::new(GameState::new().unwrap())),
+            events,
+        }
+    }
+
+    #[test]
+    fn runtime_osc_request_executes_player_move_slice() {
+        let state = test_state();
+        let request = ClientOscMessage {
+            address: "/input/move".to_string(),
+            args: vec![
+                JsonOscArg::Str("player:local".to_string()),
+                JsonOscArg::Float(1.25),
+                JsonOscArg::Float(-0.5),
+            ],
+        };
+
+        let events = run_runtime_osc_request(&state, request).unwrap();
+        let render = events
+            .iter()
+            .find_map(|event| match event {
+                ServerEvent::Osc { address, args } if address == "/render/player/transform" => {
+                    Some(args)
+                }
+                _ => None,
+            })
+            .expect("expected render transform event");
+
+        assert_eq!(render[0], JsonOscArg::Str("player:local".to_string()));
+        assert_eq!(render[1], JsonOscArg::Int64(0));
+        assert_eq!(render[2], JsonOscArg::Float(1.25));
+        assert_eq!(render[3], JsonOscArg::Float(-0.5));
+        assert_eq!(render[4], JsonOscArg::Float(0.0));
+
+        let snapshot = events
+            .iter()
+            .find_map(|event| match event {
+                ServerEvent::State { snapshot } => Some(snapshot),
+                _ => None,
+            })
+            .expect("expected state event");
+        assert!(snapshot.objects.iter().any(|object| {
+            object.id == "player:local"
+                && object.kind == "player"
+                && object.x == 1.25
+                && object.y == 0.0
+                && object.z == -0.5
+        }));
+    }
+
+    #[test]
+    fn app_action_spawn_broadcasts_world_state_for_unity_clients() {
+        let state = test_state();
+        let response = run_app_action_request(
+            &state,
+            "spawn-object".to_string(),
+            HashMap::from([
+                ("kind".to_string(), ActionValue::String("enemy".to_string())),
+                ("x".to_string(), ActionValue::Float(2.0)),
+                ("y".to_string(), ActionValue::Float(0.5)),
+                ("z".to_string(), ActionValue::Float(-3.0)),
+            ]),
+        )
+        .unwrap();
+
+        assert_eq!(response.snapshot.objects.len(), 1);
+        assert_eq!(response.snapshot.objects[0].kind, "enemy");
+        assert_eq!(response.snapshot.objects[0].x, 2.0);
+        assert_eq!(response.snapshot.objects[0].y, 0.5);
+        assert_eq!(response.snapshot.objects[0].z, -3.0);
+
+        let mut receiver = state.events.subscribe();
+        let events = run_app_action_request(
+            &state,
+            "spawn-object".to_string(),
+            HashMap::from([
+                (
+                    "kind".to_string(),
+                    ActionValue::String("treasure".to_string()),
+                ),
+                ("x".to_string(), ActionValue::Float(4.0)),
+                ("y".to_string(), ActionValue::Float(0.0)),
+                ("z".to_string(), ActionValue::Float(1.5)),
+            ]),
+        )
+        .unwrap();
+        assert_eq!(events.snapshot.objects.len(), 2);
+
+        let mut saw_state = false;
+        while let Ok(event) = receiver.try_recv() {
+            if let ServerEvent::State { snapshot } = event {
+                saw_state = true;
+                assert_eq!(snapshot.objects.len(), 2);
+                assert!(snapshot
+                    .objects
+                    .iter()
+                    .any(|object| object.kind == "treasure"));
+            }
+        }
+
+        assert!(saw_state, "expected state broadcast after spawn action");
     }
 }

--- a/crates/kitu-ecs/src/lib.rs
+++ b/crates/kitu-ecs/src/lib.rs
@@ -114,13 +114,45 @@ impl EcsWorld {
         kind: impl Into<String>,
         transform: WorldTransform,
     ) -> Result<WorldObject> {
+        let id = format!("obj-{}", self.next_world_object_id);
+        self.next_world_object_id += 1;
+        self.insert_world_object(id, kind, transform)
+    }
+
+    /// Spawns an object with a caller-owned stable identifier.
+    pub fn spawn_world_object_with_id(
+        &mut self,
+        id: impl Into<String>,
+        kind: impl Into<String>,
+        transform: WorldTransform,
+    ) -> Result<WorldObject> {
+        let id = id.into();
+        if id.is_empty() {
+            return Err(KituError::InvalidInput("world object id cannot be empty"));
+        }
+        if self.world_object(&id).is_some() {
+            return Err(KituError::InvalidInput("world object id already exists"));
+        }
+        if let Some(number) = id
+            .strip_prefix("obj-")
+            .and_then(|suffix| suffix.parse::<u64>().ok())
+        {
+            self.next_world_object_id = self.next_world_object_id.max(number + 1);
+        }
+        self.insert_world_object(id, kind, transform)
+    }
+
+    fn insert_world_object(
+        &mut self,
+        id: String,
+        kind: impl Into<String>,
+        transform: WorldTransform,
+    ) -> Result<WorldObject> {
         let kind = kind.into();
         if kind.is_empty() {
             return Err(KituError::InvalidInput("world object kind cannot be empty"));
         }
 
-        let id = format!("obj-{}", self.next_world_object_id);
-        self.next_world_object_id += 1;
         let object = WorldObject {
             id,
             kind,
@@ -232,5 +264,33 @@ mod tests {
 
         world.reset_world_objects();
         assert!(world.world_snapshot().objects.is_empty());
+    }
+
+    #[test]
+    fn world_objects_can_use_caller_owned_ids() {
+        let mut world = EcsWorld::new();
+
+        let player = world
+            .spawn_world_object_with_id(
+                "player:local",
+                "player",
+                WorldTransform::new(1.0, 0.0, 2.0),
+            )
+            .unwrap();
+        assert_eq!(player.id, "player:local");
+        assert_eq!(player.kind, "player");
+
+        assert!(world
+            .spawn_world_object_with_id(
+                "player:local",
+                "player",
+                WorldTransform::new(0.0, 0.0, 0.0),
+            )
+            .is_err());
+
+        let generated = world
+            .spawn_world_object("enemy", WorldTransform::new(0.0, 0.0, 0.0))
+            .unwrap();
+        assert_eq!(generated.id, "obj-1");
     }
 }

--- a/crates/kitu-runtime/src/lib.rs
+++ b/crates/kitu-runtime/src/lib.rs
@@ -462,13 +462,36 @@ impl<T: Transport> Runtime<T> {
 
     fn apply_player_move_slice(&mut self, parsed_moves: Vec<(String, f32, f32)>) -> Result<()> {
         for (entity_id, x, y) in parsed_moves {
-            let transform = self.player_transforms.entry(entity_id.clone()).or_default();
-            transform.x += x;
-            transform.y += y;
-            let output = render_player_transform_message(self.tick, &entity_id, transform)?;
+            let transform = {
+                let transform = self.player_transforms.entry(entity_id.clone()).or_default();
+                transform.x += x;
+                transform.y += y;
+                transform.clone()
+            };
+            self.sync_player_world_object(&entity_id, &transform)?;
+            let output = render_player_transform_message(self.tick, &entity_id, &transform)?;
             self.queue_output(output);
         }
 
+        Ok(())
+    }
+
+    fn sync_player_world_object(
+        &mut self,
+        entity_id: &str,
+        transform: &PlayerTransform,
+    ) -> Result<()> {
+        let world_transform = WorldTransform::new(transform.x, 0.0, transform.y);
+        match self.world.world_object(entity_id) {
+            Some(object) if object.kind == "player" => {
+                self.world.move_world_object(entity_id, world_transform)?;
+            }
+            Some(_) => {}
+            None => {
+                self.world
+                    .spawn_world_object_with_id(entity_id, "player", world_transform)?;
+            }
+        }
         Ok(())
     }
 
@@ -801,6 +824,14 @@ mod tests {
         runtime.tick_once().unwrap();
         let outputs = runtime.drain_output_buffer();
         assert_eq!(outputs.len(), 1);
+        assert_eq!(
+            runtime.inspect_world_state().objects,
+            vec![WorldObject {
+                id: "obj-1".to_string(),
+                kind: "enemy".to_string(),
+                transform: WorldTransform::new(1.0, 2.0, 3.0),
+            }]
+        );
 
         let moved = runtime
             .move_world_object(&object.id, 4.0, 5.0, 6.0)
@@ -926,6 +957,14 @@ mod tests {
         runtime.tick_once().unwrap();
         let outputs = runtime.drain_output_buffer();
         assert_eq!(outputs.len(), 1);
+        assert_eq!(
+            runtime.inspect_world_state().objects,
+            vec![WorldObject {
+                id: "player:local".to_string(),
+                kind: "player".to_string(),
+                transform: WorldTransform::new(1.0, 0.0, -0.25),
+            }]
+        );
         let render = &outputs[0].messages[0];
         assert_eq!(render.address, "/render/player/transform");
         assert_eq!(
@@ -1124,6 +1163,21 @@ mod tests {
         runtime.tick_once().unwrap();
         let outputs = runtime.drain_output_buffer();
         assert_eq!(outputs.len(), 2);
+        assert_eq!(
+            runtime.inspect_world_state().objects,
+            vec![
+                WorldObject {
+                    id: "player:one".to_string(),
+                    kind: "player".to_string(),
+                    transform: WorldTransform::new(1.0, 0.0, 0.0),
+                },
+                WorldObject {
+                    id: "player:two".to_string(),
+                    kind: "player".to_string(),
+                    transform: WorldTransform::new(0.0, 0.0, 2.0),
+                },
+            ]
+        );
         assert_eq!(
             outputs[0].messages[0].args,
             vec![

--- a/doc/specs/vertical-slice-player-move.md
+++ b/doc/specs/vertical-slice-player-move.md
@@ -10,7 +10,7 @@ It covers:
 ## Status
 
 - Normative for boundary contracts and responsibility separation.
-- Implemented in `kitu-runtime` and exposed through the minimal `kitu-unity-ffi` movement boundary.
+- Implemented in `kitu-runtime` and exposed through both the dev/network WebSocket boundary and the minimal `kitu-unity-ffi` movement boundary.
 - Runtime internals and future ECS expansion remain intentionally narrow for this slice.
 - Depends on `../architecture.md` and the runtime timing rules in `runtime-execution-contract.md`.
 
@@ -41,6 +41,13 @@ Does not own:
 - simulation authority
 - movement resolution
 - authoritative position state
+
+Current dev/network surface:
+
+- `apps/demo-game` exposes `GET /ws/runtime` for Unity and tool clients.
+- Clients submit OSC-IR JSON messages such as `/input/move`.
+- The host enqueues the message into the same runtime path, advances one authoritative tick, and broadcasts `/render/player/transform` OSC-IR JSON responses.
+- The host also broadcasts world state snapshots after Web Admin actions so Unity can present spawned/moved/reset world objects during development.
 
 Current minimal FFI surface:
 

--- a/kitu-integration-runner/unity-demo-game/README.md
+++ b/kitu-integration-runner/unity-demo-game/README.md
@@ -12,12 +12,36 @@ It pairs with `apps/demo-game` while staying focused on the Unity presentation/i
 - Asset serialization mode: Force Text
 
 Purpose:
-- Verify that Unity <-> `kitu-unity-ffi` integration remains bootable.
+- Verify that Unity <-> standalone Rust runtime integration remains bootable during development.
+- Verify that Unity <-> `kitu-unity-ffi` integration remains bootable for embedded builds.
 - Run smoke-level checks that the application boundary is not broken.
 - Support regression checks for representative runtime flows.
 
 Non-goal:
 - Hosting full game-specific implementation.
+
+## Development network slice
+
+The first Unity integration path uses a standalone Rust backend instead of
+loading a native plugin into Unity.
+
+1. Start the demo backend from the repository root:
+
+   ```sh
+   cargo run -p kitu-demo-game --bin kitu-demo-game-admin-host
+   ```
+
+2. Open `kitu-unity-demo-game/` in Unity `6000.5.0f1`.
+3. Use `Kitu > Build Network Runtime Demo Scene` to create `Assets/Scenes/KituNetworkDemo.unity`.
+4. Enter Play Mode and move with the horizontal/vertical input axes.
+
+The Unity client connects to `ws://127.0.0.1:8787/ws/runtime`, sends
+`/input/move`, and applies `/render/player/transform` responses to the player
+view. This is intentionally separate from the later embedded cdylib/FFI slice.
+
+The same runtime WebSocket also receives world `state` snapshots broadcast by
+the demo backend. With the network demo scene in Play Mode, Web Admin
+spawn/move/reset actions are mirrored into Unity as primitive scene objects.
 
 ## Git management
 

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu.meta
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 54f3e8945f634247a68b5b44f9f53c6d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Editor.meta
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e8a9e0a147024c338b17677c1c2e3aa8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Editor/KituNetworkDemoSceneBuilder.cs
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Editor/KituNetworkDemoSceneBuilder.cs
@@ -1,0 +1,53 @@
+using Kitu.Runtime;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace Kitu.Editor
+{
+    public static class KituNetworkDemoSceneBuilder
+    {
+        private const string ScenePath = "Assets/Scenes/KituNetworkDemo.unity";
+
+        [MenuItem("Kitu/Build Network Runtime Demo Scene")]
+        public static void BuildScene()
+        {
+            var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            scene.name = "KituNetworkDemo";
+
+            var camera = new GameObject("Main Camera");
+            camera.tag = "MainCamera";
+            camera.transform.position = new Vector3(0f, 7f, -8f);
+            camera.transform.rotation = Quaternion.Euler(55f, 0f, 0f);
+            camera.AddComponent<Camera>();
+            camera.AddComponent<AudioListener>();
+
+            var light = new GameObject("Directional Light");
+            light.transform.rotation = Quaternion.Euler(50f, -30f, 0f);
+            var directional = light.AddComponent<Light>();
+            directional.type = LightType.Directional;
+            directional.intensity = 1.2f;
+
+            var player = GameObject.CreatePrimitive(PrimitiveType.Capsule);
+            player.name = "Player View";
+            player.transform.position = Vector3.zero;
+
+            var ground = GameObject.CreatePrimitive(PrimitiveType.Plane);
+            ground.name = "Ground";
+            ground.transform.localScale = new Vector3(2f, 1f, 2f);
+
+            var runtime = new GameObject("Kitu Network Runtime");
+            var client = runtime.AddComponent<KituNetworkRuntimeClient>();
+            var controller = runtime.AddComponent<KituNetworkPlayerController>();
+            runtime.AddComponent<KituWorldObjectPresenter>();
+
+            var serializedController = new SerializedObject(controller);
+            serializedController.FindProperty("playerView").objectReferenceValue = player.transform;
+            serializedController.ApplyModifiedPropertiesWithoutUndo();
+
+            Selection.activeObject = client;
+            EditorSceneManager.SaveScene(scene, ScenePath);
+        }
+    }
+}

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Editor/KituNetworkDemoSceneBuilder.cs.meta
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Editor/KituNetworkDemoSceneBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9f9af0bd5c864391a459569db744ce15
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Runtime.meta
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 42fd0f7632dd46a3b42f88b0f4d812ce
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Runtime/KituNetworkPlayerController.cs
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Runtime/KituNetworkPlayerController.cs
@@ -1,0 +1,104 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace Kitu.Runtime
+{
+    [RequireComponent(typeof(KituNetworkRuntimeClient))]
+    public sealed class KituNetworkPlayerController : MonoBehaviour
+    {
+        [SerializeField] private string entityId = "player:local";
+        [SerializeField] private Transform playerView;
+        [SerializeField] private float moveUnitsPerSecond = 3f;
+
+        private KituNetworkRuntimeClient _client;
+
+        private void Awake()
+        {
+            _client = GetComponent<KituNetworkRuntimeClient>();
+        }
+
+        private void OnEnable()
+        {
+            if (_client != null)
+            {
+                _client.RenderTransformReceived += OnRenderTransformReceived;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (_client != null)
+            {
+                _client.RenderTransformReceived -= OnRenderTransformReceived;
+            }
+        }
+
+        private void Update()
+        {
+            if (_client == null || !_client.IsConnected)
+            {
+                return;
+            }
+
+            var axis = ReadMovementInput();
+            if (axis.sqrMagnitude <= 0.0001f)
+            {
+                return;
+            }
+
+            axis = Vector2.ClampMagnitude(axis, 1f);
+            _client.SubmitMoveInput(entityId, axis * moveUnitsPerSecond * Time.deltaTime);
+        }
+
+        private static Vector2 ReadMovementInput()
+        {
+            var axis = Vector2.zero;
+
+            var keyboard = Keyboard.current;
+            if (keyboard != null)
+            {
+                if (keyboard.aKey.isPressed || keyboard.leftArrowKey.isPressed)
+                {
+                    axis.x -= 1f;
+                }
+
+                if (keyboard.dKey.isPressed || keyboard.rightArrowKey.isPressed)
+                {
+                    axis.x += 1f;
+                }
+
+                if (keyboard.sKey.isPressed || keyboard.downArrowKey.isPressed)
+                {
+                    axis.y -= 1f;
+                }
+
+                if (keyboard.wKey.isPressed || keyboard.upArrowKey.isPressed)
+                {
+                    axis.y += 1f;
+                }
+            }
+
+            var gamepad = Gamepad.current;
+            if (gamepad != null)
+            {
+                var stick = gamepad.leftStick.ReadValue();
+                if (stick.sqrMagnitude > axis.sqrMagnitude)
+                {
+                    axis = stick;
+                }
+            }
+
+            return axis;
+        }
+
+        private void OnRenderTransformReceived(KituRenderTransformEvent renderEvent)
+        {
+            if (renderEvent.EntityId != entityId || playerView == null)
+            {
+                return;
+            }
+
+            playerView.position = new Vector3(renderEvent.X, 0f, renderEvent.Y);
+        }
+    }
+}

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Runtime/KituNetworkPlayerController.cs.meta
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Runtime/KituNetworkPlayerController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a0db25acf4e6488ba094d70155dbf8ff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Runtime/KituNetworkRuntimeClient.cs
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Runtime/KituNetworkRuntimeClient.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Concurrent;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace Kitu.Runtime
+{
+    public sealed class KituNetworkRuntimeClient : MonoBehaviour
+    {
+        [SerializeField] private string runtimeWebSocketUrl = "ws://127.0.0.1:8787/ws/runtime";
+
+        private readonly ConcurrentQueue<string> _incoming = new ConcurrentQueue<string>();
+        private readonly SemaphoreSlim _sendLock = new SemaphoreSlim(1, 1);
+        private ClientWebSocket _socket;
+        private CancellationTokenSource _cts;
+
+        public event Action<KituRenderTransformEvent> RenderTransformReceived;
+        public event Action<KituWorldSnapshotEvent> WorldSnapshotReceived;
+
+        public bool IsConnected => _socket != null && _socket.State == WebSocketState.Open;
+
+        private void OnEnable()
+        {
+            _cts = new CancellationTokenSource();
+            _ = ConnectAsync(_cts.Token);
+        }
+
+        private void Update()
+        {
+            while (_incoming.TryDequeue(out var json))
+            {
+                if (KituOscJson.TryParseRenderTransform(json, out var renderEvent))
+                {
+                    RenderTransformReceived?.Invoke(renderEvent);
+                }
+
+                if (KituOscJson.TryParseWorldSnapshot(json, out var snapshotEvent))
+                {
+                    WorldSnapshotReceived?.Invoke(snapshotEvent);
+                }
+            }
+        }
+
+        private async void OnDisable()
+        {
+            _cts?.Cancel();
+
+            if (_socket != null)
+            {
+                try
+                {
+                    if (_socket.State == WebSocketState.Open)
+                    {
+                        await _socket.CloseAsync(
+                            WebSocketCloseStatus.NormalClosure,
+                            "Unity client disabled",
+                            CancellationToken.None);
+                    }
+                }
+                catch (WebSocketException)
+                {
+                }
+                finally
+                {
+                    _socket.Dispose();
+                    _socket = null;
+                }
+            }
+
+            _cts?.Dispose();
+            _cts = null;
+        }
+
+        public void SubmitMoveInput(string entityId, Vector2 movementDelta)
+        {
+            if (!IsConnected)
+            {
+                return;
+            }
+
+            var json = KituOscJson.BuildMoveInput(entityId, movementDelta.x, movementDelta.y);
+            _ = SendTextAsync(json, _cts?.Token ?? CancellationToken.None);
+        }
+
+        private async Task ConnectAsync(CancellationToken token)
+        {
+            _socket = new ClientWebSocket();
+
+            try
+            {
+                await _socket.ConnectAsync(new Uri(runtimeWebSocketUrl), token);
+                await ReceiveLoopAsync(token);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (WebSocketException exception)
+            {
+                Debug.LogWarning($"Kitu runtime WebSocket connection failed: {exception.Message}");
+            }
+            catch (Exception exception)
+            {
+                Debug.LogException(exception);
+            }
+        }
+
+        private async Task SendTextAsync(string json, CancellationToken token)
+        {
+            var hasLock = false;
+            try
+            {
+                await _sendLock.WaitAsync(token);
+                hasLock = true;
+
+                if (!IsConnected)
+                {
+                    return;
+                }
+
+                var bytes = Encoding.UTF8.GetBytes(json);
+                await _socket.SendAsync(
+                    new ArraySegment<byte>(bytes),
+                    WebSocketMessageType.Text,
+                    true,
+                    token);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (WebSocketException exception)
+            {
+                Debug.LogWarning($"Kitu runtime WebSocket send failed: {exception.Message}");
+            }
+            finally
+            {
+                if (hasLock)
+                {
+                    _sendLock.Release();
+                }
+            }
+        }
+
+        private async Task ReceiveLoopAsync(CancellationToken token)
+        {
+            var buffer = new byte[4096];
+            var builder = new StringBuilder();
+
+            while (!token.IsCancellationRequested && _socket.State == WebSocketState.Open)
+            {
+                var result = await _socket.ReceiveAsync(new ArraySegment<byte>(buffer), token);
+                if (result.MessageType == WebSocketMessageType.Close)
+                {
+                    break;
+                }
+
+                builder.Append(Encoding.UTF8.GetString(buffer, 0, result.Count));
+                if (!result.EndOfMessage)
+                {
+                    continue;
+                }
+
+                _incoming.Enqueue(builder.ToString());
+                builder.Clear();
+            }
+        }
+    }
+}

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Runtime/KituNetworkRuntimeClient.cs.meta
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Runtime/KituNetworkRuntimeClient.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 163a8feb67694a6e986fdd45f514f1b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Runtime/KituOscJson.cs
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Runtime/KituOscJson.cs
@@ -1,0 +1,269 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+namespace Kitu.Runtime
+{
+    public readonly struct KituRenderTransformEvent
+    {
+        public KituRenderTransformEvent(string entityId, long tick, float x, float y, float z)
+        {
+            EntityId = entityId;
+            Tick = tick;
+            X = x;
+            Y = y;
+            Z = z;
+        }
+
+        public string EntityId { get; }
+        public long Tick { get; }
+        public float X { get; }
+        public float Y { get; }
+        public float Z { get; }
+    }
+
+    public readonly struct KituWorldObjectState
+    {
+        public KituWorldObjectState(string id, string kind, float x, float y, float z, string color)
+        {
+            Id = id;
+            Kind = kind;
+            X = x;
+            Y = y;
+            Z = z;
+            Color = color;
+        }
+
+        public string Id { get; }
+        public string Kind { get; }
+        public float X { get; }
+        public float Y { get; }
+        public float Z { get; }
+        public string Color { get; }
+    }
+
+    public readonly struct KituWorldSnapshotEvent
+    {
+        public KituWorldSnapshotEvent(long tick, IReadOnlyList<KituWorldObjectState> objects)
+        {
+            Tick = tick;
+            Objects = objects;
+        }
+
+        public long Tick { get; }
+        public IReadOnlyList<KituWorldObjectState> Objects { get; }
+    }
+
+    public static class KituOscJson
+    {
+        private static readonly Regex ArgRegex = new Regex(
+            "\\{\\\"type\\\":\\\"(?<type>[^\\\"]+)\\\",\\\"value\\\":(?<value>\\\"(?:\\\\.|[^\\\"])*\\\"|-?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?|true|false)\\}");
+
+        public static string BuildMoveInput(string entityId, float x, float y)
+        {
+            return "{\"address\":\"/input/move\",\"args\":["
+                + BuildStringArg(entityId)
+                + ","
+                + BuildFloatArg(x)
+                + ","
+                + BuildFloatArg(y)
+                + "]}";
+        }
+
+        public static bool TryParseRenderTransform(string json, out KituRenderTransformEvent renderEvent)
+        {
+            renderEvent = default;
+            if (json.IndexOf("\"type\":\"osc\"", StringComparison.Ordinal) < 0
+                || json.IndexOf("\"address\":\"/render/player/transform\"", StringComparison.Ordinal) < 0)
+            {
+                return false;
+            }
+
+            var args = ParseArgs(json);
+            if (args.Count != 5)
+            {
+                return false;
+            }
+
+            if (!args[0].TryString(out var entityId)
+                || !args[1].TryInt64(out var tick)
+                || !args[2].TryFloat(out var x)
+                || !args[3].TryFloat(out var y)
+                || !args[4].TryFloat(out var z))
+            {
+                return false;
+            }
+
+            renderEvent = new KituRenderTransformEvent(entityId, tick, x, y, z);
+            return true;
+        }
+
+        public static bool TryParseWorldSnapshot(string json, out KituWorldSnapshotEvent snapshotEvent)
+        {
+            snapshotEvent = default;
+            if (json.IndexOf("\"type\":\"state\"", StringComparison.Ordinal) < 0)
+            {
+                return false;
+            }
+
+            var dto = JsonUtility.FromJson<StateEventDto>(json);
+            if (dto == null || dto.snapshot == null)
+            {
+                return false;
+            }
+
+            var objects = new List<KituWorldObjectState>();
+            if (dto.snapshot.objects != null)
+            {
+                foreach (var worldObject in dto.snapshot.objects)
+                {
+                    if (string.IsNullOrEmpty(worldObject.id))
+                    {
+                        continue;
+                    }
+
+                    objects.Add(new KituWorldObjectState(
+                        worldObject.id,
+                        worldObject.kind,
+                        worldObject.x,
+                        worldObject.y,
+                        worldObject.z,
+                        worldObject.color));
+                }
+            }
+
+            snapshotEvent = new KituWorldSnapshotEvent(dto.snapshot.tick, objects);
+            return true;
+        }
+
+        private static string BuildStringArg(string value)
+        {
+            return "{\"type\":\"str\",\"value\":\"" + Escape(value) + "\"}";
+        }
+
+        private static string BuildFloatArg(float value)
+        {
+            return "{\"type\":\"float\",\"value\":"
+                + value.ToString("R", CultureInfo.InvariantCulture)
+                + "}";
+        }
+
+        private static string Escape(string value)
+        {
+            var builder = new StringBuilder(value.Length);
+            foreach (var ch in value)
+            {
+                switch (ch)
+                {
+                    case '\\':
+                        builder.Append("\\\\");
+                        break;
+                    case '"':
+                        builder.Append("\\\"");
+                        break;
+                    case '\n':
+                        builder.Append("\\n");
+                        break;
+                    case '\r':
+                        builder.Append("\\r");
+                        break;
+                    case '\t':
+                        builder.Append("\\t");
+                        break;
+                    default:
+                        builder.Append(ch);
+                        break;
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        private static List<JsonArg> ParseArgs(string json)
+        {
+            var args = new List<JsonArg>();
+            foreach (Match match in ArgRegex.Matches(json))
+            {
+                args.Add(new JsonArg(
+                    match.Groups["type"].Value,
+                    match.Groups["value"].Value));
+            }
+
+            return args;
+        }
+
+        private readonly struct JsonArg
+        {
+            private readonly string _type;
+            private readonly string _rawValue;
+
+            public JsonArg(string type, string rawValue)
+            {
+                _type = type;
+                _rawValue = rawValue;
+            }
+
+            public bool TryString(out string value)
+            {
+                value = null;
+                if (_type != "str" || _rawValue.Length < 2)
+                {
+                    return false;
+                }
+
+                value = Regex.Unescape(_rawValue.Substring(1, _rawValue.Length - 2));
+                return true;
+            }
+
+            public bool TryInt64(out long value)
+            {
+                value = 0;
+                if (_type != "int64" && _type != "int")
+                {
+                    return false;
+                }
+
+                return long.TryParse(_rawValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+            }
+
+            public bool TryFloat(out float value)
+            {
+                value = 0f;
+                if (_type != "float" && _type != "int" && _type != "int64")
+                {
+                    return false;
+                }
+
+                return float.TryParse(_rawValue, NumberStyles.Float, CultureInfo.InvariantCulture, out value);
+            }
+        }
+
+        [Serializable]
+        private sealed class StateEventDto
+        {
+            public string type;
+            public WorldSnapshotDto snapshot;
+        }
+
+        [Serializable]
+        private sealed class WorldSnapshotDto
+        {
+            public long tick;
+            public WorldObjectDto[] objects;
+        }
+
+        [Serializable]
+        private sealed class WorldObjectDto
+        {
+            public string id;
+            public string kind;
+            public float x;
+            public float y;
+            public float z;
+            public string color;
+        }
+    }
+}

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Runtime/KituOscJson.cs.meta
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Runtime/KituOscJson.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 786b8b216ae74d11a5930e67cad38bd1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Runtime/KituWorldObjectPresenter.cs
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Runtime/KituWorldObjectPresenter.cs
@@ -1,0 +1,131 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Kitu.Runtime
+{
+    [RequireComponent(typeof(KituNetworkRuntimeClient))]
+    public sealed class KituWorldObjectPresenter : MonoBehaviour
+    {
+        [SerializeField] private Transform worldRoot;
+
+        private readonly Dictionary<string, GameObject> _objects = new Dictionary<string, GameObject>();
+        private KituNetworkRuntimeClient _client;
+
+        private void Awake()
+        {
+            _client = GetComponent<KituNetworkRuntimeClient>();
+            if (worldRoot == null)
+            {
+                var root = new GameObject("Kitu World Objects");
+                worldRoot = root.transform;
+            }
+        }
+
+        private void OnEnable()
+        {
+            if (_client != null)
+            {
+                _client.WorldSnapshotReceived += ApplySnapshot;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (_client != null)
+            {
+                _client.WorldSnapshotReceived -= ApplySnapshot;
+            }
+        }
+
+        private void ApplySnapshot(KituWorldSnapshotEvent snapshot)
+        {
+            var liveIds = new HashSet<string>();
+
+            foreach (var worldObject in snapshot.Objects)
+            {
+                liveIds.Add(worldObject.Id);
+                var view = GetOrCreateView(worldObject);
+                view.transform.position = new Vector3(worldObject.X, worldObject.Y, worldObject.Z);
+                ApplyColor(view, worldObject.Color);
+            }
+
+            var staleIds = new List<string>();
+            foreach (var entry in _objects)
+            {
+                if (!liveIds.Contains(entry.Key))
+                {
+                    staleIds.Add(entry.Key);
+                }
+            }
+
+            foreach (var id in staleIds)
+            {
+                Destroy(_objects[id]);
+                _objects.Remove(id);
+            }
+        }
+
+        private GameObject GetOrCreateView(KituWorldObjectState worldObject)
+        {
+            if (_objects.TryGetValue(worldObject.Id, out var existing))
+            {
+                return existing;
+            }
+
+            var primitive = PrimitiveForKind(worldObject.Kind);
+            var view = GameObject.CreatePrimitive(primitive);
+            view.name = $"Kitu {worldObject.Kind} {worldObject.Id}";
+            view.transform.SetParent(worldRoot, true);
+            view.transform.localScale = ScaleForKind(worldObject.Kind);
+            _objects.Add(worldObject.Id, view);
+            return view;
+        }
+
+        private static PrimitiveType PrimitiveForKind(string kind)
+        {
+            switch (kind)
+            {
+                case "enemy":
+                    return PrimitiveType.Capsule;
+                case "treasure":
+                    return PrimitiveType.Sphere;
+                case "trigger":
+                    return PrimitiveType.Cylinder;
+                default:
+                    return PrimitiveType.Cube;
+            }
+        }
+
+        private static Vector3 ScaleForKind(string kind)
+        {
+            switch (kind)
+            {
+                case "trigger":
+                    return new Vector3(1.4f, 0.2f, 1.4f);
+                case "treasure":
+                    return Vector3.one * 0.7f;
+                default:
+                    return Vector3.one;
+            }
+        }
+
+        private static void ApplyColor(GameObject view, string htmlColor)
+        {
+            if (string.IsNullOrEmpty(htmlColor) || !ColorUtility.TryParseHtmlString(htmlColor, out var color))
+            {
+                color = Color.white;
+            }
+
+            var renderer = view.GetComponent<Renderer>();
+            if (renderer == null)
+            {
+                return;
+            }
+
+            if (renderer.material != null)
+            {
+                renderer.material.color = color;
+            }
+        }
+    }
+}

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Runtime/KituWorldObjectPresenter.cs.meta
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Kitu/Runtime/KituWorldObjectPresenter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8af70a3af1bd4cc8b30c2d3a6021a94a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Scenes/KituNetworkDemo.unity
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Scenes/KituNetworkDemo.unity
@@ -1,0 +1,696 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 2
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1767668
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1767672}
+  - component: {fileID: 1767671}
+  - component: {fileID: 1767670}
+  - component: {fileID: 1767669}
+  m_Layer: 0
+  m_Name: Kitu Network Runtime
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1767669
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1767668}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8af70a3af1bd4cc8b30c2d3a6021a94a, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Assembly-CSharp::Kitu.Runtime.KituWorldObjectPresenter
+  worldRoot: {fileID: 0}
+--- !u!114 &1767670
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1767668}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a0db25acf4e6488ba094d70155dbf8ff, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Assembly-CSharp::Kitu.Runtime.KituNetworkPlayerController
+  entityId: player:local
+  playerView: {fileID: 958426189}
+  moveUnitsPerSecond: 3
+--- !u!114 &1767671
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1767668}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 163a8feb67694a6e986fdd45f514f1b5, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Assembly-CSharp::Kitu.Runtime.KituNetworkRuntimeClient
+  runtimeWebSocketUrl: ws://127.0.0.1:8787/ws/runtime
+--- !u!4 &1767672
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1767668}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &806669255
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 806669257}
+  - component: {fileID: 806669256}
+  - component: {fileID: 806669258}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &806669256
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 806669255}
+  m_Enabled: 1
+  serializedVersion: 13
+  m_Type: 1
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 1.2
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.802082
+  m_CookieSize2D: {x: 0.5, y: 0.5}
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ForceVisible: 0
+  m_ShapeRadius: 0.025
+  m_ShadowAngle: 0
+  m_LightUnit: 1
+  m_LuxAtDistance: 1
+  m_EnableSpotReflector: 1
+--- !u!4 &806669257
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 806669255}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.40821794, y: -0.23456973, z: 0.10938166, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &806669258
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 806669255}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.RenderPipelines.Universal.Runtime::UnityEngine.Rendering.Universal.UniversalAdditionalLightData
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_CustomShadowLayers: 0
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
+  m_RenderingLayersMask:
+    serializedVersion: 0
+    m_Bits: 1
+  m_ShadowRenderingLayersMask:
+    serializedVersion: 0
+    m_Bits: 1
+  m_Version: 4
+  m_LightLayerMask: 1
+  m_ShadowLayerMask: 1
+  m_RenderingLayers: 1
+  m_ShadowRenderingLayers: 1
+--- !u!1 &958426188
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 958426189}
+  - component: {fileID: 958426192}
+  - component: {fileID: 958426191}
+  - component: {fileID: 958426190}
+  m_Layer: 0
+  m_Name: Player View
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &958426189
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 958426188}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &958426190
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 958426188}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &958426191
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 958426188}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &958426192
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 958426188}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1160449259
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1160449263}
+  - component: {fileID: 1160449262}
+  - component: {fileID: 1160449261}
+  - component: {fileID: 1160449260}
+  m_Layer: 0
+  m_Name: Ground
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &1160449260
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1160449259}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!64 &1160449261
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1160449259}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!33 &1160449262
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1160449259}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1160449263
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1160449259}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 2, y: 1, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1730041961
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1730041964}
+  - component: {fileID: 1730041963}
+  - component: {fileID: 1730041962}
+  - component: {fileID: 1730041965}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1730041962
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1730041961}
+  m_Enabled: 1
+--- !u!20 &1730041963
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1730041961}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1730041964
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1730041961}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.46174863, y: 0, z: 0, w: 0.8870109}
+  m_LocalPosition: {x: 0, y: 7, z: -8}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1730041965
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1730041961}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.RenderPipelines.Universal.Runtime::UnityEngine.Rendering.Universal.UniversalAdditionalCameraData
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+  m_Version: 2
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1730041964}
+  - {fileID: 806669257}
+  - {fileID: 958426189}
+  - {fileID: 1160449263}
+  - {fileID: 1767672}

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Scenes/KituNetworkDemo.unity.meta
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Scenes/KituNetworkDemo.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 29ffa32d79a4d412b99b24783d4ba513
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Settings/PC_RPAsset.asset
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/Settings/PC_RPAsset.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bf2edee5c58d82540a51f03df9d42094, type: 3}
   m_Name: PC_RPAsset
   m_EditorClassIdentifier: 
-  k_AssetVersion: 12
-  k_AssetPreviousVersion: 12
+  k_AssetVersion: 13
+  k_AssetPreviousVersion: 13
   m_RendererType: 1
   m_RendererData: {fileID: 0}
   m_RendererDataList:
@@ -53,6 +53,7 @@ MonoBehaviour:
   m_AdditionalLightsShadowResolutionTierHigh: 1024
   m_ReflectionProbeBlending: 1
   m_ReflectionProbeBoxProjection: 1
+  m_ReflectionProbeAtlas: 1
   m_ShadowDistance: 50
   m_ShadowCascadeCount: 4
   m_Cascade2Split: 0.25
@@ -73,7 +74,6 @@ MonoBehaviour:
   m_MixedLightingSupported: 1
   m_SupportsLightCookies: 1
   m_SupportsLightLayers: 1
-  m_DebugLevel: 0
   m_StoreActionsOptimization: 0
   m_UseAdaptivePerformance: 1
   m_ColorGradingMode: 0
@@ -127,10 +127,15 @@ MonoBehaviour:
   m_PrefilterSoftShadowsQualityHigh: 0
   m_PrefilterSoftShadows: 0
   m_PrefilterScreenCoord: 1
+  m_PrefilterScreenSpaceIrradiance: 0
   m_PrefilterNativeRenderPass: 1
   m_PrefilterUseLegacyLightmaps: 0
+  m_PrefilterBicubicLightmapSampling: 0
+  m_PrefilterReflectionProbeRotation: 0
   m_PrefilterReflectionProbeBlending: 0
   m_PrefilterReflectionProbeBoxProjection: 0
+  m_PrefilterReflectionProbeAtlas: 0
+  m_PrefilterPointSamplingUpsampling: 0
   m_ShaderVariantLogLevel: 0
   m_ShadowCascades: 0
   m_Textures:

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/ProjectSettings/SceneTemplateSettings.json
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/ProjectSettings/SceneTemplateSettings.json
@@ -1,0 +1,121 @@
+{
+    "templatePinStates": [],
+    "dependencyTypeInfos": [
+        {
+            "userAdded": false,
+            "type": "UnityEngine.AnimationClip",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.Animations.AnimatorController",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.AnimatorOverrideController",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.Audio.AudioMixerController",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.ComputeShader",
+            "defaultInstantiationMode": 1
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Cubemap",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.GameObject",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.LightingDataAsset",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.LightingSettings",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Material",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.MonoScript",
+            "defaultInstantiationMode": 1
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.PhysicsMaterial",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.PhysicsMaterial2D",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.PostProcessing.PostProcessProfile",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.PostProcessing.PostProcessResources",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.VolumeProfile",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.SceneAsset",
+            "defaultInstantiationMode": 1
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Shader",
+            "defaultInstantiationMode": 1
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.ShaderVariantCollection",
+            "defaultInstantiationMode": 1
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Texture",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Texture2D",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Timeline.TimelineAsset",
+            "defaultInstantiationMode": 0
+        }
+    ],
+    "defaultDependencyTypeInfo": {
+        "userAdded": false,
+        "type": "<default_scene_template_dependencies>",
+        "defaultInstantiationMode": 1
+    },
+    "newSceneOverride": 0
+}

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/ProjectSettings/ShaderGraphSettings.asset
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/ProjectSettings/ShaderGraphSettings.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   shaderVariantLimit: 128
+  overrideShaderVariantLimit: 0
   customInterpolatorErrorThreshold: 32
   customInterpolatorWarningThreshold: 16
   customHeatmapValues: {fileID: 0}

--- a/tools/kitu-web-admin/frontend/src/lib/components/WorldCanvas.svelte
+++ b/tools/kitu-web-admin/frontend/src/lib/components/WorldCanvas.svelte
@@ -115,10 +115,7 @@
     for (const object of currentObjects) {
       let mesh = meshes.get(object.id);
       if (!mesh) {
-        const geometry =
-          object.kind === "trigger"
-            ? new THREE.TorusGeometry(0.55, 0.15, 12, 32)
-            : new THREE.BoxGeometry(1, 1, 1);
+        const geometry = geometryForKind(object.kind);
         const material = new THREE.MeshStandardMaterial({
           color: object.color,
           roughness: 0.55,
@@ -131,6 +128,19 @@
       mesh.position.set(object.x, 0.5 + object.y, object.z);
       mesh.scale.setScalar(object.kind === "treasure" ? 0.8 : 1);
     }
+  }
+
+  function geometryForKind(kind: string): BufferGeometry {
+    if (!THREE) {
+      throw new Error("Three.js is not ready");
+    }
+    if (kind === "player") {
+      return new THREE.SphereGeometry(0.55, 24, 16);
+    }
+    if (kind === "trigger") {
+      return new THREE.TorusGeometry(0.55, 0.15, 12, 32);
+    }
+    return new THREE.BoxGeometry(1, 1, 1);
   }
 </script>
 


### PR DESCRIPTION
## Summary

- add the Unity network runtime demo scene and client scripts for `/ws/runtime`
- expose runtime player movement in the authoritative world snapshot as `kind: "player"`
- render player objects distinctly in Web Admin while preserving existing spawned world object kinds
- document the runtime WebSocket development slice and demo flow

## Why

Unity could move the local player through the demo-game runtime endpoint, but Web Admin only rendered `WorldSnapshot.objects`. The player existed as runtime output through `/render/player/transform`, but it was invisible in the Web Admin world view.

## Validation

- `devcontainer exec --workspace-folder . cargo fmt --all --check`
- `devcontainer exec --workspace-folder . cargo test -p kitu-ecs -p kitu-runtime -p kitu-demo-game`
- `devcontainer exec --workspace-folder . pnpm --dir tools/kitu-web-admin/frontend check`
- `docker compose -f apps/demo-game/docker-compose.yml up -d --build`
- `curl -sS http://localhost:8787/health`

Closes #83