### PR TITLE
[codex] Reuse WebTransport session relay

### DIFF
--- a/doc/specs/webtransport-gateway.md
+++ b/doc/specs/webtransport-gateway.md
@@ -94,11 +94,11 @@ Gateway smoke validation can be run from the repository root:
 tools/kitu-webtransport-gateway/scripts/smoke-in-docker.sh
 ```
 
-The smoke script starts `demo-game` and `webtransport-gateway`, sends one KEP
-`osc` envelope over a WebTransport bidirectional stream, verifies that a KEP
-`json` response envelope is returned on the response stream, and checks that the
-existing application server state contains the spawned `webtransport-smoke`
-object.
+The smoke script starts `demo-game` and `webtransport-gateway`, sends two KEP
+`osc` envelopes over two bidirectional streams in one WebTransport session,
+verifies that KEP `json` response envelopes are returned, and checks that the
+existing application server state contains the spawned `webtransport-smoke-0`
+and `webtransport-smoke-1` objects.
 
 ## TLS notes
 
@@ -176,6 +176,24 @@ After a connection sends a binary KEP request, subsequent server events on that
 connection are sent as KEP binary frames with `t = "json"` and
 `r = "/server/event"`.
 
+## Internal relay lifecycle
+
+Each accepted WebTransport session owns one lazy internal WebSocket relay to
+`KITU_GATEWAY_INTERNAL_WS_URL`. The relay is opened on the first bidirectional
+stream that carries a valid KEP `osc` request and is reused by later streams in
+the same WebTransport session.
+
+Gateway stream handling serializes access to the relay for now. This keeps the
+internal WebSocket message order unambiguous while the gateway remains an
+experiment lane. If a relay send or read returns an error, the gateway drops the
+internal WebSocket handle. The next WebTransport stream in the same session may
+open a fresh internal WebSocket connection. A response timeout is treated as an
+empty response for the request and does not by itself reset the relay.
+
+The relay lifecycle is intentionally local to the WebTransport session. It does
+not replace the existing WebSocket endpoints, and it does not change the
+browser/Unity fallback paths.
+
 ## Browser connection check
 
 1. Start the compose stack.
@@ -231,7 +249,6 @@ If WebTransport is unavailable, fails TLS verification, or fails while sending, 
 ## Follow-up work
 
 - Add a stable development TLS/certificate-hash workflow for browser verification.
-- Keep a persistent internal WebSocket connection per WebTransport session instead of connecting once per stream.
 - Stream multiple app-server KEP responses per WebTransport request if the protocol needs more than one response envelope.
 - Add WebTransport datagram support for high-frequency real-time updates.
 - Add integration tests that run the gateway against a demo-game container.

--- a/tools/kitu-webtransport-gateway/scripts/smoke-in-docker.sh
+++ b/tools/kitu-webtransport-gateway/scripts/smoke-in-docker.sh
@@ -28,6 +28,9 @@ docker compose -f "$compose_file" run --rm \
   cargo run --locked --bin kitu-webtransport-gateway-smoke-client
 
 curl -fsS http://localhost:8787/state \
-  | grep -q '"kind":"webtransport-smoke"'
+  | grep -q '"kind":"webtransport-smoke-0"'
+
+curl -fsS http://localhost:8787/state \
+  | grep -q '"kind":"webtransport-smoke-1"'
 
 printf "%s\n" "WebTransport gateway smoke test passed."

--- a/tools/kitu-webtransport-gateway/src/bin/smoke_client.rs
+++ b/tools/kitu-webtransport-gateway/src/bin/smoke_client.rs
@@ -10,6 +10,7 @@ use wtransport::{tls::Sha256Digest, ClientConfig, Endpoint};
 const DEFAULT_URL: &str = "https://webtransport-gateway:9443";
 const DEFAULT_ROUTE: &str = "/room/main";
 const DEFAULT_OBJECT_ID: &str = "webtransport-smoke";
+const SEND_COUNT: usize = 2;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -32,15 +33,35 @@ async fn main() -> Result<()> {
         .await
         .with_context(|| format!("connect WebTransport {url}"))?;
 
+    for index in 0..SEND_COUNT {
+        let current_object_id = format!("{object_id}-{index}");
+        send_spawn_request(&connection, &route, &current_object_id)
+            .await
+            .with_context(|| format!("send WebTransport KEP request {index}"))?;
+    }
+    connection.close(0u32.into(), b"smoke complete");
+    endpoint.wait_idle().await;
+
+    println!(
+        "sent {SEND_COUNT} WebTransport KEP smoke OSC /admin/world/spawn requests for {object_id}-* on one session"
+    );
+    Ok(())
+}
+
+async fn send_spawn_request(
+    connection: &wtransport::Connection,
+    route: &str,
+    object_id: &str,
+) -> Result<()> {
     let mut message = OscMessage::new("/admin/world/spawn");
-    message.push_arg(OscArg::Str(object_id.clone()));
+    message.push_arg(OscArg::Str(object_id.to_string()));
     message.push_arg(OscArg::Float(1.0));
     message.push_arg(OscArg::Float(2.0));
     message.push_arg(OscArg::Float(3.0));
 
     let osc_packet = encode_osc_packet(&message).context("encode OSC packet")?;
     let mut envelope = KepEnvelope::osc(osc_packet);
-    envelope.route = Some(route);
+    envelope.route = Some(route.to_string());
     envelope.flags = Some(0);
     let bytes = encode_kep_envelope(&envelope).context("encode KEP envelope")?;
 
@@ -68,13 +89,6 @@ async fn main() -> Result<()> {
     anyhow::ensure!(
         response_json.get("type").is_some(),
         "expected server event JSON response"
-    );
-    connection.close(0u32.into(), b"smoke complete");
-    endpoint.wait_idle().await;
-
-    println!(
-        "sent WebTransport KEP smoke OSC /admin/world/spawn for {object_id}; received KEP {} response",
-        response_envelope.payload_type
     );
     Ok(())
 }

--- a/tools/kitu-webtransport-gateway/src/main.rs
+++ b/tools/kitu-webtransport-gateway/src/main.rs
@@ -7,7 +7,7 @@ use std::{
 use anyhow::{Context, Result};
 use futures_util::{
     stream::{SplitSink, SplitStream},
-    SinkExt, StreamExt,
+    FutureExt, SinkExt, StreamExt,
 };
 use kitu_transport::{decode_kep_envelope, KEP_PAYLOAD_JSON, KEP_PAYLOAD_OSC};
 use tokio::{net::TcpStream, sync::Mutex};
@@ -233,6 +233,8 @@ impl InternalWebSocketRelay {
     }
 
     async fn relay_connected(&mut self, bytes: Vec<u8>) -> Result<Option<Vec<u8>>> {
+        self.drain_idle_messages().await?;
+
         let writer = self
             .writer
             .as_mut()
@@ -281,6 +283,42 @@ impl InternalWebSocketRelay {
         }
 
         Ok(response)
+    }
+
+    async fn drain_idle_messages(&mut self) -> Result<()> {
+        let reader = self
+            .reader
+            .as_mut()
+            .context("internal WebSocket reader is not connected")?;
+        let mut drained = 0usize;
+
+        while let Some(message) = reader.next().now_or_never().flatten() {
+            match message.context("read queued internal WebSocket message")? {
+                Message::Binary(bytes) => {
+                    let response = bytes.to_vec();
+                    let envelope = decode_kep_envelope(&response)
+                        .context("decode queued internal WebSocket KEP response")?;
+                    if envelope.payload_type == KEP_PAYLOAD_JSON {
+                        drained += 1;
+                        continue;
+                    }
+                    warn!(
+                        payload_type = envelope.payload_type,
+                        "ignoring unsupported queued internal WebSocket KEP response"
+                    );
+                }
+                Message::Close(_) => anyhow::bail!("internal WebSocket closed"),
+                _ => {}
+            }
+        }
+
+        if drained > 0 {
+            info!(
+                drained,
+                "dropped queued internal WebSocket KEP broadcasts before relaying request"
+            );
+        }
+        Ok(())
     }
 
     fn reset(&mut self) {

--- a/tools/kitu-webtransport-gateway/src/main.rs
+++ b/tools/kitu-webtransport-gateway/src/main.rs
@@ -5,11 +5,20 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use futures_util::{SinkExt, StreamExt};
+use futures_util::{
+    stream::{SplitSink, SplitStream},
+    SinkExt, StreamExt,
+};
 use kitu_transport::{decode_kep_envelope, KEP_PAYLOAD_JSON, KEP_PAYLOAD_OSC};
+use tokio::{net::TcpStream, sync::Mutex};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tracing::{info, warn};
 use wtransport::{Endpoint, Identity, RecvStream, SendStream, ServerConfig};
+
+type InternalSocket =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<TcpStream>>;
+type InternalWriter = SplitSink<InternalSocket, Message>;
+type InternalReader = SplitStream<InternalSocket>;
 
 const DEFAULT_BIND_PORT: u16 = 9443;
 const DEFAULT_INTERNAL_WS_URL: &str = "ws://demo-game:8787/ws";
@@ -105,6 +114,9 @@ async fn load_identity(config: &GatewayConfig) -> Result<Identity> {
 
 async fn handle_connection(connection: wtransport::Connection, config: GatewayConfig) {
     let mut recent_messages = VecDeque::new();
+    let internal_relay = std::sync::Arc::new(Mutex::new(InternalWebSocketRelay::new(
+        config.internal_ws_url.clone(),
+    )));
 
     loop {
         match connection.accept_bi().await {
@@ -119,9 +131,10 @@ async fn handle_connection(connection: wtransport::Connection, config: GatewayCo
                 }
                 recent_messages.push_back(Instant::now());
 
-                let config = config.clone();
+                let internal_relay = internal_relay.clone();
                 tokio::spawn(async move {
-                    if let Err(err) = handle_stream(send_stream, recv_stream, config).await {
+                    if let Err(err) = handle_stream(send_stream, recv_stream, internal_relay).await
+                    {
                         warn!("WebTransport stream relay failed: {err:#}");
                     }
                 });
@@ -137,7 +150,7 @@ async fn handle_connection(connection: wtransport::Connection, config: GatewayCo
 async fn handle_stream(
     mut send_stream: SendStream,
     recv_stream: RecvStream,
-    config: GatewayConfig,
+    internal_relay: std::sync::Arc<Mutex<InternalWebSocketRelay>>,
 ) -> Result<()> {
     let bytes = read_stream(recv_stream).await?;
     let envelope = decode_kep_envelope(&bytes).context("decode KEP envelope")?;
@@ -145,7 +158,12 @@ async fn handle_stream(
         anyhow::bail!("unsupported KEP payload type: {}", envelope.payload_type);
     }
 
-    if let Some(response) = relay_kep_envelope(&config.internal_ws_url, bytes).await? {
+    if let Some(response) = internal_relay
+        .lock()
+        .await
+        .relay_kep_envelope(bytes)
+        .await?
+    {
         send_stream
             .write_all(&response)
             .await
@@ -173,54 +191,103 @@ async fn read_stream(mut recv_stream: RecvStream) -> Result<Vec<u8>> {
     Ok(bytes)
 }
 
-async fn relay_kep_envelope(internal_ws_url: &str, bytes: Vec<u8>) -> Result<Option<Vec<u8>>> {
-    let (socket, _) = connect_async(internal_ws_url)
-        .await
-        .with_context(|| format!("connect internal WebSocket {internal_ws_url}"))?;
-    let (mut writer, mut reader) = socket.split();
+struct InternalWebSocketRelay {
+    url: String,
+    writer: Option<InternalWriter>,
+    reader: Option<InternalReader>,
+}
 
-    tokio::time::sleep(Duration::from_millis(50)).await;
-    writer
-        .send(Message::Binary(bytes.into()))
-        .await
-        .context("send internal WebSocket KEP binary")?;
-
-    let response = match tokio::time::timeout(Duration::from_secs(2), async {
-        while let Some(message) = reader.next().await {
-            match message.context("read internal WebSocket response")? {
-                Message::Binary(bytes) => {
-                    let response = bytes.to_vec();
-                    let envelope = decode_kep_envelope(&response)
-                        .context("decode internal WebSocket KEP response")?;
-                    if envelope.payload_type == KEP_PAYLOAD_JSON {
-                        return Ok::<Option<Vec<u8>>, anyhow::Error>(Some(response));
-                    }
-                    warn!(
-                        payload_type = envelope.payload_type,
-                        "ignoring unsupported internal WebSocket KEP response"
-                    );
-                }
-                Message::Close(_) => return Ok::<Option<Vec<u8>>, anyhow::Error>(None),
-                _ => {}
-            }
+impl InternalWebSocketRelay {
+    fn new(url: String) -> Self {
+        Self {
+            url,
+            writer: None,
+            reader: None,
         }
-        Ok::<Option<Vec<u8>>, anyhow::Error>(None)
-    })
-    .await
-    {
-        Ok(result) => result?,
-        Err(_) => None,
-    };
-
-    if response.is_some() {
-        let _ = tokio::time::timeout(Duration::from_millis(200), async {
-            while reader.next().await.is_some() {}
-        })
-        .await;
     }
 
-    let _ = writer.close().await;
-    Ok(response)
+    async fn relay_kep_envelope(&mut self, bytes: Vec<u8>) -> Result<Option<Vec<u8>>> {
+        if self.writer.is_none() || self.reader.is_none() {
+            self.connect().await?;
+        }
+
+        match self.relay_connected(bytes).await {
+            Ok(response) => Ok(response),
+            Err(err) => {
+                self.reset();
+                Err(err)
+            }
+        }
+    }
+
+    async fn connect(&mut self) -> Result<()> {
+        let (socket, _) = connect_async(&self.url)
+            .await
+            .with_context(|| format!("connect internal WebSocket {}", self.url))?;
+        let (writer, reader) = socket.split();
+        self.writer = Some(writer);
+        self.reader = Some(reader);
+        info!(internal_ws_url = %self.url, "opened internal WebSocket relay");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        Ok(())
+    }
+
+    async fn relay_connected(&mut self, bytes: Vec<u8>) -> Result<Option<Vec<u8>>> {
+        let writer = self
+            .writer
+            .as_mut()
+            .context("internal WebSocket writer is not connected")?;
+        writer
+            .send(Message::Binary(bytes.into()))
+            .await
+            .context("send internal WebSocket KEP binary")?;
+
+        let reader = self
+            .reader
+            .as_mut()
+            .context("internal WebSocket reader is not connected")?;
+        let response = match tokio::time::timeout(Duration::from_secs(2), async {
+            while let Some(message) = reader.next().await {
+                match message.context("read internal WebSocket response")? {
+                    Message::Binary(bytes) => {
+                        let response = bytes.to_vec();
+                        let envelope = decode_kep_envelope(&response)
+                            .context("decode internal WebSocket KEP response")?;
+                        if envelope.payload_type == KEP_PAYLOAD_JSON {
+                            return Ok::<Option<Vec<u8>>, anyhow::Error>(Some(response));
+                        }
+                        warn!(
+                            payload_type = envelope.payload_type,
+                            "ignoring unsupported internal WebSocket KEP response"
+                        );
+                    }
+                    Message::Close(_) => anyhow::bail!("internal WebSocket closed"),
+                    _ => {}
+                }
+            }
+            anyhow::bail!("internal WebSocket closed")
+        })
+        .await
+        {
+            Ok(result) => result?,
+            Err(_) => None,
+        };
+
+        if response.is_some() {
+            let _ = tokio::time::timeout(Duration::from_millis(200), async {
+                while reader.next().await.is_some() {}
+            })
+            .await;
+        }
+
+        Ok(response)
+    }
+
+    fn reset(&mut self) {
+        warn!(internal_ws_url = %self.url, "resetting internal WebSocket relay");
+        self.writer = None;
+        self.reader = None;
+    }
 }
 
 fn prune_rate_window(recent_messages: &mut VecDeque<Instant>) {

--- a/tools/kitu-webtransport-gateway/src/main.rs
+++ b/tools/kitu-webtransport-gateway/src/main.rs
@@ -233,7 +233,10 @@ impl InternalWebSocketRelay {
     }
 
     async fn relay_connected(&mut self, bytes: Vec<u8>) -> Result<Option<Vec<u8>>> {
-        self.drain_idle_messages().await?;
+        if self.drain_idle_messages().await? {
+            self.reset();
+            self.connect().await?;
+        }
 
         let writer = self
             .writer
@@ -285,14 +288,19 @@ impl InternalWebSocketRelay {
         Ok(response)
     }
 
-    async fn drain_idle_messages(&mut self) -> Result<()> {
+    async fn drain_idle_messages(&mut self) -> Result<bool> {
         let reader = self
             .reader
             .as_mut()
             .context("internal WebSocket reader is not connected")?;
         let mut drained = 0usize;
+        let mut disconnected = false;
 
-        while let Some(message) = reader.next().now_or_never().flatten() {
+        while let Some(next) = reader.next().now_or_never() {
+            let Some(message) = next else {
+                disconnected = true;
+                break;
+            };
             match message.context("read queued internal WebSocket message")? {
                 Message::Binary(bytes) => {
                     let response = bytes.to_vec();
@@ -307,7 +315,10 @@ impl InternalWebSocketRelay {
                         "ignoring unsupported queued internal WebSocket KEP response"
                     );
                 }
-                Message::Close(_) => anyhow::bail!("internal WebSocket closed"),
+                Message::Close(_) => {
+                    disconnected = true;
+                    break;
+                }
                 _ => {}
             }
         }
@@ -318,7 +329,7 @@ impl InternalWebSocketRelay {
                 "dropped queued internal WebSocket KEP broadcasts before relaying request"
             );
         }
-        Ok(())
+        Ok(disconnected)
     }
 
     fn reset(&mut self) {


### PR DESCRIPTION
## Summary

Closes #89.

- Add a per-WebTransport-session internal WebSocket relay owner in the experimental gateway.
- Lazily open the internal WebSocket on the first valid KEP `osc` stream and reuse it for later streams in the same WebTransport session.
- Serialize relay access for now so internal WebSocket request/response ordering stays unambiguous.
- Reset the relay on send/read errors so a later stream can reconnect.
- Expand the smoke client to send two WebTransport KEP requests through one session and verify both objects are created.
- Document the session relay lifecycle and failure handling.

## Validation

- `devcontainer exec --workspace-folder . cargo fmt --all --check`
- `devcontainer exec --workspace-folder . cargo test -p kitu-transport -p kitu-demo-game`
- `docker run --rm -v /Users/mujina/MujinaProd/kitu-workspace/kitu-logic-processor:/workspace -w /workspace/tools/kitu-webtransport-gateway rust:1.88-bookworm cargo fmt -- --check`
- `tools/kitu-webtransport-gateway/scripts/check-in-docker.sh`
- `tools/kitu-webtransport-gateway/scripts/smoke-in-docker.sh`
  - Result: sent 2 WebTransport KEP `/admin/world/spawn` requests on one session and verified `webtransport-smoke-0` plus `webtransport-smoke-1` in app state.
- `docker compose -f apps/demo-game/docker-compose.yml logs --no-color webtransport-gateway | grep 'opened internal WebSocket relay'`
  - Result: one relay-open log line for the smoke run.

## Browser Manual Check

1. Generate the WebTransport dev certificate if needed: `tools/kitu-webtransport-gateway/scripts/generate-dev-cert-in-docker.sh`.
2. Start the Web Admin compose stack: `docker compose -f tools/kitu-web-admin/docker-compose.yml up --build`.
3. Open `http://localhost:5173` in a browser with WebTransport support.
4. Trigger two World actions without reloading the page.
5. Expected result: both actions succeed over the same browser WebTransport session, WebSocket fallback remains available, and gateway logs show one internal WebSocket relay open unless the documented reset/reconnect path is hit.

## Notes

- This branch is intentionally based on `origin/develop` per the issue workflow, so it does not include PR #97 / #86 stream framing changes. If #86 merges first, this PR may need a small rebase around gateway response handling.
- `/ws/runtime` remains the authoritative MVP WebSocket path.
- WebTransport remains limited to the Web Admin / gateway experiment lane.