### PR TITLE
Define WebTransport KEP datagram support

### DIFF
--- a/doc/specs/kitu-envelope-protocol.md
+++ b/doc/specs/kitu-envelope-protocol.md
@@ -227,7 +227,36 @@ WebTransport Datagram
 KEP Envelope
 ```
 
-Datagrams should remain within the practical MTU limits of the transport path.
+WebTransport Datagrams are unreliable and unordered. A KEP datagram may be lost,
+duplicated by application retries, or arrive after a newer datagram. Applications
+must not require acknowledgement, ordering, or replay determinism from the
+datagram transport itself.
+
+MVP datagram use is limited to small, loss-tolerant `t = "json"` envelopes such
+as browser-to-gateway telemetry probes or high-frequency preview state where a
+newer update supersedes an older update. OSC command envelopes, authoritative
+runtime input, and any request that mutates persistent state must continue to use
+reliable WebTransport streams or the existing WebSocket path.
+
+Each datagram must fit within the practical path MTU. Implementations should keep
+encoded KEP datagrams at or below 1200 bytes unless a peer-specific limit is
+known and validated through the WebTransport API.
+
+The initial gateway datagram probe route is:
+
+```text
+/gateway/datagram/probe
+```
+
+The gateway may respond with a best-effort JSON acknowledgement datagram on:
+
+```text
+/gateway/datagram/ack
+```
+
+This acknowledgement exists for development smoke validation and diagnostics. It
+does not make datagram delivery reliable and should not be used for gameplay or
+runtime command semantics.
 
 ---
 

--- a/doc/specs/webtransport-gateway.md
+++ b/doc/specs/webtransport-gateway.md
@@ -56,6 +56,21 @@ The client-to-server path uses `t = "osc"` and `p = OSC packet binary`. The gate
 
 The server-to-client path uses `t = "json"` and `p = ServerEvent JSON bytes` with route `/server/event`. This keeps the current `ServerEvent` shape intact while making the transport hop KEP-native in both directions. The WebTransport gateway relays the first KEP JSON response from the internal WebSocket back on the WebTransport response stream.
 
+WebTransport datagrams are enabled only for loss-tolerant KEP JSON envelopes.
+The gateway currently accepts one MessagePack KEP envelope per datagram, rejects
+non-JSON datagram payload types, and leaves OSC command semantics on reliable
+streams or the WebSocket fallback path. The first implemented datagram slice is
+a browser/client-to-gateway probe on `/gateway/datagram/probe`; the gateway
+decodes it and replies with a best-effort KEP JSON acknowledgement datagram on
+`/gateway/datagram/ack`. This path exists to validate the transport mapping and
+development smoke coverage before routing real high-frequency preview updates.
+It must not be used for authoritative runtime input, persistent state mutation,
+or any action where loss or reordering would be user-visible.
+
+Datagram KEP envelopes should stay at or below 1200 encoded bytes unless a
+connection-specific WebTransport limit is checked first. Larger payloads should
+use streams.
+
 ## Docker Compose
 
 Both local compose files include the gateway:
@@ -96,7 +111,8 @@ tools/kitu-webtransport-gateway/scripts/smoke-in-docker.sh
 
 The smoke script starts `demo-game` and `webtransport-gateway`, sends one KEP
 `osc` envelope over a WebTransport bidirectional stream, verifies that a KEP
-`json` response envelope is returned on the response stream, and checks that the
+`json` response envelope is returned on the response stream, sends a KEP
+`json` datagram probe, verifies a KEP `json` datagram ack, and checks that the
 existing application server state contains the spawned `webtransport-smoke`
 object.
 
@@ -148,6 +164,11 @@ WebSocket remains active for:
 
 For OSC sends, the browser tries WebTransport first after the WebTransport session is ready. If that send fails, it falls back to the existing WebSocket JSON send path.
 When WebTransport succeeds, the browser reads a KEP `json` response envelope from the response stream and applies the decoded `ServerEvent`.
+
+Browser datagram use is not part of the authoritative MVP send path. A future
+Web Admin UI may send small loss-tolerant preview or telemetry updates as KEP
+JSON datagrams after it confirms `WebTransportDatagramDuplexStream` support and
+the encoded payload size. It must keep OSC actions on the reliable send path.
 
 ## Implemented KEP support
 
@@ -228,11 +249,14 @@ behavior regardless of transport.
 
 If WebTransport is unavailable, fails TLS verification, or fails while sending, the browser falls back to WebSocket for OSC send attempts.
 
+Datagram failure does not trigger replay or command fallback because datagrams
+must only carry data that can be dropped safely. If a payload needs fallback, it
+belongs on the reliable stream/WebSocket path instead.
+
 ## Follow-up work
 
 - Add a stable development TLS/certificate-hash workflow for browser verification.
 - Keep a persistent internal WebSocket connection per WebTransport session instead of connecting once per stream.
 - Stream multiple app-server KEP responses per WebTransport request if the protocol needs more than one response envelope.
-- Add WebTransport datagram support for high-frequency real-time updates.
 - Add integration tests that run the gateway against a demo-game container.
 - Expand OSC packet support if bundles, blobs, or arrays become required.

--- a/tools/kitu-webtransport-gateway/src/bin/smoke_client.rs
+++ b/tools/kitu-webtransport-gateway/src/bin/smoke_client.rs
@@ -83,6 +83,10 @@ async fn main() -> Result<()> {
 }
 
 async fn send_datagram_probe(connection: &wtransport::Connection) -> Result<()> {
+    connection
+        .send_datagram(b"not a KEP datagram")
+        .context("send invalid KEP datagram probe")?;
+
     let mut envelope = KepEnvelope::json(br#"{"type":"webTransportDatagramProbe"}"#.to_vec());
     envelope.route = Some(KEP_ROUTE_DATAGRAM_PROBE.to_string());
     envelope.correlation_id = Some(1);

--- a/tools/kitu-webtransport-gateway/src/bin/smoke_client.rs
+++ b/tools/kitu-webtransport-gateway/src/bin/smoke_client.rs
@@ -10,6 +10,8 @@ use wtransport::{tls::Sha256Digest, ClientConfig, Endpoint};
 const DEFAULT_URL: &str = "https://webtransport-gateway:9443";
 const DEFAULT_ROUTE: &str = "/room/main";
 const DEFAULT_OBJECT_ID: &str = "webtransport-smoke";
+const KEP_ROUTE_DATAGRAM_PROBE: &str = "/gateway/datagram/probe";
+const KEP_ROUTE_DATAGRAM_ACK: &str = "/gateway/datagram/ack";
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -69,12 +71,62 @@ async fn main() -> Result<()> {
         response_json.get("type").is_some(),
         "expected server event JSON response"
     );
+    send_datagram_probe(&connection).await?;
     connection.close(0u32.into(), b"smoke complete");
     endpoint.wait_idle().await;
 
     println!(
-        "sent WebTransport KEP smoke OSC /admin/world/spawn for {object_id}; received KEP {} response",
+        "sent WebTransport KEP smoke OSC /admin/world/spawn for {object_id}; received KEP {} response and datagram ack",
         response_envelope.payload_type
+    );
+    Ok(())
+}
+
+async fn send_datagram_probe(connection: &wtransport::Connection) -> Result<()> {
+    let mut envelope = KepEnvelope::json(br#"{"type":"webTransportDatagramProbe"}"#.to_vec());
+    envelope.route = Some(KEP_ROUTE_DATAGRAM_PROBE.to_string());
+    envelope.correlation_id = Some(1);
+    envelope.flags = Some(0);
+    let bytes = encode_kep_envelope(&envelope).context("encode KEP datagram probe")?;
+    if let Some(max_datagram_size) = connection.max_datagram_size() {
+        anyhow::ensure!(
+            bytes.len() <= max_datagram_size,
+            "KEP datagram probe is {} bytes, larger than peer limit {}",
+            bytes.len(),
+            max_datagram_size
+        );
+    }
+
+    connection
+        .send_datagram(&bytes)
+        .context("send KEP datagram probe")?;
+
+    let datagram = tokio::time::timeout(Duration::from_secs(2), connection.receive_datagram())
+        .await
+        .context("timeout waiting for KEP datagram ack")?
+        .context("receive KEP datagram ack")?;
+    let ack = decode_kep_envelope(&datagram.payload()).context("decode KEP datagram ack")?;
+    anyhow::ensure!(
+        ack.payload_type == KEP_PAYLOAD_JSON,
+        "expected JSON KEP datagram ack, got {}",
+        ack.payload_type
+    );
+    anyhow::ensure!(
+        ack.route.as_deref() == Some(KEP_ROUTE_DATAGRAM_ACK),
+        "expected KEP datagram ack route {}, got {:?}",
+        KEP_ROUTE_DATAGRAM_ACK,
+        ack.route
+    );
+    anyhow::ensure!(
+        ack.correlation_id == Some(1),
+        "expected KEP datagram ack correlation id 1, got {:?}",
+        ack.correlation_id
+    );
+    let payload: serde_json::Value =
+        serde_json::from_slice(&ack.payload).context("decode KEP datagram ack JSON")?;
+    anyhow::ensure!(
+        payload.get("type").and_then(serde_json::Value::as_str) == Some("webTransportDatagramAck"),
+        "expected webTransportDatagramAck payload, got {payload}"
     );
     Ok(())
 }

--- a/tools/kitu-webtransport-gateway/src/main.rs
+++ b/tools/kitu-webtransport-gateway/src/main.rs
@@ -204,7 +204,18 @@ async fn handle_datagrams(connection: wtransport::Connection) -> Result<()> {
             continue;
         }
 
-        if let Some(response) = handle_datagram_payload(bytes.as_ref())? {
+        let response = match handle_datagram_payload(bytes.as_ref()) {
+            Ok(response) => response,
+            Err(err) => {
+                warn!(
+                    connection_id = connection.stable_id(),
+                    "dropping invalid WebTransport KEP datagram: {err:#}"
+                );
+                continue;
+            }
+        };
+
+        if let Some(response) = response {
             if let Some(max_datagram_size) = connection.max_datagram_size() {
                 if response.len() > max_datagram_size {
                     warn!(

--- a/tools/kitu-webtransport-gateway/src/main.rs
+++ b/tools/kitu-webtransport-gateway/src/main.rs
@@ -1,12 +1,15 @@
 use std::{
     collections::VecDeque,
     env,
+    sync::Arc,
     time::{Duration, Instant},
 };
 
 use anyhow::{Context, Result};
 use futures_util::{SinkExt, StreamExt};
-use kitu_transport::{decode_kep_envelope, KEP_PAYLOAD_JSON, KEP_PAYLOAD_OSC};
+use kitu_transport::{
+    decode_kep_envelope, encode_kep_envelope, KepEnvelope, KEP_PAYLOAD_JSON, KEP_PAYLOAD_OSC,
+};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tracing::{info, warn};
 use wtransport::{Endpoint, Identity, RecvStream, SendStream, ServerConfig};
@@ -14,7 +17,11 @@ use wtransport::{Endpoint, Identity, RecvStream, SendStream, ServerConfig};
 const DEFAULT_BIND_PORT: u16 = 9443;
 const DEFAULT_INTERNAL_WS_URL: &str = "ws://demo-game:8787/ws";
 const MAX_STREAM_BYTES: usize = 64 * 1024;
+const MAX_DATAGRAM_BYTES: usize = 1200;
 const MAX_MESSAGES_PER_SECOND: usize = 240;
+const MAX_DATAGRAMS_PER_SECOND: usize = 240;
+const KEP_ROUTE_DATAGRAM_PROBE: &str = "/gateway/datagram/probe";
+const KEP_ROUTE_DATAGRAM_ACK: &str = "/gateway/datagram/ack";
 
 #[derive(Debug, Clone)]
 struct GatewayConfig {
@@ -56,7 +63,7 @@ async fn main() -> Result<()> {
                             remote = %connection.remote_address(),
                             "accepted WebTransport session"
                         );
-                        handle_connection(connection, config).await;
+                        handle_connection(connection, Arc::new(config)).await;
                     }
                     Err(err) => warn!("failed to accept WebTransport request: {err}"),
                 },
@@ -103,8 +110,15 @@ async fn load_identity(config: &GatewayConfig) -> Result<Identity> {
     }
 }
 
-async fn handle_connection(connection: wtransport::Connection, config: GatewayConfig) {
+async fn handle_connection(connection: wtransport::Connection, config: Arc<GatewayConfig>) {
     let mut recent_messages = VecDeque::new();
+    let connection_id = connection.stable_id();
+    let datagram_connection = connection.clone();
+    let datagram_task = tokio::spawn(async move {
+        if let Err(err) = handle_datagrams(datagram_connection).await {
+            info!(connection_id, "WebTransport datagram loop closed: {err:#}");
+        }
+    });
 
     loop {
         match connection.accept_bi().await {
@@ -119,7 +133,7 @@ async fn handle_connection(connection: wtransport::Connection, config: GatewayCo
                 }
                 recent_messages.push_back(Instant::now());
 
-                let config = config.clone();
+                let config = Arc::clone(&config);
                 tokio::spawn(async move {
                     if let Err(err) = handle_stream(send_stream, recv_stream, config).await {
                         warn!("WebTransport stream relay failed: {err:#}");
@@ -132,12 +146,14 @@ async fn handle_connection(connection: wtransport::Connection, config: GatewayCo
             }
         }
     }
+
+    datagram_task.abort();
 }
 
 async fn handle_stream(
     mut send_stream: SendStream,
     recv_stream: RecvStream,
-    config: GatewayConfig,
+    config: Arc<GatewayConfig>,
 ) -> Result<()> {
     let bytes = read_stream(recv_stream).await?;
     let envelope = decode_kep_envelope(&bytes).context("decode KEP envelope")?;
@@ -159,6 +175,84 @@ async fn handle_stream(
     Ok(())
 }
 
+async fn handle_datagrams(connection: wtransport::Connection) -> Result<()> {
+    let mut recent_datagrams = VecDeque::new();
+
+    loop {
+        let datagram = connection
+            .receive_datagram()
+            .await
+            .context("receive WebTransport datagram")?;
+        prune_rate_window(&mut recent_datagrams);
+        if recent_datagrams.len() >= MAX_DATAGRAMS_PER_SECOND {
+            warn!(
+                connection_id = connection.stable_id(),
+                "dropping WebTransport datagram after rate limit"
+            );
+            continue;
+        }
+        recent_datagrams.push_back(Instant::now());
+
+        let bytes = datagram.payload();
+        if bytes.len() > MAX_DATAGRAM_BYTES {
+            warn!(
+                connection_id = connection.stable_id(),
+                bytes = bytes.len(),
+                max_bytes = MAX_DATAGRAM_BYTES,
+                "dropping oversized WebTransport KEP datagram"
+            );
+            continue;
+        }
+
+        if let Some(response) = handle_datagram_payload(bytes.as_ref())? {
+            if let Some(max_datagram_size) = connection.max_datagram_size() {
+                if response.len() > max_datagram_size {
+                    warn!(
+                        connection_id = connection.stable_id(),
+                        response_bytes = response.len(),
+                        max_datagram_size,
+                        "dropping WebTransport datagram ack larger than peer limit"
+                    );
+                    continue;
+                }
+            }
+            connection
+                .send_datagram(&response)
+                .context("send WebTransport KEP datagram ack")?;
+        }
+    }
+}
+
+fn handle_datagram_payload(bytes: &[u8]) -> Result<Option<Vec<u8>>> {
+    let envelope = decode_kep_envelope(bytes).context("decode KEP datagram envelope")?;
+    if envelope.payload_type != KEP_PAYLOAD_JSON {
+        anyhow::bail!(
+            "unsupported KEP datagram payload type: {}",
+            envelope.payload_type
+        );
+    }
+
+    if envelope.route.as_deref() == Some(KEP_ROUTE_DATAGRAM_PROBE) {
+        return Ok(Some(encode_datagram_ack(&envelope, bytes.len())?));
+    }
+
+    Ok(None)
+}
+
+fn encode_datagram_ack(request: &KepEnvelope, received_bytes: usize) -> Result<Vec<u8>> {
+    let payload = serde_json::to_vec(&serde_json::json!({
+        "type": "webTransportDatagramAck",
+        "receivedRoute": request.route,
+        "receivedBytes": received_bytes,
+    }))
+    .context("encode WebTransport datagram ack JSON")?;
+    let mut response = KepEnvelope::json(payload);
+    response.route = Some(KEP_ROUTE_DATAGRAM_ACK.to_string());
+    response.correlation_id = request.correlation_id;
+    response.flags = Some(0);
+    encode_kep_envelope(&response).context("encode WebTransport datagram ack KEP envelope")
+}
+
 async fn read_stream(mut recv_stream: RecvStream) -> Result<Vec<u8>> {
     let mut bytes = Vec::new();
     let mut chunk = [0; 4096];
@@ -166,11 +260,68 @@ async fn read_stream(mut recv_stream: RecvStream) -> Result<Vec<u8>> {
     while let Some(read) = recv_stream.read(&mut chunk).await.context("read stream")? {
         bytes.extend_from_slice(&chunk[..read]);
         if bytes.len() > MAX_STREAM_BYTES {
-            anyhow::bail!("stream exceeds {} bytes", MAX_STREAM_BYTES);
+            anyhow::bail!("stream exceeds {MAX_STREAM_BYTES} bytes");
         }
     }
 
     Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use kitu_transport::{encode_kep_envelope, KepEnvelope};
+
+    use super::{
+        handle_datagram_payload, KEP_ROUTE_DATAGRAM_ACK, KEP_ROUTE_DATAGRAM_PROBE,
+        MAX_DATAGRAM_BYTES,
+    };
+
+    #[test]
+    fn datagram_probe_returns_json_ack() {
+        let mut request = KepEnvelope::json(br#"{"type":"probe"}"#.to_vec());
+        request.route = Some(KEP_ROUTE_DATAGRAM_PROBE.to_string());
+        request.correlation_id = Some(7);
+        let bytes = encode_kep_envelope(&request).expect("encode probe envelope");
+
+        let ack = handle_datagram_payload(&bytes)
+            .expect("handle datagram")
+            .expect("ack response");
+        assert!(ack.len() <= MAX_DATAGRAM_BYTES);
+
+        let envelope = kitu_transport::decode_kep_envelope(&ack).expect("decode ack envelope");
+        assert_eq!(envelope.payload_type, kitu_transport::KEP_PAYLOAD_JSON);
+        assert_eq!(envelope.route.as_deref(), Some(KEP_ROUTE_DATAGRAM_ACK));
+        assert_eq!(envelope.correlation_id, Some(7));
+
+        let json: serde_json::Value =
+            serde_json::from_slice(&envelope.payload).expect("decode ack JSON");
+        assert_eq!(json["type"], "webTransportDatagramAck");
+        assert_eq!(json["receivedRoute"], KEP_ROUTE_DATAGRAM_PROBE);
+    }
+
+    #[test]
+    fn datagram_json_on_non_probe_route_is_receive_only() {
+        let mut request = KepEnvelope::json(br#"{"type":"telemetry"}"#.to_vec());
+        request.route = Some("/client/telemetry".to_string());
+        let bytes = encode_kep_envelope(&request).expect("encode telemetry envelope");
+
+        let ack = handle_datagram_payload(&bytes).expect("handle datagram");
+
+        assert!(ack.is_none());
+    }
+
+    #[test]
+    fn datagram_rejects_reliable_osc_commands() {
+        let mut request = KepEnvelope::osc(vec![0, 1, 2, 3]);
+        request.route = Some("/room/main".to_string());
+        let bytes = encode_kep_envelope(&request).expect("encode OSC envelope");
+
+        let err = handle_datagram_payload(&bytes).expect_err("OSC commands stay reliable");
+
+        assert!(err
+            .to_string()
+            .contains("unsupported KEP datagram payload type"));
+    }
 }
 
 async fn relay_kep_envelope(internal_ws_url: &str, bytes: Vec<u8>) -> Result<Option<Vec<u8>>> {


### PR DESCRIPTION
## Summary

- Documents the MVP WebTransport Datagram mapping for KEP, including reliability, ordering, MTU, and when not to use datagrams.
- Adds a gateway datagram receive loop for loss-tolerant `t = "json"` KEP envelopes.
- Implements a development probe route (`/gateway/datagram/probe`) and best-effort ack route (`/gateway/datagram/ack`) so Docker smoke can prove send/decode/receive behavior.
- Extends the gateway smoke client to send a KEP datagram probe and require a KEP JSON datagram ack.

## Boundaries

- OSC command envelopes remain on reliable WebTransport streams or WebSocket fallback.
- `/ws/runtime` remains the MVP authoritative WebSocket path.
- This PR is based directly on `origin/develop` for issue #92 and does not include the earlier independent WebTransport PRs.

Fixes #92

## Verification

- `devcontainer exec --workspace-folder . cargo fmt --all --check`
- `devcontainer exec --workspace-folder . cargo test -p kitu-transport -p kitu-demo-game`
- `devcontainer exec --workspace-folder . cargo clippy -p kitu-transport -p kitu-demo-game --all-targets -- -D warnings`
- `docker run --rm -v /Users/mujina/MujinaProd/kitu-workspace/kitu-logic-processor:/workspace -w /workspace/tools/kitu-webtransport-gateway rust:1.88-bookworm cargo fmt -- --check`
- `docker run --rm -v /Users/mujina/MujinaProd/kitu-workspace/kitu-logic-processor:/workspace -w /workspace/tools/kitu-webtransport-gateway rust:1.88-bookworm cargo test --locked --bins`
- `docker run --rm -v /Users/mujina/MujinaProd/kitu-workspace/kitu-logic-processor:/workspace -w /workspace/tools/kitu-webtransport-gateway rust:1.88-bookworm sh -eu -c 'rustup component add clippy >/dev/null && cargo clippy --locked --bins -- -D warnings'`
- `tools/kitu-webtransport-gateway/scripts/check-in-docker.sh`
- `tools/kitu-webtransport-gateway/scripts/smoke-in-docker.sh`

Smoke result included:

```text
sent WebTransport KEP smoke OSC /admin/world/spawn for webtransport-smoke; received KEP json response and datagram ack
WebTransport gateway smoke test passed.
```
