### PR TITLE
[codex] Implement WebTransport KEP stream framing

### DIFF
--- a/crates/kitu-transport/src/lib.rs
+++ b/crates/kitu-transport/src/lib.rs
@@ -20,6 +20,8 @@ use thiserror::Error;
 pub const KEP_PAYLOAD_OSC: &str = "osc";
 /// Payload type used for UTF-8 JSON bytes inside KEP envelopes.
 pub const KEP_PAYLOAD_JSON: &str = "json";
+/// Number of bytes used by the WebTransport stream frame length prefix.
+pub const KEP_STREAM_FRAME_LENGTH_BYTES: usize = 4;
 
 /// Kitu Envelope Protocol message.
 ///
@@ -84,6 +86,17 @@ pub enum KepCodecError {
     /// The OSC packet used an unsupported type tag.
     #[error("unsupported OSC type tag: {0}")]
     UnsupportedOscType(char),
+    /// A KEP stream frame payload is too large for the uint32 length prefix.
+    #[error("KEP stream frame is too large: {0} bytes")]
+    StreamFrameTooLarge(usize),
+    /// A KEP stream frame ended before the expected byte count.
+    #[error("incomplete KEP stream frame: expected {expected} bytes, got {actual} bytes")]
+    IncompleteStreamFrame {
+        /// Expected number of envelope bytes after the length prefix.
+        expected: usize,
+        /// Actual number of envelope bytes available after the length prefix.
+        actual: usize,
+    },
 }
 
 /// Encodes a KEP envelope as MessagePack bytes.
@@ -94,6 +107,73 @@ pub fn encode_kep_envelope(envelope: &KepEnvelope) -> std::result::Result<Vec<u8
 /// Decodes a KEP envelope from MessagePack bytes.
 pub fn decode_kep_envelope(bytes: &[u8]) -> std::result::Result<KepEnvelope, KepCodecError> {
     rmp_serde::from_slice(bytes).map_err(KepCodecError::DecodeEnvelope)
+}
+
+/// Encodes a single KEP envelope into a length-prefixed stream frame.
+///
+/// The frame format is a 4-byte unsigned big-endian length followed by one
+/// MessagePack KEP envelope. It is intended for transports that expose a byte
+/// stream rather than message boundaries, such as WebTransport reliable streams.
+pub fn encode_kep_stream_frame(
+    envelope: &KepEnvelope,
+) -> std::result::Result<Vec<u8>, KepCodecError> {
+    let envelope_bytes = encode_kep_envelope(envelope)?;
+    encode_kep_stream_frame_bytes(&envelope_bytes)
+}
+
+/// Wraps encoded KEP envelope bytes in a length-prefixed stream frame.
+pub fn encode_kep_stream_frame_bytes(
+    envelope_bytes: &[u8],
+) -> std::result::Result<Vec<u8>, KepCodecError> {
+    let length: u32 = envelope_bytes
+        .len()
+        .try_into()
+        .map_err(|_| KepCodecError::StreamFrameTooLarge(envelope_bytes.len()))?;
+    let mut frame = Vec::with_capacity(KEP_STREAM_FRAME_LENGTH_BYTES + envelope_bytes.len());
+    frame.extend_from_slice(&length.to_be_bytes());
+    frame.extend_from_slice(envelope_bytes);
+    Ok(frame)
+}
+
+/// Decodes all length-prefixed KEP envelopes from a complete stream buffer.
+///
+/// The input must contain zero or more whole frames. A truncated length prefix or
+/// payload returns an error instead of silently dropping the partial envelope.
+pub fn decode_kep_stream_frames(
+    bytes: &[u8],
+) -> std::result::Result<Vec<KepEnvelope>, KepCodecError> {
+    let mut offset = 0;
+    let mut frames = Vec::new();
+
+    while offset < bytes.len() {
+        let remaining = bytes.len() - offset;
+        if remaining < KEP_STREAM_FRAME_LENGTH_BYTES {
+            return Err(KepCodecError::IncompleteStreamFrame {
+                expected: KEP_STREAM_FRAME_LENGTH_BYTES,
+                actual: remaining,
+            });
+        }
+
+        let length = u32::from_be_bytes(
+            bytes[offset..offset + KEP_STREAM_FRAME_LENGTH_BYTES]
+                .try_into()
+                .expect("slice length is checked"),
+        ) as usize;
+        offset += KEP_STREAM_FRAME_LENGTH_BYTES;
+
+        let remaining = bytes.len() - offset;
+        if remaining < length {
+            return Err(KepCodecError::IncompleteStreamFrame {
+                expected: length,
+                actual: remaining,
+            });
+        }
+
+        frames.push(decode_kep_envelope(&bytes[offset..offset + length])?);
+        offset += length;
+    }
+
+    Ok(frames)
 }
 
 /// Encodes a single OSC-IR message into an OSC packet binary.
@@ -366,6 +446,46 @@ mod tests {
         let decoded = decode_kep_envelope(&encoded).expect("decode envelope");
 
         assert_eq!(decoded, envelope);
+    }
+
+    #[test]
+    fn kep_stream_frames_round_trip_multiple_envelopes() {
+        let first = KepEnvelope {
+            payload_type: KEP_PAYLOAD_JSON.to_string(),
+            route: Some("/server/event".to_string()),
+            correlation_id: Some(1),
+            flags: Some(0),
+            payload: br#"{"type":"connected"}"#.to_vec(),
+        };
+        let second = KepEnvelope {
+            payload_type: KEP_PAYLOAD_JSON.to_string(),
+            route: Some("/server/event".to_string()),
+            correlation_id: Some(2),
+            flags: Some(0),
+            payload: br#"{"type":"state"}"#.to_vec(),
+        };
+
+        let mut bytes = encode_kep_stream_frame(&first).expect("encode first frame");
+        bytes.extend(encode_kep_stream_frame(&second).expect("encode second frame"));
+
+        let decoded = decode_kep_stream_frames(&bytes).expect("decode stream frames");
+        assert_eq!(decoded, vec![first, second]);
+    }
+
+    #[test]
+    fn kep_stream_frame_rejects_truncated_payload() {
+        let envelope = KepEnvelope::json(br#"{"type":"state"}"#.to_vec());
+        let mut bytes = encode_kep_stream_frame(&envelope).expect("encode frame");
+        bytes.pop();
+
+        let err = decode_kep_stream_frames(&bytes).expect_err("truncated frame should fail");
+        assert!(matches!(
+            err,
+            KepCodecError::IncompleteStreamFrame {
+                expected: _,
+                actual: _
+            }
+        ));
     }
 
     #[test]

--- a/doc/specs/kitu-envelope-protocol.md
+++ b/doc/specs/kitu-envelope-protocol.md
@@ -207,12 +207,33 @@ KEP Envelope
 
 ## WebTransport Stream
 
-One KEP envelope per stream message.
+Reliable WebTransport streams are byte streams, so KEP envelopes are framed as
+an ordered sequence of length-prefixed messages.
+
+Each frame is:
+
+```text
+uint32_be envelope_length
+MessagePack KEP envelope bytes
+```
+
+The length prefix counts only the MessagePack KEP envelope bytes and does not
+include the four prefix bytes. Receivers must process frames in stream order and
+must treat a truncated length prefix or truncated envelope payload as a decode
+error.
+
+The current Web Admin gateway request path sends one `t = "osc"` frame on a
+bidirectional stream. The response path may send zero or more `t = "json"`
+frames on the same stream before finishing it.
 
 ```text
 WebTransport Stream
     ↓
-KEP Envelope
+uint32_be length + KEP Envelope
+    ↓
+uint32_be length + KEP Envelope
+    ↓
+...
 ```
 
 ---

--- a/doc/specs/webtransport-gateway.md
+++ b/doc/specs/webtransport-gateway.md
@@ -52,9 +52,19 @@ Candidates considered:
 
 The first implementation uses internal WebSocket because it has the smallest blast radius. Text frames retain the existing JSON OSC-IR shape for browser and Unity fallback clients. Binary frames carry one KEP envelope per WebSocket message.
 
-The client-to-server path uses `t = "osc"` and `p = OSC packet binary`. The gateway validates the KEP envelope and forwards the original MessagePack bytes to `ws://demo-game:8787/ws`; the existing application server decodes KEP, extracts the OSC packet binary, and runs the same OSC handling path used by JSON clients.
+The client-to-server WebTransport stream path uses one length-prefixed KEP
+frame containing `t = "osc"` and `p = OSC packet binary`. The gateway validates
+the KEP envelope and forwards the KEP MessagePack envelope bytes to
+`ws://demo-game:8787/ws`; the existing application server decodes KEP, extracts
+the OSC packet binary, and runs the same OSC handling path used by JSON clients.
 
-The server-to-client path uses `t = "json"` and `p = ServerEvent JSON bytes` with route `/server/event`. This keeps the current `ServerEvent` shape intact while making the transport hop KEP-native in both directions. The WebTransport gateway relays the first KEP JSON response from the internal WebSocket back on the WebTransport response stream.
+The server-to-client WebTransport stream path uses a sequence of length-prefixed
+KEP frames. Each frame carries `t = "json"` and `p = ServerEvent JSON bytes`
+with route `/server/event`. This keeps the current `ServerEvent` shape intact
+while making the transport hop KEP-native in both directions. After the internal
+WebSocket produces the first KEP JSON response, the gateway drains additional
+KEP JSON responses for a short window and writes each one to the same
+WebTransport response stream in arrival order before finishing the stream.
 
 ## Docker Compose
 
@@ -94,11 +104,11 @@ Gateway smoke validation can be run from the repository root:
 tools/kitu-webtransport-gateway/scripts/smoke-in-docker.sh
 ```
 
-The smoke script starts `demo-game` and `webtransport-gateway`, sends one KEP
-`osc` envelope over a WebTransport bidirectional stream, verifies that a KEP
-`json` response envelope is returned on the response stream, and checks that the
-existing application server state contains the spawned `webtransport-smoke`
-object.
+The smoke script starts `demo-game` and `webtransport-gateway`, sends one
+length-prefixed KEP `osc` frame over a WebTransport bidirectional stream,
+verifies that at least two length-prefixed KEP `json` response frames are
+returned on the response stream, and checks that the existing application server
+state contains the spawned `webtransport-smoke` object.
 
 ## TLS notes
 
@@ -147,7 +157,9 @@ WebSocket remains active for:
 - fallback OSC sends.
 
 For OSC sends, the browser tries WebTransport first after the WebTransport session is ready. If that send fails, it falls back to the existing WebSocket JSON send path.
-When WebTransport succeeds, the browser reads a KEP `json` response envelope from the response stream and applies the decoded `ServerEvent`.
+When WebTransport succeeds, the browser reads KEP `json` response frames from
+the response stream and applies the decoded `ServerEvent` values in stream
+order.
 
 ## Implemented KEP support
 
@@ -173,8 +185,9 @@ Supported OSC packet argument types:
 - Binary frames: KEP MessagePack envelopes with `t = "osc"` and `p = OSC packet binary`.
 
 After a connection sends a binary KEP request, subsequent server events on that
-connection are sent as KEP binary frames with `t = "json"` and
-`r = "/server/event"`.
+connection are sent as KEP binary WebSocket messages with `t = "json"` and
+`r = "/server/event"`. The gateway converts those message boundaries to
+length-prefixed WebTransport stream frames.
 
 ## Browser connection check
 
@@ -232,7 +245,6 @@ If WebTransport is unavailable, fails TLS verification, or fails while sending, 
 
 - Add a stable development TLS/certificate-hash workflow for browser verification.
 - Keep a persistent internal WebSocket connection per WebTransport session instead of connecting once per stream.
-- Stream multiple app-server KEP responses per WebTransport request if the protocol needs more than one response envelope.
 - Add WebTransport datagram support for high-frequency real-time updates.
 - Add integration tests that run the gateway against a demo-game container.
 - Expand OSC packet support if bundles, blobs, or arrays become required.

--- a/tools/kitu-web-admin/frontend/src/lib/admin-client.ts
+++ b/tools/kitu-web-admin/frontend/src/lib/admin-client.ts
@@ -10,7 +10,11 @@ import type {
   ServerEvent,
   WorldSnapshot,
 } from "./types";
-import { decodeKepEnvelope, encodeKepEnvelope, encodeOscPacket } from "./kep";
+import {
+  decodeKepStreamFrames,
+  encodeKepStreamFrame,
+  encodeOscPacket,
+} from "./kep";
 
 type ConnectionState = "idle" | "connecting" | "open" | "closed" | "error";
 type WebTransportSession = {
@@ -145,7 +149,7 @@ async function sendOscOverWebTransport(
   }
   const writer = stream.writable.getWriter();
   const oscPacket = encodeOscPacket(payload);
-  const envelope = encodeKepEnvelope({
+  const frame = encodeKepStreamFrame({
     payloadType: "osc",
     route: env.PUBLIC_KITU_ADMIN_KEP_ROUTE ?? "/room/main",
     flags: 0,
@@ -154,7 +158,7 @@ async function sendOscOverWebTransport(
 
   try {
     try {
-      await writer.write(envelope);
+      await writer.write(frame);
     } catch (error) {
       lastError.set(
         error instanceof Error
@@ -166,7 +170,7 @@ async function sendOscOverWebTransport(
     await writer.close();
     const response = await readStreamBytes(stream.readable);
     if (response.length > 0) {
-      applyKepServerEvent(response);
+      applyKepServerEvents(response);
     }
     lastError.set(null);
     return { requestWritten: true };
@@ -200,16 +204,18 @@ async function readStreamBytes(stream: ReadableStream<Uint8Array>) {
   return bytes;
 }
 
-function applyKepServerEvent(bytes: Uint8Array) {
-  const envelope = decodeKepEnvelope(bytes);
-  if (envelope.payloadType !== "json") {
-    throw new Error(
-      `Unsupported KEP response payload: ${envelope.payloadType}`,
-    );
-  }
+function applyKepServerEvents(bytes: Uint8Array) {
+  const textDecoder = new TextDecoder();
+  for (const envelope of decodeKepStreamFrames(bytes)) {
+    if (envelope.payloadType !== "json") {
+      throw new Error(
+        `Unsupported KEP response payload: ${envelope.payloadType}`,
+      );
+    }
 
-  const json = new TextDecoder().decode(envelope.payload);
-  applyServerEvent(JSON.parse(json) as ServerEvent);
+    const json = textDecoder.decode(envelope.payload);
+    applyServerEvent(JSON.parse(json) as ServerEvent);
+  }
 }
 
 export async function spawnObject(

--- a/tools/kitu-web-admin/frontend/src/lib/kep.ts
+++ b/tools/kitu-web-admin/frontend/src/lib/kep.ts
@@ -40,6 +40,18 @@ export function encodeKepEnvelope(envelope: KepEnvelopeInput): Uint8Array {
   return writer.finish();
 }
 
+export function encodeKepStreamFrame(envelope: KepEnvelopeInput): Uint8Array {
+  const envelopeBytes = encodeKepEnvelope(envelope);
+  const frame = new Uint8Array(4 + envelopeBytes.length);
+  new DataView(frame.buffer, frame.byteOffset, frame.byteLength).setUint32(
+    0,
+    envelopeBytes.length,
+    false,
+  );
+  frame.set(envelopeBytes, 4);
+  return frame;
+}
+
 export function decodeKepEnvelope(bytes: Uint8Array): KepEnvelope {
   const reader = new ByteReader(bytes);
   const size = reader.readMapHeader();
@@ -72,6 +84,33 @@ export function decodeKepEnvelope(bytes: Uint8Array): KepEnvelope {
   if (!envelope.payloadType) throw new Error("KEP envelope is missing t");
   if (!envelope.payload) throw new Error("KEP envelope is missing p");
   return envelope as KepEnvelope;
+}
+
+export function decodeKepStreamFrames(bytes: Uint8Array): KepEnvelope[] {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const envelopes: KepEnvelope[] = [];
+  let offset = 0;
+
+  while (offset < bytes.length) {
+    if (bytes.length - offset < 4) {
+      throw new Error("incomplete KEP stream frame length");
+    }
+
+    const length = view.getUint32(offset, false);
+    offset += 4;
+    if (bytes.length - offset < length) {
+      throw new Error(
+        `incomplete KEP stream frame payload: expected ${length} bytes, got ${
+          bytes.length - offset
+        } bytes`,
+      );
+    }
+
+    envelopes.push(decodeKepEnvelope(bytes.slice(offset, offset + length)));
+    offset += length;
+  }
+
+  return envelopes;
 }
 
 export function encodeOscPacket(message: ClientOscMessage): Uint8Array {

--- a/tools/kitu-webtransport-gateway/src/bin/smoke_client.rs
+++ b/tools/kitu-webtransport-gateway/src/bin/smoke_client.rs
@@ -3,7 +3,8 @@ use std::{env, time::Duration};
 use anyhow::{Context, Result};
 use kitu_osc_ir::{OscArg, OscMessage};
 use kitu_transport::{
-    decode_kep_envelope, encode_kep_envelope, encode_osc_packet, KepEnvelope, KEP_PAYLOAD_JSON,
+    decode_kep_stream_frames, encode_kep_stream_frame, encode_osc_packet, KepEnvelope,
+    KEP_PAYLOAD_JSON,
 };
 use wtransport::{tls::Sha256Digest, ClientConfig, Endpoint};
 
@@ -42,7 +43,7 @@ async fn main() -> Result<()> {
     let mut envelope = KepEnvelope::osc(osc_packet);
     envelope.route = Some(route);
     envelope.flags = Some(0);
-    let bytes = encode_kep_envelope(&envelope).context("encode KEP envelope")?;
+    let bytes = encode_kep_stream_frame(&envelope).context("encode KEP stream frame")?;
 
     let (mut send_stream, mut recv_stream) = connection.open_bi().await?.await?;
     send_stream.write_all(&bytes).await?;
@@ -53,28 +54,32 @@ async fn main() -> Result<()> {
         response.extend_from_slice(&chunk[..read]);
     }
 
+    let response_envelopes =
+        decode_kep_stream_frames(&response).context("decode KEP response frames")?;
     anyhow::ensure!(
-        !response.is_empty(),
-        "expected WebTransport KEP response envelope"
+        response_envelopes.len() >= 2,
+        "expected at least two WebTransport KEP response envelopes, got {}",
+        response_envelopes.len()
     );
-    let response_envelope = decode_kep_envelope(&response).context("decode KEP response")?;
-    anyhow::ensure!(
-        response_envelope.payload_type == KEP_PAYLOAD_JSON,
-        "expected JSON KEP response, got {}",
-        response_envelope.payload_type
-    );
-    let response_json: serde_json::Value =
-        serde_json::from_slice(&response_envelope.payload).context("decode KEP response JSON")?;
-    anyhow::ensure!(
-        response_json.get("type").is_some(),
-        "expected server event JSON response"
-    );
+    for response_envelope in &response_envelopes {
+        anyhow::ensure!(
+            response_envelope.payload_type == KEP_PAYLOAD_JSON,
+            "expected JSON KEP response, got {}",
+            response_envelope.payload_type
+        );
+        let response_json: serde_json::Value = serde_json::from_slice(&response_envelope.payload)
+            .context("decode KEP response JSON")?;
+        anyhow::ensure!(
+            response_json.get("type").is_some(),
+            "expected server event JSON response"
+        );
+    }
     connection.close(0u32.into(), b"smoke complete");
     endpoint.wait_idle().await;
 
     println!(
-        "sent WebTransport KEP smoke OSC /admin/world/spawn for {object_id}; received KEP {} response",
-        response_envelope.payload_type
+        "sent WebTransport KEP smoke OSC /admin/world/spawn for {object_id}; received {} KEP JSON responses",
+        response_envelopes.len()
     );
     Ok(())
 }

--- a/tools/kitu-webtransport-gateway/src/main.rs
+++ b/tools/kitu-webtransport-gateway/src/main.rs
@@ -5,8 +5,11 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use futures_util::{SinkExt, StreamExt};
-use kitu_transport::{decode_kep_envelope, KEP_PAYLOAD_JSON, KEP_PAYLOAD_OSC};
+use futures_util::{SinkExt, Stream, StreamExt};
+use kitu_transport::{
+    decode_kep_envelope, decode_kep_stream_frames, encode_kep_envelope,
+    encode_kep_stream_frame_bytes, KEP_PAYLOAD_JSON, KEP_PAYLOAD_OSC,
+};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tracing::{info, warn};
 use wtransport::{Endpoint, Identity, RecvStream, SendStream, ServerConfig};
@@ -140,16 +143,26 @@ async fn handle_stream(
     config: GatewayConfig,
 ) -> Result<()> {
     let bytes = read_stream(recv_stream).await?;
-    let envelope = decode_kep_envelope(&bytes).context("decode KEP envelope")?;
+    let mut envelopes =
+        decode_kep_stream_frames(&bytes).context("decode WebTransport KEP frames")?;
+    anyhow::ensure!(
+        envelopes.len() == 1,
+        "expected exactly one KEP request frame, got {}",
+        envelopes.len()
+    );
+    let envelope = envelopes.pop().expect("frame count checked");
     if envelope.payload_type != KEP_PAYLOAD_OSC {
         anyhow::bail!("unsupported KEP payload type: {}", envelope.payload_type);
     }
+    let request_bytes = encode_kep_envelope(&envelope).context("encode internal WebSocket KEP")?;
 
-    if let Some(response) = relay_kep_envelope(&config.internal_ws_url, bytes).await? {
+    for response in relay_kep_envelope(&config.internal_ws_url, request_bytes).await? {
+        let frame =
+            encode_kep_stream_frame_bytes(&response).context("encode WebTransport KEP frame")?;
         send_stream
-            .write_all(&response)
+            .write_all(&frame)
             .await
-            .context("write WebTransport KEP response")?;
+            .context("write WebTransport KEP response frame")?;
     }
 
     send_stream
@@ -173,7 +186,7 @@ async fn read_stream(mut recv_stream: RecvStream) -> Result<Vec<u8>> {
     Ok(bytes)
 }
 
-async fn relay_kep_envelope(internal_ws_url: &str, bytes: Vec<u8>) -> Result<Option<Vec<u8>>> {
+async fn relay_kep_envelope(internal_ws_url: &str, bytes: Vec<u8>) -> Result<Vec<Vec<u8>>> {
     let (socket, _) = connect_async(internal_ws_url)
         .await
         .with_context(|| format!("connect internal WebSocket {internal_ws_url}"))?;
@@ -185,42 +198,62 @@ async fn relay_kep_envelope(internal_ws_url: &str, bytes: Vec<u8>) -> Result<Opt
         .await
         .context("send internal WebSocket KEP binary")?;
 
-    let response = match tokio::time::timeout(Duration::from_secs(2), async {
-        while let Some(message) = reader.next().await {
-            match message.context("read internal WebSocket response")? {
-                Message::Binary(bytes) => {
-                    let response = bytes.to_vec();
-                    let envelope = decode_kep_envelope(&response)
-                        .context("decode internal WebSocket KEP response")?;
-                    if envelope.payload_type == KEP_PAYLOAD_JSON {
-                        return Ok::<Option<Vec<u8>>, anyhow::Error>(Some(response));
-                    }
-                    warn!(
-                        payload_type = envelope.payload_type,
-                        "ignoring unsupported internal WebSocket KEP response"
-                    );
-                }
-                Message::Close(_) => return Ok::<Option<Vec<u8>>, anyhow::Error>(None),
-                _ => {}
-            }
-        }
-        Ok::<Option<Vec<u8>>, anyhow::Error>(None)
-    })
+    let mut responses = Vec::new();
+    match tokio::time::timeout(
+        Duration::from_secs(2),
+        read_next_json_kep_response(&mut reader),
+    )
     .await
     {
-        Ok(result) => result?,
-        Err(_) => None,
-    };
+        Ok(Some(response)) => responses.push(response?),
+        Ok(None) | Err(_) => {}
+    }
 
-    if response.is_some() {
-        let _ = tokio::time::timeout(Duration::from_millis(200), async {
-            while reader.next().await.is_some() {}
-        })
-        .await;
+    while !responses.is_empty() {
+        match tokio::time::timeout(
+            Duration::from_millis(200),
+            read_next_json_kep_response(&mut reader),
+        )
+        .await
+        {
+            Ok(Some(response)) => responses.push(response?),
+            Ok(None) | Err(_) => break,
+        }
     }
 
     let _ = writer.close().await;
-    Ok(response)
+    Ok(responses)
+}
+
+async fn read_next_json_kep_response<R>(reader: &mut R) -> Option<Result<Vec<u8>>>
+where
+    R: Stream<Item = std::result::Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin,
+{
+    while let Some(message) = reader.next().await {
+        match message.context("read internal WebSocket response") {
+            Ok(Message::Binary(bytes)) => {
+                let response = bytes.to_vec();
+                match decode_kep_envelope(&response)
+                    .context("decode internal WebSocket KEP response")
+                {
+                    Ok(envelope) if envelope.payload_type == KEP_PAYLOAD_JSON => {
+                        return Some(Ok(response));
+                    }
+                    Ok(envelope) => {
+                        warn!(
+                            payload_type = envelope.payload_type,
+                            "ignoring unsupported internal WebSocket KEP response"
+                        );
+                    }
+                    Err(err) => return Some(Err(err)),
+                }
+            }
+            Ok(Message::Close(_)) => return None,
+            Ok(_) => {}
+            Err(err) => return Some(Err(err)),
+        }
+    }
+    None
 }
 
 fn prune_rate_window(recent_messages: &mut VecDeque<Instant>) {


### PR DESCRIPTION
## Summary

Closes #86.

- Define WebTransport reliable stream framing as `uint32_be length + MessagePack KEP envelope` frame sequences.
- Add shared Rust helpers/tests for KEP stream frame encode/decode.
- Update the WebTransport gateway, smoke client, and Web Admin browser client to send/read framed KEP streams.
- Relay multiple app-server KEP JSON responses on one WebTransport response stream while keeping WebSocket message framing and fallback paths unchanged.

## Validation

- `devcontainer exec --workspace-folder . cargo fmt --all --check`
- `devcontainer exec --workspace-folder . cargo test -p kitu-transport -p kitu-demo-game`
- `docker run --rm -v /Users/mujina/MujinaProd/kitu-workspace/kitu-logic-processor:/workspace -w /workspace/tools/kitu-webtransport-gateway rust:1.88-bookworm cargo fmt -- --check`
- `tools/kitu-webtransport-gateway/scripts/check-in-docker.sh`
- `tools/kitu-webtransport-gateway/scripts/smoke-in-docker.sh`
  - Result: `received 3 KEP JSON responses`
- `docker compose -f tools/kitu-web-admin/docker-compose.yml run --rm --no-deps frontend sh -c "pnpm install --frozen-lockfile --ignore-scripts && pnpm run check"`

## Browser Manual Check

1. Generate the WebTransport dev certificate if needed: `tools/kitu-webtransport-gateway/scripts/generate-dev-cert-in-docker.sh`.
2. Start the Web Admin compose stack: `docker compose -f tools/kitu-web-admin/docker-compose.yml up --build`.
3. Open `http://localhost:5173` in a browser with WebTransport support.
4. Confirm WebSocket status stays open and WebTransport sends are attempted when `PUBLIC_KITU_ADMIN_WT_URL=https://localhost:9443` and `PUBLIC_KITU_ADMIN_WT_CERT_SHA256` are available.
5. Trigger a World action such as spawn object.
6. Expected result: the WebTransport response stream contains multiple framed KEP `json` server events, the Web Admin applies them in order, and fallback WebSocket JSON sends still work if WebTransport is unavailable or fails before the request is written.

## Notes

- `/ws/runtime` remains the authoritative MVP WebSocket path.
- WebTransport remains limited to the Web Admin / gateway experiment lane.
- Datagram support remains out of scope for #92.