### PR TITLE
[codex] Document runtime transport decision

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -457,6 +457,28 @@ flowchart LR
 - Replay and diagnostics should operate in both local and CI contexts.
 - Production hardening details (network auth, process isolation, secrets) are deferred to implementation documents.
 
+### Runtime transport decision for MVP
+
+For the MVP, runtime clients use WebSocket as the authoritative transport path.
+The `/ws/runtime` endpoint remains the stable path for runtime input, tick
+execution, and replay-oriented validation.
+
+WebTransport is limited to the Web Admin / gateway experiment lane during the
+MVP. This lets the project validate browser KEP transport behavior without
+making runtime authority depend on the experimental gateway.
+
+Longer term, runtime transports should be selectable by platform:
+
+- Unity Editor: WebSocket.
+- Browser: WebTransport, with WebSocket fallback where appropriate.
+- Native desktop on Windows, macOS, and Linux: WebSocket or QUIC.
+- Native mobile: WebSocket or QUIC.
+
+Native platforms should treat QUIC as the likely transport backend name unless
+they specifically adopt HTTP/3/WebTransport semantics. All runtime transport
+backends must preserve the ordering and delivery guarantees required by
+deterministic tick execution and replay.
+
 ## Use case list
 
 This list tracks scenario coverage and should remain aligned with runtime and tooling boundaries.

--- a/doc/architecture_JP.md
+++ b/doc/architecture_JP.md
@@ -93,6 +93,28 @@ kitu/
 - **kitu-web-admin-backend**: Web Admin のバックエンド（HTTP + WS）
 - **kitu-unity-ffi**: Unity 組み込み cdylib 用の C API。現在の MVP surface はプレイヤー移動 slice に限定し、初期化、移動入力送信、tick 実行、`/render/player/transform` の取得を扱う。
 
+### MVP における runtime transport 方針
+
+MVP では、runtime client の authoritative transport は WebSocket とする。
+`/ws/runtime` は runtime input、tick 実行、replay-oriented validation の安定
+経路として維持する。
+
+WebTransport は当面 Web Admin / gateway experiment lane に限定する。これに
+より、browser 由来の KEP transport behavior を検証しつつ、runtime authority を
+experimental gateway に依存させない。
+
+将来的には、runtime transport は platform ごとに選択可能にする。
+
+- Unity Editor: WebSocket
+- Browser: WebTransport。ただし必要に応じて WebSocket fallback を維持する。
+- Native desktop（Windows / macOS / Linux）: WebSocket または QUIC
+- Native mobile: WebSocket または QUIC
+
+Native platform では、HTTP/3/WebTransport semantics を明示的に採用しない限り、
+WebTransport ではなく QUIC transport backend と呼ぶ。いずれの transport backend
+でも、deterministic tick execution と replay に必要な ordering / delivery guarantee
+を維持しなければならない。
+
 ### Unity demo-game 検証アプリ（kitu-integration-runner 配下）
 
 ```

--- a/doc/specs/webtransport-gateway.md
+++ b/doc/specs/webtransport-gateway.md
@@ -203,7 +203,28 @@ The existing WebSocket endpoints are unchanged:
 - `ws://localhost:8787/ws`
 - `ws://localhost:8787/ws/runtime`
 
-The Unity runtime client remains WebSocket-only for now.
+The Unity runtime client remains WebSocket-only for the MVP. The `/ws/runtime`
+path is the authoritative runtime transport for MVP input, tick, and replay
+validation because it is already stable, ordered, and easy to exercise in local
+and CI environments.
+
+WebTransport remains limited to the Web Admin / gateway experiment lane for now.
+It is used to validate browser-originated KEP transport behavior without moving
+runtime authority away from the established WebSocket path.
+
+Future runtime transport backends should be selected by platform rather than
+forcing one protocol everywhere:
+
+- Unity Editor: WebSocket.
+- Browser: WebTransport, with WebSocket fallback where appropriate.
+- Native desktop on Windows, macOS, and Linux: WebSocket or QUIC.
+- Native mobile: WebSocket or QUIC.
+
+Native platforms should usually refer to a QUIC transport backend rather than a
+WebTransport backend unless the implementation specifically adopts the
+HTTP/3/WebTransport semantics. Authoritative runtime inputs must preserve the
+ordering and delivery guarantees required by deterministic tick and replay
+behavior regardless of transport.
 
 If WebTransport is unavailable, fails TLS verification, or fails while sending, the browser falls back to WebSocket for OSC send attempts.
 
@@ -213,6 +234,5 @@ If WebTransport is unavailable, fails TLS verification, or fails while sending, 
 - Keep a persistent internal WebSocket connection per WebTransport session instead of connecting once per stream.
 - Stream multiple app-server KEP responses per WebTransport request if the protocol needs more than one response envelope.
 - Add WebTransport datagram support for high-frequency real-time updates.
-- Decide whether `/ws/runtime` should also have a WebTransport route.
 - Add integration tests that run the gateway against a demo-game container.
 - Expand OSC packet support if bundles, blobs, or arrays become required.


### PR DESCRIPTION
## Summary

Closes #93.

This PR records the runtime transport decision for the MVP:

- `/ws/runtime` remains the authoritative runtime path over WebSocket for MVP input, tick, and replay validation.
- WebTransport remains limited to the Web Admin / gateway experiment lane for now.
- Future runtime transports should be selectable by platform rather than forced into one protocol everywhere.

## Platform Direction

- Unity Editor: WebSocket.
- Browser: WebTransport, with WebSocket fallback where appropriate.
- Native desktop on Windows, macOS, and Linux: WebSocket or QUIC.
- Native mobile: WebSocket or QUIC.

Native targets should generally use the QUIC backend name unless they explicitly adopt HTTP/3/WebTransport semantics.

## Validation

- `git diff --check`
- `devcontainer exec --workspace-folder . cargo fmt --all --check`
- `devcontainer exec --workspace-folder . cargo test -p kitu-demo-game`

Note: the first `cargo test -p kitu-demo-game` attempt exposed stale/incompatible Cargo artifacts in `target` (`GLIBC_2.34` mismatch from a proc-macro artifact). I ran `devcontainer exec --workspace-folder . cargo clean`, then reran the test successfully.