### PR TITLE
Add WebTransport gateway Docker integration test

### DIFF
--- a/doc/specs/webtransport-gateway.md
+++ b/doc/specs/webtransport-gateway.md
@@ -100,6 +100,23 @@ The smoke script starts `demo-game` and `webtransport-gateway`, sends one KEP
 existing application server state contains the spawned `webtransport-smoke`
 object.
 
+Gateway Docker integration validation can be run from the repository root:
+
+```sh
+tools/kitu-webtransport-gateway/scripts/integration-in-docker.sh
+```
+
+The integration script starts the same `demo-game` and `webtransport-gateway`
+containers, verifies the successful KEP OSC request and KEP JSON response path,
+then sends invalid KEP bytes and an unsupported `t = "json"` stream request to
+confirm the gateway rejects validation failures without producing a successful
+response. It also checks that the existing application server state contains the
+spawned `webtransport-integration` object.
+
+Use the smoke script for a quick local health check. Use the integration script
+when changing gateway validation, relay behavior, stream handling, TLS setup, or
+Docker wiring, and before wiring these checks into CI.
+
 ## TLS notes
 
 WebTransport requires TLS because it runs over HTTP/3 and QUIC.

--- a/tools/kitu-webtransport-gateway/Cargo.toml
+++ b/tools/kitu-webtransport-gateway/Cargo.toml
@@ -16,6 +16,10 @@ path = "src/main.rs"
 name = "kitu-webtransport-gateway-smoke-client"
 path = "src/bin/smoke_client.rs"
 
+[[bin]]
+name = "kitu-webtransport-gateway-integration-client"
+path = "src/bin/integration_client.rs"
+
 [dependencies]
 anyhow = "1"
 futures-util = "0.3"

--- a/tools/kitu-webtransport-gateway/scripts/integration-in-docker.sh
+++ b/tools/kitu-webtransport-gateway/scripts/integration-in-docker.sh
@@ -21,6 +21,21 @@ for attempt in $(seq 1 60); do
   sleep 1
 done
 
+for attempt in $(seq 1 60); do
+  if docker compose -f "$compose_file" run --rm \
+    -e KITU_WT_INTEGRATION_URL=https://webtransport-gateway:9443 \
+    -e KITU_WT_INTEGRATION_READY_ONLY=1 \
+    webtransport-gateway \
+    cargo run --locked --bin kitu-webtransport-gateway-integration-client >/dev/null 2>&1; then
+    break
+  fi
+  if [ "$attempt" -eq 60 ]; then
+    printf "%s\n" "webtransport-gateway did not become ready." >&2
+    exit 1
+  fi
+  sleep 1
+done
+
 docker compose -f "$compose_file" run --rm \
   -e KITU_WT_INTEGRATION_URL=https://webtransport-gateway:9443 \
   -e KITU_WT_INTEGRATION_OBJECT_ID=webtransport-integration \

--- a/tools/kitu-webtransport-gateway/scripts/integration-in-docker.sh
+++ b/tools/kitu-webtransport-gateway/scripts/integration-in-docker.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)"
+compose_file="$repo_root/apps/demo-game/docker-compose.yml"
+
+if [ ! -f "$repo_root/tools/kitu-webtransport-gateway/certs/webtransport.env" ]; then
+  "$repo_root/tools/kitu-webtransport-gateway/scripts/generate-dev-cert-in-docker.sh"
+fi
+
+docker compose -f "$compose_file" up -d --build --force-recreate demo-game webtransport-gateway
+
+for attempt in $(seq 1 60); do
+  if curl -fsS http://localhost:8787/health >/dev/null 2>&1; then
+    break
+  fi
+  if [ "$attempt" -eq 60 ]; then
+    printf "%s\n" "demo-game did not become healthy." >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+docker compose -f "$compose_file" run --rm \
+  -e KITU_WT_INTEGRATION_URL=https://webtransport-gateway:9443 \
+  -e KITU_WT_INTEGRATION_OBJECT_ID=webtransport-integration \
+  webtransport-gateway \
+  cargo run --locked --bin kitu-webtransport-gateway-integration-client
+
+curl -fsS http://localhost:8787/state \
+  | grep -q '"kind":"webtransport-integration"'
+
+printf "%s\n" "WebTransport gateway Docker integration test passed."

--- a/tools/kitu-webtransport-gateway/src/bin/integration_client.rs
+++ b/tools/kitu-webtransport-gateway/src/bin/integration_client.rs
@@ -1,0 +1,151 @@
+use std::{env, time::Duration};
+
+use anyhow::{Context, Result};
+use kitu_osc_ir::{OscArg, OscMessage};
+use kitu_transport::{
+    decode_kep_envelope, encode_kep_envelope, encode_osc_packet, KepEnvelope, KEP_PAYLOAD_JSON,
+};
+use wtransport::{tls::Sha256Digest, ClientConfig, Connection, Endpoint, RecvStream};
+
+const DEFAULT_URL: &str = "https://webtransport-gateway:9443";
+const DEFAULT_ROUTE: &str = "/room/main";
+const DEFAULT_OBJECT_ID: &str = "webtransport-integration";
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let url = env::var("KITU_WT_INTEGRATION_URL").unwrap_or_else(|_| DEFAULT_URL.to_string());
+    let cert_hash = env::var("PUBLIC_KITU_ADMIN_WT_CERT_SHA256")
+        .or_else(|_| env::var("KITU_WT_SMOKE_CERT_SHA256"))
+        .context("PUBLIC_KITU_ADMIN_WT_CERT_SHA256 or KITU_WT_SMOKE_CERT_SHA256 is required")?;
+    let route = env::var("KITU_WT_INTEGRATION_ROUTE").unwrap_or_else(|_| DEFAULT_ROUTE.to_string());
+    let object_id =
+        env::var("KITU_WT_INTEGRATION_OBJECT_ID").unwrap_or_else(|_| DEFAULT_OBJECT_ID.to_string());
+
+    let client_config = ClientConfig::builder()
+        .with_bind_default()
+        .with_server_certificate_hashes([parse_sha256_digest(&cert_hash)?])
+        .keep_alive_interval(Some(Duration::from_secs(2)))
+        .build();
+    let endpoint = Endpoint::client(client_config)?;
+    let connection = endpoint
+        .connect(url.as_str())
+        .await
+        .with_context(|| format!("connect WebTransport {url}"))?;
+
+    expect_spawn_response(&connection, &route, &object_id).await?;
+    expect_no_response(
+        &connection,
+        b"not a KEP MessagePack envelope",
+        "invalid KEP",
+    )
+    .await?;
+    expect_no_response(
+        &connection,
+        &unsupported_payload_envelope()?,
+        "unsupported KEP payload type",
+    )
+    .await?;
+
+    connection.close(0u32.into(), b"integration complete");
+    endpoint.wait_idle().await;
+
+    println!(
+        "WebTransport gateway integration passed: valid KEP relay plus invalid envelope and unsupported payload validation"
+    );
+    Ok(())
+}
+
+async fn expect_spawn_response(
+    connection: &Connection,
+    route: &str,
+    object_id: &str,
+) -> Result<()> {
+    let mut message = OscMessage::new("/admin/world/spawn");
+    message.push_arg(OscArg::Str(object_id.to_string()));
+    message.push_arg(OscArg::Float(1.0));
+    message.push_arg(OscArg::Float(2.0));
+    message.push_arg(OscArg::Float(3.0));
+
+    let osc_packet = encode_osc_packet(&message).context("encode OSC packet")?;
+    let mut envelope = KepEnvelope::osc(osc_packet);
+    envelope.route = Some(route.to_string());
+    envelope.flags = Some(0);
+    let response = send_request(connection, &encode_kep_envelope(&envelope)?)
+        .await?
+        .context("expected KEP response for valid OSC request")?;
+    let response_envelope = decode_kep_envelope(&response).context("decode KEP response")?;
+    anyhow::ensure!(
+        response_envelope.payload_type == KEP_PAYLOAD_JSON,
+        "expected JSON KEP response, got {}",
+        response_envelope.payload_type
+    );
+    let response_json: serde_json::Value =
+        serde_json::from_slice(&response_envelope.payload).context("decode KEP response JSON")?;
+    anyhow::ensure!(
+        response_json.get("type").is_some(),
+        "expected server event JSON response"
+    );
+    Ok(())
+}
+
+async fn expect_no_response(connection: &Connection, bytes: &[u8], label: &str) -> Result<()> {
+    let response = send_request(connection, bytes).await?;
+    anyhow::ensure!(
+        response.is_none(),
+        "{label} unexpectedly produced a WebTransport response"
+    );
+    Ok(())
+}
+
+async fn send_request(connection: &Connection, bytes: &[u8]) -> Result<Option<Vec<u8>>> {
+    let (mut send_stream, recv_stream) = connection.open_bi().await?.await?;
+    send_stream.write_all(bytes).await?;
+    send_stream.finish().await?;
+    read_optional_response(recv_stream).await
+}
+
+async fn read_optional_response(mut recv_stream: RecvStream) -> Result<Option<Vec<u8>>> {
+    let mut response = Vec::new();
+    let mut chunk = [0; 4096];
+    let result = tokio::time::timeout(Duration::from_secs(2), async {
+        while let Some(read) = recv_stream.read(&mut chunk).await? {
+            response.extend_from_slice(&chunk[..read]);
+        }
+        Ok::<(), wtransport::error::StreamReadError>(())
+    })
+    .await;
+
+    match result {
+        Ok(Ok(())) => Ok((!response.is_empty()).then_some(response)),
+        Ok(Err(err)) if response.is_empty() => {
+            tracing::debug!("validation stream closed while reading expected failure: {err}");
+            Ok(None)
+        }
+        Ok(Err(err)) => Err(err).context("read WebTransport response"),
+        Err(_) if response.is_empty() => Ok(None),
+        Err(_) => Ok(Some(response)),
+    }
+}
+
+fn unsupported_payload_envelope() -> Result<Vec<u8>> {
+    let mut envelope = KepEnvelope::json(br#"{"type":"not-an-osc-command"}"#.to_vec());
+    envelope.route = Some(DEFAULT_ROUTE.to_string());
+    envelope.flags = Some(0);
+    encode_kep_envelope(&envelope).context("encode unsupported KEP envelope")
+}
+
+fn parse_sha256_digest(value: &str) -> Result<Sha256Digest> {
+    let normalized = value.replace(|character: char| !character.is_ascii_hexdigit(), "");
+    anyhow::ensure!(
+        normalized.len() == 64,
+        "certificate SHA-256 hash must be 64 hex chars"
+    );
+
+    let mut bytes = [0u8; 32];
+    for (index, byte) in bytes.iter_mut().enumerate() {
+        let start = index * 2;
+        *byte = u8::from_str_radix(&normalized[start..start + 2], 16)
+            .context("parse certificate SHA-256 hash")?;
+    }
+    Ok(Sha256Digest::new(bytes))
+}

--- a/tools/kitu-webtransport-gateway/src/bin/integration_client.rs
+++ b/tools/kitu-webtransport-gateway/src/bin/integration_client.rs
@@ -31,6 +31,12 @@ async fn main() -> Result<()> {
         .connect(url.as_str())
         .await
         .with_context(|| format!("connect WebTransport {url}"))?;
+    if env::var("KITU_WT_INTEGRATION_READY_ONLY").as_deref() == Ok("1") {
+        connection.close(0u32.into(), b"readiness complete");
+        endpoint.wait_idle().await;
+        println!("WebTransport gateway readiness check passed");
+        return Ok(());
+    }
 
     expect_spawn_response(&connection, &route, &object_id).await?;
     expect_no_response(

--- a/tools/kitu-webtransport-gateway/src/bin/integration_client.rs
+++ b/tools/kitu-webtransport-gateway/src/bin/integration_client.rs
@@ -128,7 +128,9 @@ async fn read_optional_response(mut recv_stream: RecvStream) -> Result<Option<Ve
             Ok(None)
         }
         Ok(Err(err)) => Err(err).context("read WebTransport response"),
-        Err(_) if response.is_empty() => Ok(None),
+        Err(_) if response.is_empty() => {
+            anyhow::bail!("timed out waiting for validation stream to close")
+        }
         Err(_) => Ok(Some(response)),
     }
 }

--- a/tools/kitu-webtransport-gateway/src/main.rs
+++ b/tools/kitu-webtransport-gateway/src/main.rs
@@ -166,7 +166,7 @@ async fn read_stream(mut recv_stream: RecvStream) -> Result<Vec<u8>> {
     while let Some(read) = recv_stream.read(&mut chunk).await.context("read stream")? {
         bytes.extend_from_slice(&chunk[..read]);
         if bytes.len() > MAX_STREAM_BYTES {
-            anyhow::bail!("stream exceeds {} bytes", MAX_STREAM_BYTES);
+            anyhow::bail!("stream exceeds {MAX_STREAM_BYTES} bytes");
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds `tools/kitu-webtransport-gateway/scripts/integration-in-docker.sh` as a Docker-first gateway + demo-game integration command.
- Adds `kitu-webtransport-gateway-integration-client` to verify a successful KEP OSC request / KEP JSON response, invalid KEP bytes, and unsupported stream payload validation.
- Documents when to use the quick smoke check versus the richer integration command.

## Boundaries

- This PR is based directly on `origin/develop` for issue #94.
- Because #86 and #92 are still separate draft PRs, this covers the current develop stream relay path and validation failures. Multi-response framing and datagram cases can be folded into this command after those PRs land.
- No browser automation is added; this stays Docker/Compose-only as requested.

Fixes #94

## Verification

- `tools/kitu-webtransport-gateway/scripts/check-in-docker.sh`
- `tools/kitu-webtransport-gateway/scripts/smoke-in-docker.sh`
- `tools/kitu-webtransport-gateway/scripts/integration-in-docker.sh`
- `docker run --rm -v /Users/mujina/MujinaProd/kitu-workspace/kitu-logic-processor:/workspace -w /workspace/tools/kitu-webtransport-gateway rust:1.88-bookworm cargo fmt -- --check`
- `docker run --rm -v /Users/mujina/MujinaProd/kitu-workspace/kitu-logic-processor:/workspace -w /workspace/tools/kitu-webtransport-gateway rust:1.88-bookworm cargo test --locked --bins`
- `docker run --rm -v /Users/mujina/MujinaProd/kitu-workspace/kitu-logic-processor:/workspace -w /workspace/tools/kitu-webtransport-gateway rust:1.88-bookworm sh -eu -c 'rustup component add clippy >/dev/null && cargo clippy --locked --bins -- -D warnings'`

Integration result included:

```text
WebTransport gateway integration passed: valid KEP relay plus invalid envelope and unsupported payload validation
WebTransport gateway Docker integration test passed.
```

Smoke result included:

```text
sent WebTransport KEP smoke OSC /admin/world/spawn for webtransport-smoke; received KEP json response
WebTransport gateway smoke test passed.
```
