### PR TITLE
[codex] Stabilize WebTransport dev TLS workflow

### DIFF
--- a/doc/specs/webtransport-gateway.md
+++ b/doc/specs/webtransport-gateway.md
@@ -113,26 +113,67 @@ Browser verification is the hard part. The local development path uses the
 WebTransport `serverCertificateHashes` option so the browser can authenticate a
 short-lived self-signed certificate without modifying the host OS trust store.
 
-Generate the local certificate files before starting Compose:
+Generate and verify the local certificate files before starting Compose:
 
 ```sh
 tools/kitu-webtransport-gateway/scripts/generate-dev-cert-in-docker.sh
+tools/kitu-webtransport-gateway/scripts/check-dev-cert-in-docker.sh
 ```
 
 The script writes ignored files under `tools/kitu-webtransport-gateway/certs/`:
 
 - `webtransport-cert.pem`: ECDSA P-256 self-signed certificate for `localhost`, valid for 13 days.
 - `webtransport-key.pem`: private key used by the gateway.
-- `webtransport.env`: Compose env file containing `KITU_WT_GATEWAY_CERT`, `KITU_WT_GATEWAY_KEY`, and `PUBLIC_KITU_ADMIN_WT_CERT_SHA256`.
+- `webtransport.env`: Compose env file containing `KITU_WT_GATEWAY_CERT`, `KITU_WT_GATEWAY_KEY`, `PUBLIC_KITU_ADMIN_WT_CERT_SHA256`, and `KITU_WT_SMOKE_CERT_SHA256`.
 - `webtransport-cert.sha256`: SHA-256 hash of the DER certificate.
 
-Both Compose files load `webtransport.env` if it exists. If it does not exist,
-the gateway falls back to an ephemeral self-signed certificate, which is useful
-for server bring-up but most browsers will reject it.
+The 13-day validity window is intentionally short for browser development. When
+the check script reports that the certificate expires within 24 hours, regenerate
+it before browser testing and restart the Compose stack so both the gateway and
+frontend receive the same env file.
+
+Both Compose files load the same generated `webtransport.env` if it exists:
+
+- `tools/kitu-web-admin/docker-compose.yml`
+- `apps/demo-game/docker-compose.yml`
+
+If `webtransport.env` does not exist, the gateway falls back to an ephemeral
+self-signed certificate. That mode is useful for server bring-up and non-browser
+smoke work, but it is not the reliable browser verification path because the
+browser frontend does not receive a stable certificate hash for
+`serverCertificateHashes`.
 
 An OS-trusted local CA, for example through `mkcert`, is also possible, but it
 requires changing the developer machine trust store and is intentionally left as
 an explicit manual step rather than Compose startup behavior.
+
+Repeatable browser verification sequence:
+
+1. Generate and verify the dev certificate:
+
+```sh
+tools/kitu-webtransport-gateway/scripts/generate-dev-cert-in-docker.sh
+tools/kitu-webtransport-gateway/scripts/check-dev-cert-in-docker.sh
+```
+
+2. Confirm both Compose files consume the generated env file:
+
+```sh
+docker compose -f tools/kitu-web-admin/docker-compose.yml config
+docker compose -f apps/demo-game/docker-compose.yml config
+```
+
+3. Start the Web Admin stack:
+
+```sh
+docker compose -f tools/kitu-web-admin/docker-compose.yml up --build
+```
+
+4. Open `http://localhost:5173` in a browser with WebTransport support.
+5. Confirm the Web Admin connects to WebSocket and can establish WebTransport
+   with `https://localhost:9443`.
+6. Trigger a World action and confirm gateway logs show an accepted
+   WebTransport session.
 
 ## Browser behavior
 
@@ -183,6 +224,7 @@ connection are sent as KEP binary frames with `t = "json"` and
 
 ```sh
 tools/kitu-webtransport-gateway/scripts/generate-dev-cert-in-docker.sh
+tools/kitu-webtransport-gateway/scripts/check-dev-cert-in-docker.sh
 ```
 
 2. Open `http://localhost:5173`.
@@ -230,7 +272,6 @@ If WebTransport is unavailable, fails TLS verification, or fails while sending, 
 
 ## Follow-up work
 
-- Add a stable development TLS/certificate-hash workflow for browser verification.
 - Keep a persistent internal WebSocket connection per WebTransport session instead of connecting once per stream.
 - Stream multiple app-server KEP responses per WebTransport request if the protocol needs more than one response envelope.
 - Add WebTransport datagram support for high-frequency real-time updates.

--- a/tools/kitu-web-admin/README.md
+++ b/tools/kitu-web-admin/README.md
@@ -44,6 +44,7 @@ certificate and certificate hash:
 
 ```sh
 tools/kitu-webtransport-gateway/scripts/generate-dev-cert-in-docker.sh
+tools/kitu-webtransport-gateway/scripts/check-dev-cert-in-docker.sh
 ```
 
 To run the local WebTransport gateway smoke test:

--- a/tools/kitu-web-admin/frontend/src/lib/admin-client.ts
+++ b/tools/kitu-web-admin/frontend/src/lib/admin-client.ts
@@ -309,10 +309,12 @@ function connectAdminWebTransport() {
     .catch((error: unknown) => {
       webTransportReady = false;
       webTransport = null;
+      const detail = error instanceof Error ? error.message : String(error);
+      const certificateHint = env.PUBLIC_KITU_ADMIN_WT_CERT_SHA256
+        ? ""
+        : " Run tools/kitu-webtransport-gateway/scripts/generate-dev-cert-in-docker.sh and restart Compose, or use a browser-trusted certificate.";
       lastError.set(
-        error instanceof Error
-          ? `WebTransport connection failed: ${error.message}`
-          : `WebTransport connection failed: ${error}`,
+        `WebTransport connection failed: ${detail}.${certificateHint}`,
       );
     });
 
@@ -345,7 +347,9 @@ function parseHexSha256(value: string | undefined) {
 
   const normalized = value.replace(/[^a-fA-F0-9]/g, "");
   if (normalized.length !== 64) {
-    lastError.set("WebTransport certificate SHA-256 must be 64 hex chars");
+    lastError.set(
+      "PUBLIC_KITU_ADMIN_WT_CERT_SHA256 must be 64 hex chars. Regenerate the WebTransport dev certificate.",
+    );
     return null;
   }
 

--- a/tools/kitu-webtransport-gateway/scripts/check-dev-cert-in-docker.sh
+++ b/tools/kitu-webtransport-gateway/scripts/check-dev-cert-in-docker.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)"
+
+docker run --rm \
+  -v "$repo_root:/workspace" \
+  -w /workspace/tools/kitu-webtransport-gateway \
+  rust:1.88-bookworm \
+  sh -eu -c '
+    cert="certs/webtransport-cert.pem"
+    key="certs/webtransport-key.pem"
+    env_file="certs/webtransport.env"
+    hash_file="certs/webtransport-cert.sha256"
+
+    for path in "$cert" "$key" "$env_file" "$hash_file"; do
+      if [ ! -f "$path" ]; then
+        printf "%s\n" "Missing $path. Run tools/kitu-webtransport-gateway/scripts/generate-dev-cert-in-docker.sh first." >&2
+        exit 1
+      fi
+    done
+
+    cert_hash="$(openssl x509 -in "$cert" -outform der \
+      | openssl dgst -sha256 -r \
+      | awk "{print \$1}")"
+    file_hash="$(tr -d "[:space:]" < "$hash_file")"
+    public_env_hash="$(awk -F= "/^PUBLIC_KITU_ADMIN_WT_CERT_SHA256=/ {print \$2}" "$env_file")"
+    smoke_env_hash="$(awk -F= "/^KITU_WT_SMOKE_CERT_SHA256=/ {print \$2}" "$env_file")"
+
+    for value in "$file_hash" "$public_env_hash" "$smoke_env_hash"; do
+      if ! printf "%s" "$value" | grep -Eq "^[0-9a-fA-F]{64}$"; then
+        printf "%s\n" "Invalid WebTransport certificate hash in generated files. Regenerate the dev certificate." >&2
+        exit 1
+      fi
+    done
+
+    if [ "$cert_hash" != "$file_hash" ] || \
+       [ "$cert_hash" != "$public_env_hash" ] || \
+       [ "$cert_hash" != "$smoke_env_hash" ]; then
+      printf "%s\n" "Generated WebTransport certificate hash files do not match. Regenerate the dev certificate." >&2
+      exit 1
+    fi
+
+    cert_pubkey_hash="$(openssl x509 -in "$cert" -pubkey -noout \
+      | openssl pkey -pubin -outform der \
+      | openssl dgst -sha256 -r \
+      | awk "{print \$1}")"
+    key_pubkey_hash="$(openssl pkey -in "$key" -pubout -outform der \
+      | openssl dgst -sha256 -r \
+      | awk "{print \$1}")"
+    if [ "$cert_pubkey_hash" != "$key_pubkey_hash" ]; then
+      printf "%s\n" "Generated WebTransport certificate and key do not match. Regenerate the dev certificate." >&2
+      exit 1
+    fi
+
+    if ! openssl x509 -in "$cert" -checkend 86400 -noout >/dev/null; then
+      printf "%s\n" "Generated WebTransport certificate expires within 24 hours. Regenerate it before browser testing." >&2
+      exit 1
+    fi
+
+    printf "%s\n" "WebTransport dev certificate files are consistent."
+    printf "Certificate SHA-256: %s\n" "$cert_hash"
+    printf "Certificate expires: "
+    openssl x509 -in "$cert" -noout -enddate | sed "s/^notAfter=//"
+  '

--- a/tools/kitu-webtransport-gateway/scripts/generate-dev-cert-in-docker.sh
+++ b/tools/kitu-webtransport-gateway/scripts/generate-dev-cert-in-docker.sh
@@ -31,6 +31,7 @@ docker run --rm \
       printf "%s\n" "KITU_WT_GATEWAY_CERT=/workspace/tools/kitu-webtransport-gateway/certs/webtransport-cert.pem"
       printf "%s\n" "KITU_WT_GATEWAY_KEY=/workspace/tools/kitu-webtransport-gateway/certs/webtransport-key.pem"
       printf "%s\n" "PUBLIC_KITU_ADMIN_WT_CERT_SHA256=$cert_hash"
+      printf "%s\n" "KITU_WT_SMOKE_CERT_SHA256=$cert_hash"
     } > certs/webtransport.env
 
     printf "%s\n" "$cert_hash" > certs/webtransport-cert.sha256
@@ -40,3 +41,4 @@ docker run --rm \
 printf "Generated WebTransport dev certificate files in %s\n" "$cert_dir"
 printf "Certificate SHA-256: "
 cat "$cert_dir/webtransport-cert.sha256"
+printf "%s\n" "Run tools/kitu-webtransport-gateway/scripts/check-dev-cert-in-docker.sh to verify the generated files."


### PR DESCRIPTION
## Summary

Closes #91.

- Add `tools/kitu-webtransport-gateway/scripts/check-dev-cert-in-docker.sh` to verify generated cert/key/env/hash consistency.
- Extend `generate-dev-cert-in-docker.sh` so the generated env file includes both `PUBLIC_KITU_ADMIN_WT_CERT_SHA256` and `KITU_WT_SMOKE_CERT_SHA256` from the same certificate hash.
- Improve Web Admin TLS failure messages for missing or malformed certificate hash configuration.
- Document the repeatable browser WebTransport TLS workflow from cert generation through Compose config and browser verification.
- Distinguish reliable browser verification from the gateway's ephemeral self-signed bring-up mode.

## Validation

- `tools/kitu-webtransport-gateway/scripts/generate-dev-cert-in-docker.sh`
  - Generated SHA-256: `8637f72ab2d41bb930eedd5babc425e4a4367439c3741ff71e555f4136ab0cb4`
- `tools/kitu-webtransport-gateway/scripts/check-dev-cert-in-docker.sh`
  - Result: cert/key/env/hash files are consistent.
  - Certificate expires: `Jul 10 06:39:00 2026 GMT`.
- `docker compose -f tools/kitu-web-admin/docker-compose.yml config`
  - Confirmed frontend and gateway receive the generated cert paths and hash.
- `docker compose -f apps/demo-game/docker-compose.yml config`
  - Confirmed web-admin and gateway receive the generated cert paths and hash.
- `docker compose -f tools/kitu-web-admin/docker-compose.yml run --rm --no-deps frontend sh -c "pnpm install --frozen-lockfile --ignore-scripts && pnpm run check"`
  - Result: `svelte-check found 0 errors and 0 warnings`.
- `tools/kitu-webtransport-gateway/scripts/smoke-in-docker.sh`
  - Result: WebTransport gateway smoke test passed with the generated cert env.

## Browser Manual Check

1. Run `tools/kitu-webtransport-gateway/scripts/generate-dev-cert-in-docker.sh`.
2. Run `tools/kitu-webtransport-gateway/scripts/check-dev-cert-in-docker.sh`.
3. Confirm both Compose files include the same `PUBLIC_KITU_ADMIN_WT_CERT_SHA256` with `docker compose -f tools/kitu-web-admin/docker-compose.yml config` and `docker compose -f apps/demo-game/docker-compose.yml config`.
4. Start the Web Admin stack: `docker compose -f tools/kitu-web-admin/docker-compose.yml up --build`.
5. Open `http://localhost:5173` in a browser with WebTransport support.
6. Trigger a World action and confirm the browser establishes WebTransport with `https://localhost:9443`; gateway logs should show an accepted WebTransport session.

Browser automation note: the in-app browser connector failed to start earlier in this environment because required sandbox metadata was unavailable, so browser-only verification remains documented for a human run.

## Notes

- This branch is based directly on `origin/develop` per the issue workflow and does not include PR #97 / #86, PR #98 / #89, or PR #99 / #90 changes.
- The workflow does not modify the host OS trust store.
- The gateway Rust 1.88 Docker path remains isolated.