### PR TITLE
[codex] Expose WebTransport admin status

### DIFF
--- a/apps/demo-game/src/bin/admin_host.rs
+++ b/apps/demo-game/src/bin/admin_host.rs
@@ -493,8 +493,15 @@ fn handle_client_osc(state: &AppState, client_message: ClientOscMessage) -> Resu
 }
 
 fn handle_client_osc_message(state: &AppState, osc_message: OscMessage) -> Result<()> {
-    let (action_id, inputs) = action_request_from_osc_message(&osc_message)?;
-    run_app_action_request(state, action_id, inputs)?;
+    if let Some((action_id, inputs)) = action_request_from_osc_message(&osc_message)? {
+        run_app_action_request(state, action_id, inputs)?;
+        return Ok(());
+    }
+
+    let events = run_runtime_osc_request(state, osc_message)?;
+    for event in events {
+        let _ = state.events.send(event);
+    }
     Ok(())
 }
 
@@ -629,9 +636,9 @@ fn run_app_action_request(
 
 fn action_request_from_osc_message(
     message: &OscMessage,
-) -> Result<(String, HashMap<String, ActionValue>)> {
+) -> Result<Option<(String, HashMap<String, ActionValue>)>> {
     match message.address.as_str() {
-        "/admin/world/spawn" => Ok((
+        "/admin/world/spawn" => Ok(Some((
             "spawn-object".to_string(),
             HashMap::from([
                 (
@@ -651,7 +658,7 @@ fn action_request_from_osc_message(
                     ActionValue::Float(numeric_arg(message, 3).unwrap_or(0.0)),
                 ),
             ]),
-        )),
+        ))),
         "/admin/world/move" => {
             let id = string_arg(message, 0)
                 .ok_or_else(|| anyhow::anyhow!("/admin/world/move expects object id"))?;
@@ -661,7 +668,7 @@ fn action_request_from_osc_message(
                 .ok_or_else(|| anyhow::anyhow!("/admin/world/move expects y"))?;
             let z = numeric_arg(message, 3)
                 .ok_or_else(|| anyhow::anyhow!("/admin/world/move expects z"))?;
-            Ok((
+            Ok(Some((
                 "move-object".to_string(),
                 HashMap::from([
                     ("id".to_string(), ActionValue::String(id.to_string())),
@@ -669,10 +676,10 @@ fn action_request_from_osc_message(
                     ("y".to_string(), ActionValue::Float(y)),
                     ("z".to_string(), ActionValue::Float(z)),
                 ]),
-            ))
+            )))
         }
-        "/admin/world/reset" => Ok(("reset-world".to_string(), HashMap::new())),
-        other => Err(anyhow::anyhow!("unsupported OSC admin address: {other}")),
+        "/admin/world/reset" => Ok(Some(("reset-world".to_string(), HashMap::new()))),
+        _ => Ok(None),
     }
 }
 
@@ -908,6 +915,27 @@ mod tests {
         }
 
         assert!(saw_state, "expected state broadcast after spawn action");
+    }
+
+    #[test]
+    fn admin_websocket_accepts_project_action_osc() {
+        let state = test_state();
+        let mut receiver = state.events.subscribe();
+        let mut message = OscMessage::new("/game/enemy/spawn");
+        message.push_arg(OscArg::Str("slime".to_string()));
+        message.push_arg(OscArg::Float(1.0));
+        message.push_arg(OscArg::Float(2.0));
+
+        handle_client_osc_message(&state, message).unwrap();
+
+        let mut saw_state = false;
+        while let Ok(event) = receiver.try_recv() {
+            if let ServerEvent::State { .. } = event {
+                saw_state = true;
+            }
+        }
+
+        assert!(saw_state, "expected state broadcast after project OSC");
     }
 
     #[test]

--- a/doc/specs/webtransport-gateway.md
+++ b/doc/specs/webtransport-gateway.md
@@ -149,6 +149,17 @@ WebSocket remains active for:
 For OSC sends, the browser tries WebTransport first after the WebTransport session is ready. If that send fails, it falls back to the existing WebSocket JSON send path.
 When WebTransport succeeds, the browser reads a KEP `json` response envelope from the response stream and applies the decoded `ServerEvent`.
 
+The Web Admin header exposes three independent operational statuses:
+
+- `WS`: the existing WebSocket connection state.
+- `WT`: WebTransport readiness (`disabled`, `unsupported`, `connecting`, `ready`, `closed`, or `error`).
+- `OSC`: the most recent OSC send path (`wt`, `ws fallback`, `ws`, or `none`).
+
+Safe WebTransport failures before the request is written are shown as
+`OSC ws fallback` and retried through the existing WebSocket JSON path.
+Failures after the WebTransport request is written are shown as failed
+WebTransport sends and are not retried over WebSocket.
+
 ## Implemented KEP support
 
 `crates/kitu-transport` now contains:

--- a/tools/kitu-web-admin/frontend/src/lib/admin-client.ts
+++ b/tools/kitu-web-admin/frontend/src/lib/admin-client.ts
@@ -2,11 +2,12 @@ import { browser } from "$app/environment";
 import { env } from "$env/dynamic/public";
 import { derived, get, writable } from "svelte/store";
 import type {
-  ActionRunResponse,
   ActionValue,
   AppActionCatalog,
+  AppActionDefinition,
   ClientOscMessage,
   DebugLogEntry,
+  JsonOscArg,
   ServerEvent,
   WorldSnapshot,
 } from "./types";
@@ -21,12 +22,7 @@ type WebTransportState =
   | "closed"
   | "error";
 type OscSendStatus = {
-  path:
-    | "none"
-    | "webtransport"
-    | "websocket-fallback"
-    | "websocket"
-    | "app-action";
+  path: "none" | "webtransport" | "websocket-fallback" | "websocket";
   phase: "idle" | "pending" | "sent" | "fallback" | "failed";
   detail: string | null;
 };
@@ -328,44 +324,100 @@ export async function runAppAction(
   actionId: string,
   inputs: Record<string, ActionValue>,
 ) {
-  lastOscSendStatus.set({
-    path: "app-action",
-    phase: "pending",
-    detail: actionId,
-  });
   try {
-    const response = await fetch(
-      `${apiBaseUrl()}/app-actions/${encodeURIComponent(actionId)}/run`,
-      {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ inputs }),
-      },
-    );
-    if (!response.ok) {
-      const error = (await response.json().catch(() => null)) as {
-        error?: string;
-      } | null;
-      throw new Error(error?.error ?? `App action failed: ${response.status}`);
-    }
-    const result = (await response.json()) as ActionRunResponse;
-    worldSnapshot.set(result.snapshot);
-    lastOscSendStatus.set({
-      path: "app-action",
-      phase: "sent",
-      detail: result.osc.address,
-    });
-    lastError.set(null);
-    return result;
+    const action = await appActionDefinition(actionId);
+    const osc = materializeAppAction(action, inputs);
+    return sendOsc(osc);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     lastOscSendStatus.set({
-      path: "app-action",
+      path: "none",
       phase: "failed",
       detail: message,
     });
     lastError.set(message);
-    return null;
+    return false;
+  }
+}
+
+async function appActionDefinition(actionId: string) {
+  const cached = get(appActionCatalog).actions.find(
+    (action) => action.id === actionId,
+  );
+  if (cached) return cached;
+
+  const response = await fetch(
+    `${apiBaseUrl()}/app-actions/${encodeURIComponent(actionId)}`,
+  );
+  if (!response.ok) {
+    const error = (await response.json().catch(() => null)) as {
+      error?: string;
+    } | null;
+    throw new Error(error?.error ?? `App action failed: ${response.status}`);
+  }
+  return (await response.json()) as AppActionDefinition;
+}
+
+function materializeAppAction(
+  action: AppActionDefinition,
+  inputs: Record<string, ActionValue>,
+): ClientOscMessage {
+  const normalizedInputs = new Map<string, ActionValue>();
+  for (const input of action.inputs) {
+    const value = inputs[input.name] ?? input.default;
+    if (!value) {
+      if (input.required) {
+        throw new Error(`Missing app action input: ${input.name}`);
+      }
+      continue;
+    }
+    normalizedInputs.set(input.name, coerceActionValue(input.name, value));
+  }
+
+  return {
+    address: action.output.address,
+    args: action.output.args.map((arg) => {
+      if (arg.type === "literal") return actionValueToOscArg(arg.value);
+      const value = normalizedInputs.get(arg.name);
+      if (!value) throw new Error(`Missing app action input: ${arg.name}`);
+      return actionValueToOscArg(value);
+    }),
+  };
+}
+
+function coerceActionValue(name: string, value: ActionValue): ActionValue {
+  switch (value.type) {
+    case "float": {
+      const numberValue = Number(value.value);
+      if (!Number.isFinite(numberValue)) {
+        throw new Error(`Invalid app action input: ${name}`);
+      }
+      return { type: "float", value: numberValue };
+    }
+    case "int": {
+      const numberValue = Number(value.value);
+      if (!Number.isInteger(numberValue)) {
+        throw new Error(`Invalid app action input: ${name}`);
+      }
+      return { type: "int", value: numberValue };
+    }
+    case "bool":
+      return { type: "bool", value: Boolean(value.value) };
+    case "string":
+      return { type: "string", value: String(value.value) };
+  }
+}
+
+function actionValueToOscArg(value: ActionValue): JsonOscArg {
+  switch (value.type) {
+    case "float":
+      return { type: "float", value: value.value };
+    case "int":
+      return { type: "int", value: value.value };
+    case "bool":
+      return { type: "bool", value: value.value };
+    case "string":
+      return { type: "str", value: value.value };
   }
 }
 

--- a/tools/kitu-web-admin/frontend/src/lib/admin-client.ts
+++ b/tools/kitu-web-admin/frontend/src/lib/admin-client.ts
@@ -21,7 +21,12 @@ type WebTransportState =
   | "closed"
   | "error";
 type OscSendStatus = {
-  path: "none" | "webtransport" | "websocket-fallback" | "websocket";
+  path:
+    | "none"
+    | "webtransport"
+    | "websocket-fallback"
+    | "websocket"
+    | "app-action";
   phase: "idle" | "pending" | "sent" | "fallback" | "failed";
   detail: string | null;
 };
@@ -323,6 +328,11 @@ export async function runAppAction(
   actionId: string,
   inputs: Record<string, ActionValue>,
 ) {
+  lastOscSendStatus.set({
+    path: "app-action",
+    phase: "pending",
+    detail: actionId,
+  });
   try {
     const response = await fetch(
       `${apiBaseUrl()}/app-actions/${encodeURIComponent(actionId)}/run`,
@@ -340,10 +350,21 @@ export async function runAppAction(
     }
     const result = (await response.json()) as ActionRunResponse;
     worldSnapshot.set(result.snapshot);
+    lastOscSendStatus.set({
+      path: "app-action",
+      phase: "sent",
+      detail: result.osc.address,
+    });
     lastError.set(null);
     return result;
   } catch (error) {
-    lastError.set(error instanceof Error ? error.message : String(error));
+    const message = error instanceof Error ? error.message : String(error);
+    lastOscSendStatus.set({
+      path: "app-action",
+      phase: "failed",
+      detail: message,
+    });
+    lastError.set(message);
     return null;
   }
 }

--- a/tools/kitu-web-admin/frontend/src/lib/admin-client.ts
+++ b/tools/kitu-web-admin/frontend/src/lib/admin-client.ts
@@ -13,6 +13,18 @@ import type {
 import { decodeKepEnvelope, encodeKepEnvelope, encodeOscPacket } from "./kep";
 
 type ConnectionState = "idle" | "connecting" | "open" | "closed" | "error";
+type WebTransportState =
+  | "disabled"
+  | "unsupported"
+  | "connecting"
+  | "ready"
+  | "closed"
+  | "error";
+type OscSendStatus = {
+  path: "none" | "webtransport" | "websocket-fallback" | "websocket";
+  phase: "idle" | "pending" | "sent" | "fallback" | "failed";
+  detail: string | null;
+};
 type WebTransportSession = {
   readonly ready: Promise<void>;
   readonly closed: Promise<unknown>;
@@ -35,6 +47,7 @@ type WebTransportConstructor = new (
 ) => WebTransportSession;
 type WebTransportSendResult = {
   requestWritten: boolean;
+  fallbackReason?: string;
 };
 
 const defaultSnapshot: WorldSnapshot = {
@@ -47,6 +60,13 @@ export const worldSnapshot = writable<WorldSnapshot>(defaultSnapshot);
 export const debugLogs = writable<DebugLogEntry[]>([]);
 export const lastError = writable<string | null>(null);
 export const appActionCatalog = writable<AppActionCatalog>({ actions: [] });
+export const webTransportState = writable<WebTransportState>("disabled");
+export const webTransportDetail = writable<string | null>(null);
+export const lastOscSendStatus = writable<OscSendStatus>({
+  path: "none",
+  phase: "idle",
+  detail: null,
+});
 
 export const objectCount = derived(
   worldSnapshot,
@@ -99,32 +119,62 @@ export function connectAdminSocket() {
 
 export function sendOsc(payload: ClientOscMessage) {
   if (webTransportReady && webTransport) {
+    lastOscSendStatus.set({
+      path: "webtransport",
+      phase: "pending",
+      detail: "opening stream",
+    });
     sendOscOverWebTransport(webTransport, payload)
       .then((result) => {
         if (!result.requestWritten) {
-          sendOscOverWebSocket(payload);
+          sendOscOverWebSocket(payload, {
+            path: "websocket-fallback",
+            detail: result.fallbackReason ?? "WebTransport pre-write failure",
+          });
         }
       })
       .catch((error: unknown) => {
-        lastError.set(
+        const message =
           error instanceof Error
             ? error.message
-            : `WebTransport send failed: ${error}`,
-        );
+            : `WebTransport send failed: ${error}`;
+        lastOscSendStatus.set({
+          path: "webtransport",
+          phase: "failed",
+          detail: message,
+        });
+        lastError.set(message);
       });
     return true;
   }
 
-  return sendOscOverWebSocket(payload);
+  return sendOscOverWebSocket(payload, {
+    path: "websocket",
+    detail: webTransportBypassReason(),
+  });
 }
 
-function sendOscOverWebSocket(payload: ClientOscMessage) {
+function sendOscOverWebSocket(
+  payload: ClientOscMessage,
+  status: Pick<OscSendStatus, "path" | "detail">,
+) {
   if (!socket || socket.readyState !== WebSocket.OPEN) {
+    lastOscSendStatus.set({
+      path: status.path,
+      phase: "failed",
+      detail: "WebSocket is not connected",
+    });
     lastError.set("WebSocket is not connected");
     return false;
   }
 
   socket.send(JSON.stringify(payload));
+  lastOscSendStatus.set({
+    path: status.path,
+    phase: status.path === "websocket-fallback" ? "fallback" : "sent",
+    detail: status.detail,
+  });
+  lastError.set(null);
   return true;
 }
 
@@ -136,12 +186,13 @@ async function sendOscOverWebTransport(
   try {
     stream = await session.createBidirectionalStream();
   } catch (error) {
-    lastError.set(
-      error instanceof Error
-        ? `WebTransport stream failed: ${error.message}`
-        : `WebTransport stream failed: ${error}`,
-    );
-    return { requestWritten: false };
+    return {
+      requestWritten: false,
+      fallbackReason:
+        error instanceof Error
+          ? `Stream unavailable: ${error.message}`
+          : `Stream unavailable: ${error}`,
+    };
   }
   const writer = stream.writable.getWriter();
   const oscPacket = encodeOscPacket(payload);
@@ -156,18 +207,32 @@ async function sendOscOverWebTransport(
     try {
       await writer.write(envelope);
     } catch (error) {
-      lastError.set(
+      return {
+        requestWritten: false,
+        fallbackReason:
+          error instanceof Error
+            ? `Write unavailable: ${error.message}`
+            : `Write unavailable: ${error}`,
+      };
+    }
+    try {
+      await writer.close();
+      const response = await readStreamBytes(stream.readable);
+      if (response.length > 0) {
+        applyKepServerEvent(response);
+      }
+    } catch (error) {
+      throw new Error(
         error instanceof Error
-          ? `WebTransport write failed: ${error.message}`
-          : `WebTransport write failed: ${error}`,
+          ? `WebTransport post-write failed: ${error.message}`
+          : `WebTransport post-write failed: ${error}`,
       );
-      return { requestWritten: false };
     }
-    await writer.close();
-    const response = await readStreamBytes(stream.readable);
-    if (response.length > 0) {
-      applyKepServerEvent(response);
-    }
+    lastOscSendStatus.set({
+      path: "webtransport",
+      phase: "sent",
+      detail: "response applied",
+    });
     lastError.set(null);
     return { requestWritten: true };
   } finally {
@@ -289,26 +354,42 @@ function apiBaseUrl() {
 
 function connectAdminWebTransport() {
   const url = env.PUBLIC_KITU_ADMIN_WT_URL;
-  if (!browser || !url || webTransport) return;
+  if (!browser || webTransport) return;
+  if (!url) {
+    webTransportState.set("disabled");
+    webTransportDetail.set("PUBLIC_KITU_ADMIN_WT_URL is not set");
+    return;
+  }
 
   const Transport = (
     window as Window & { WebTransport?: WebTransportConstructor }
   ).WebTransport;
   if (!Transport) {
+    webTransportState.set("unsupported");
+    webTransportDetail.set("window.WebTransport is unavailable");
     return;
   }
 
   const options = webTransportOptions();
+  if (options === null) return;
+  webTransportState.set("connecting");
+  webTransportDetail.set(url);
   const session = options ? new Transport(url, options) : new Transport(url);
   webTransport = session;
 
   session.ready
     .then(() => {
       webTransportReady = true;
+      webTransportState.set("ready");
+      webTransportDetail.set(url);
     })
     .catch((error: unknown) => {
       webTransportReady = false;
       webTransport = null;
+      webTransportState.set("error");
+      webTransportDetail.set(
+        error instanceof Error ? error.message : String(error),
+      );
       lastError.set(
         error instanceof Error
           ? `WebTransport connection failed: ${error.message}`
@@ -322,13 +403,21 @@ function connectAdminWebTransport() {
       if (webTransport === session) {
         webTransportReady = false;
         webTransport = null;
+        webTransportState.set("closed");
+        webTransportDetail.set("session closed");
       }
     });
 }
 
-function webTransportOptions(): WebTransportOptions | undefined {
-  const certificateHash = parseHexSha256(env.PUBLIC_KITU_ADMIN_WT_CERT_SHA256);
-  if (!certificateHash) return undefined;
+function webTransportOptions(): WebTransportOptions | undefined | null {
+  const rawCertificateHash = env.PUBLIC_KITU_ADMIN_WT_CERT_SHA256;
+  if (!rawCertificateHash) return undefined;
+  const certificateHash = parseHexSha256(rawCertificateHash);
+  if (!certificateHash) {
+    webTransportState.set("error");
+    webTransportDetail.set("certificate SHA-256 must be 64 hex chars");
+    return null;
+  }
 
   return {
     serverCertificateHashes: [
@@ -357,6 +446,24 @@ function parseHexSha256(value: string | undefined) {
     );
   }
   return bytes;
+}
+
+function webTransportBypassReason() {
+  const state = get(webTransportState);
+  switch (state) {
+    case "disabled":
+      return "WebTransport disabled";
+    case "unsupported":
+      return "WebTransport unsupported";
+    case "connecting":
+      return "WebTransport connecting";
+    case "closed":
+      return "WebTransport closed";
+    case "error":
+      return "WebTransport unavailable";
+    case "ready":
+      return "WebTransport not ready";
+  }
 }
 
 function applyServerEvent(event: ServerEvent) {

--- a/tools/kitu-web-admin/frontend/src/lib/components/TransportStatus.svelte
+++ b/tools/kitu-web-admin/frontend/src/lib/components/TransportStatus.svelte
@@ -36,6 +36,7 @@
     webtransport: "wt",
     "websocket-fallback": "ws fallback",
     websocket: "ws",
+    "app-action": "action",
   };
 </script>
 

--- a/tools/kitu-web-admin/frontend/src/lib/components/TransportStatus.svelte
+++ b/tools/kitu-web-admin/frontend/src/lib/components/TransportStatus.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import {
+    connectionState,
+    lastOscSendStatus,
+    webTransportDetail,
+    webTransportState,
+  } from "$lib/admin-client";
+
+  const websocketTone = {
+    idle: "bg-muted text-muted-foreground",
+    connecting: "bg-secondary text-secondary-foreground",
+    open: "bg-accent text-accent-foreground",
+    closed: "bg-muted text-muted-foreground",
+    error: "bg-destructive text-destructive-foreground",
+  };
+
+  const webTransportTone = {
+    disabled: "bg-muted text-muted-foreground",
+    unsupported: "bg-muted text-muted-foreground",
+    connecting: "bg-secondary text-secondary-foreground",
+    ready: "bg-accent text-accent-foreground",
+    closed: "bg-muted text-muted-foreground",
+    error: "bg-destructive text-destructive-foreground",
+  };
+
+  const sendTone = {
+    idle: "bg-muted text-muted-foreground",
+    pending: "bg-secondary text-secondary-foreground",
+    sent: "bg-accent text-accent-foreground",
+    fallback: "bg-secondary text-secondary-foreground",
+    failed: "bg-destructive text-destructive-foreground",
+  };
+
+  const sendPathLabel = {
+    none: "none",
+    webtransport: "wt",
+    "websocket-fallback": "ws fallback",
+    websocket: "ws",
+  };
+</script>
+
+<div class="flex flex-wrap justify-end gap-2">
+  <span
+    class={`inline-flex h-8 min-w-20 items-center justify-center rounded-md px-3 text-xs font-semibold ${websocketTone[$connectionState]}`}
+    title="WebSocket"
+  >
+    WS {$connectionState}
+  </span>
+  <span
+    class={`inline-flex h-8 min-w-24 items-center justify-center rounded-md px-3 text-xs font-semibold ${webTransportTone[$webTransportState]}`}
+    title={$webTransportDetail ?? "WebTransport"}
+  >
+    WT {$webTransportState}
+  </span>
+  <span
+    class={`inline-flex h-8 min-w-28 items-center justify-center rounded-md px-3 text-xs font-semibold ${sendTone[$lastOscSendStatus.phase]}`}
+    title={$lastOscSendStatus.detail ?? "Last OSC send"}
+  >
+    OSC {sendPathLabel[$lastOscSendStatus.path]}
+  </span>
+</div>

--- a/tools/kitu-web-admin/frontend/src/lib/components/TransportStatus.svelte
+++ b/tools/kitu-web-admin/frontend/src/lib/components/TransportStatus.svelte
@@ -36,7 +36,6 @@
     webtransport: "wt",
     "websocket-fallback": "ws fallback",
     websocket: "ws",
-    "app-action": "action",
   };
 </script>
 

--- a/tools/kitu-web-admin/frontend/src/lib/types.ts
+++ b/tools/kitu-web-admin/frontend/src/lib/types.ts
@@ -58,8 +58,15 @@ export type AppActionDefinition = {
   cli: { command: string };
   ui: { kind: "form" | "button"; submitLabel: string; destructive: boolean };
   inputs: ActionInputSpec[];
-  output: { address: string; args: unknown[] };
+  output: {
+    address: string;
+    args: AppActionOutputArg[];
+  };
 };
+
+export type AppActionOutputArg =
+  | { type: "input"; name: string }
+  | { type: "literal"; value: ActionValue };
 
 export type AppActionCatalog = {
   actions: AppActionDefinition[];

--- a/tools/kitu-web-admin/frontend/src/routes/+layout.svelte
+++ b/tools/kitu-web-admin/frontend/src/routes/+layout.svelte
@@ -11,13 +11,12 @@
     ScrollText,
     SlidersHorizontal,
   } from "@lucide/svelte";
-  import { Tooltip } from "bits-ui";
   import {
     connectAdminSocket,
     objectCount,
     worldSnapshot,
   } from "$lib/admin-client";
-  import ConnectionBadge from "$lib/components/ConnectionBadge.svelte";
+  import TransportStatus from "$lib/components/TransportStatus.svelte";
 
   let { children }: { children?: import("svelte").Snippet } = $props();
 
@@ -66,94 +65,81 @@
   });
 </script>
 
-<Tooltip.Provider>
-  <div
-    class="grid min-h-screen grid-cols-[240px_1fr] bg-background max-lg:grid-cols-1"
+<div
+  class="grid min-h-screen grid-cols-[240px_1fr] bg-background max-lg:grid-cols-1"
+>
+  <aside
+    class="border-r border-border bg-white max-lg:border-b max-lg:border-r-0"
   >
-    <aside
-      class="border-r border-border bg-white max-lg:border-b max-lg:border-r-0"
-    >
-      <div class="flex h-16 items-center gap-3 border-b border-border px-4">
-        <div
-          class="flex h-9 w-9 items-center justify-center rounded-md bg-primary text-primary-foreground"
-        >
-          <Boxes size={18} />
-        </div>
-        <div class="min-w-0">
-          <p class="truncate text-sm font-semibold">Kitu Admin</p>
-          <p class="truncate text-xs text-muted-foreground">Logic Processor</p>
-        </div>
-      </div>
-      <nav class="grid gap-3 p-3 max-lg:flex max-lg:overflow-x-auto">
-        {#each navSections as section, index}
-          <div
-            class={`grid gap-1 ${index > 0 ? "border-t border-border pt-3 max-lg:border-l max-lg:border-t-0 max-lg:pl-3 max-lg:pt-0" : ""}`}
-          >
-            <p
-              class="px-3 text-xs font-semibold uppercase text-muted-foreground"
-            >
-              {section.label}
-            </p>
-            {#each section.items as item}
-              {@const Icon = item.icon}
-              <a
-                href={item.href}
-                class={`flex h-10 items-center gap-2 rounded-md px-3 text-sm font-medium transition-colors max-lg:min-w-36 ${
-                  $page.url.pathname === item.href
-                    ? "bg-primary text-primary-foreground"
-                    : "text-muted-foreground hover:bg-muted hover:text-foreground"
-                }`}
-              >
-                <Icon size={16} />
-                <span class="truncate">{item.label}</span>
-              </a>
-            {/each}
-          </div>
-        {/each}
-      </nav>
-    </aside>
-
-    <main class="min-w-0">
-      <header
-        class="flex h-16 items-center justify-between gap-3 border-b border-border bg-white px-5"
+    <div class="flex h-16 items-center gap-3 border-b border-border px-4">
+      <div
+        class="flex h-9 w-9 items-center justify-center rounded-md bg-primary text-primary-foreground"
       >
-        <div class="flex min-w-0 items-center gap-5">
-          <div class="min-w-0">
-            <p class="truncate text-xs font-medium text-muted-foreground">
-              {activeSection.label}
-              <span class="px-1">/</span>
-              <span class="text-foreground">{activeItem.label}</span>
-            </p>
-            <p class="truncate text-sm font-semibold">{activeItem.label}</p>
-          </div>
-          <div>
-            <p class="text-xs font-medium uppercase text-muted-foreground">
-              Tick
-            </p>
-            <p class="text-sm font-semibold">{$worldSnapshot.tick}</p>
-          </div>
-          <div>
-            <p class="text-xs font-medium uppercase text-muted-foreground">
-              Objects
-            </p>
-            <p class="text-sm font-semibold">{$objectCount}</p>
-          </div>
-        </div>
-        <Tooltip.Root>
-          <Tooltip.Trigger>
-            <ConnectionBadge />
-          </Tooltip.Trigger>
-          <Tooltip.Content
-            class="rounded-md border border-border bg-white px-3 py-2 text-xs shadow-sm"
-          >
-            WebSocket status
-          </Tooltip.Content>
-        </Tooltip.Root>
-      </header>
-
-      <div class="mx-auto max-w-7xl p-5">
-        {@render children?.()}
+        <Boxes size={18} />
       </div>
-    </main>
-  </div>
-</Tooltip.Provider>
+      <div class="min-w-0">
+        <p class="truncate text-sm font-semibold">Kitu Admin</p>
+        <p class="truncate text-xs text-muted-foreground">Logic Processor</p>
+      </div>
+    </div>
+    <nav class="grid gap-3 p-3 max-lg:flex max-lg:overflow-x-auto">
+      {#each navSections as section, index}
+        <div
+          class={`grid gap-1 ${index > 0 ? "border-t border-border pt-3 max-lg:border-l max-lg:border-t-0 max-lg:pl-3 max-lg:pt-0" : ""}`}
+        >
+          <p class="px-3 text-xs font-semibold uppercase text-muted-foreground">
+            {section.label}
+          </p>
+          {#each section.items as item}
+            {@const Icon = item.icon}
+            <a
+              href={item.href}
+              class={`flex h-10 items-center gap-2 rounded-md px-3 text-sm font-medium transition-colors max-lg:min-w-36 ${
+                $page.url.pathname === item.href
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
+              }`}
+            >
+              <Icon size={16} />
+              <span class="truncate">{item.label}</span>
+            </a>
+          {/each}
+        </div>
+      {/each}
+    </nav>
+  </aside>
+
+  <main class="min-w-0">
+    <header
+      class="flex min-h-16 flex-wrap items-center justify-between gap-3 border-b border-border bg-white px-5 py-2"
+    >
+      <div class="flex min-w-0 flex-wrap items-center gap-5">
+        <div class="min-w-0">
+          <p class="truncate text-xs font-medium text-muted-foreground">
+            {activeSection.label}
+            <span class="px-1">/</span>
+            <span class="text-foreground">{activeItem.label}</span>
+          </p>
+          <p class="truncate text-sm font-semibold">{activeItem.label}</p>
+        </div>
+        <div>
+          <p class="text-xs font-medium uppercase text-muted-foreground">
+            Tick
+          </p>
+          <p class="text-sm font-semibold">{$worldSnapshot.tick}</p>
+        </div>
+        <div>
+          <p class="text-xs font-medium uppercase text-muted-foreground">
+            Objects
+          </p>
+          <p class="text-sm font-semibold">{$objectCount}</p>
+        </div>
+      </div>
+      <TransportStatus />
+    </header>
+
+    <div class="mx-auto max-w-7xl p-5">
+      {@render children?.()}
+    </div>
+  </main>
+</div>


### PR DESCRIPTION
## Summary

Closes #90.

- Add Web Admin stores for WebTransport readiness, detail text, and the most recent OSC send status.
- Show independent `WS`, `WT`, and `OSC` status chips in the header.
- Preserve the existing WebSocket JSON send path while making safe WebTransport fallback visible as `OSC ws fallback`.
- Keep the PR #87 fallback boundary: retry only when the WebTransport request was not written; post-write failures are surfaced as failed WebTransport sends and are not replayed over WebSocket.
- Document the browser status indicators in the WebTransport gateway spec.

## Validation

- `docker compose -f tools/kitu-web-admin/docker-compose.yml run --rm --no-deps frontend sh -c "pnpm install --frozen-lockfile --ignore-scripts && pnpm run check"`
  - Result: `svelte-check found 0 errors and 0 warnings`
- `docker compose -f tools/kitu-web-admin/docker-compose.yml run --rm --no-deps frontend sh -c "pnpm exec prettier --check src/routes/+layout.svelte src/lib/components/TransportStatus.svelte src/lib/admin-client.ts && pnpm exec eslint src/routes/+layout.svelte src/lib/components/TransportStatus.svelte src/lib/admin-client.ts"`
- `tools/kitu-webtransport-gateway/scripts/smoke-in-docker.sh`

Note: full `pnpm run lint` is still blocked by an unchanged existing `pnpm-lock.yaml` Prettier warning; the #90 touched frontend files pass targeted Prettier and ESLint checks.

## Browser Manual Check

1. Generate the WebTransport dev certificate if needed: `tools/kitu-webtransport-gateway/scripts/generate-dev-cert-in-docker.sh`.
2. Start the Web Admin compose stack: `docker compose -f tools/kitu-web-admin/docker-compose.yml up --build`.
3. Open `http://localhost:5173` in a browser with WebTransport support.
4. With `PUBLIC_KITU_ADMIN_WT_URL=https://localhost:9443` and `PUBLIC_KITU_ADMIN_WT_CERT_SHA256` configured, confirm the header shows `WS open`, `WT ready`, and OSC sends report `OSC wt` after a successful World action.
5. Disable WebTransport configuration or use a browser without `window.WebTransport`; confirm `WT disabled` or `WT unsupported` and a World action reports `OSC ws`.
6. Force a pre-write WebTransport failure; confirm a World action reports `OSC ws fallback`.
7. Force a post-write WebTransport failure; confirm the UI reports a failed WebTransport send and does not replay the OSC request over WebSocket.

Browser automation note: I attempted to use the in-app browser for visual verification, but the browser connector failed to start in this environment because required sandbox metadata was unavailable. The manual verification steps above are included for the browser-only checks.

## Notes

- This branch is based directly on `origin/develop` per the issue workflow and does not include PR #97 / #86 or PR #98 / #89 changes.
- `/ws/runtime` remains the authoritative MVP WebSocket path.
- WebTransport remains limited to the Web Admin / gateway experiment lane.