### PR TITLE
Add OSC bundle packet support

### DIFF
--- a/crates/kitu-transport/README.md
+++ b/crates/kitu-transport/README.md
@@ -7,6 +7,37 @@ Transport abstraction and adapters for moving OSC/IR messages between the runtim
 - Provide composable adapters (in-memory, network, etc.) without dictating routing policies.
 - Keep the runtime deterministic by clearly separating transport concerns from game logic.
 
+## KEP and OSC helpers
+
+`kitu-transport` provides MessagePack KEP helpers:
+
+- `KepEnvelope`
+- `encode_kep_envelope`
+- `decode_kep_envelope`
+
+It also provides OSC packet helpers for the OSC-IR model:
+
+- `encode_osc_packet`
+- `decode_osc_packet`
+- `encode_osc_bundle`
+- `decode_osc_bundle`
+
+Supported OSC message argument types:
+
+- `i`: int32
+- `h`: int64
+- `f`: float32
+- `s`: string
+- `T` / `F`: bool
+
+Supported OSC packet shapes:
+
+- Single OSC messages.
+- OSC bundles containing message elements with the immediate timetag.
+
+Nested OSC bundles, blobs, arrays, and additional scalar tags remain unsupported
+until a concrete Kitu client or runtime path requires them.
+
 ## Publish readiness
 - Status: internal-only (`publish = false`) while the MVP takes shape; metadata now aligns with crates.io requirements.
 - Before enabling publication, run the workspace gates:

--- a/crates/kitu-transport/src/lib.rs
+++ b/crates/kitu-transport/src/lib.rs
@@ -249,6 +249,16 @@ pub fn decode_osc_bundle(bytes: &[u8]) -> std::result::Result<OscBundle, KepCode
     if bytes.get(..8) != Some(OSC_BUNDLE_HEADER) {
         return Err(KepCodecError::InvalidOsc("missing OSC bundle header"));
     }
+    let timetag = u64::from_be_bytes(
+        bytes[8..16]
+            .try_into()
+            .expect("bundle timetag length checked"),
+    );
+    if timetag != OSC_IMMEDIATE_TIMETAG {
+        return Err(KepCodecError::InvalidOsc(
+            "non-immediate OSC bundle timetags are not supported",
+        ));
+    }
 
     let mut offset = 16;
     let mut bundle = OscBundle::new();
@@ -529,6 +539,19 @@ mod tests {
         assert!(err
             .to_string()
             .contains("nested OSC bundles are not supported"));
+    }
+
+    #[test]
+    fn osc_bundle_rejects_non_immediate_timetag() {
+        let mut encoded = Vec::new();
+        encoded.extend_from_slice(OSC_BUNDLE_HEADER);
+        encoded.extend_from_slice(&2_u64.to_be_bytes());
+
+        let err = decode_osc_bundle(&encoded).expect_err("non-immediate timetag should fail");
+
+        assert!(err
+            .to_string()
+            .contains("non-immediate OSC bundle timetags are not supported"));
     }
 
     #[test]

--- a/crates/kitu-transport/src/lib.rs
+++ b/crates/kitu-transport/src/lib.rs
@@ -16,6 +16,9 @@ use kitu_osc_ir::{OscArg, OscBundle, OscMessage};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+const OSC_BUNDLE_HEADER: &[u8; 8] = b"#bundle\0";
+const OSC_IMMEDIATE_TIMETAG: u64 = 1;
+
 /// Payload type used for OSC packet binaries inside KEP envelopes.
 pub const KEP_PAYLOAD_OSC: &str = "osc";
 /// Payload type used for UTF-8 JSON bytes inside KEP envelopes.
@@ -131,6 +134,44 @@ pub fn encode_osc_packet(message: &OscMessage) -> std::result::Result<Vec<u8>, K
     Ok(bytes)
 }
 
+/// Encodes an OSC-IR bundle into an OSC bundle packet binary.
+///
+/// Kitu currently models bundle scheduling outside the OSC payload, so encoded
+/// bundles use the OSC immediate timetag. Nested bundles are not represented by
+/// [`OscBundle`] and are therefore not emitted by this helper.
+///
+/// # Examples
+///
+/// ```
+/// use kitu_osc_ir::{OscArg, OscBundle, OscMessage};
+/// use kitu_transport::{decode_osc_bundle, encode_osc_bundle};
+///
+/// let mut message = OscMessage::new("/input/move");
+/// message.push_arg(OscArg::Float(1.0));
+///
+/// let mut bundle = OscBundle::new();
+/// bundle.push(message);
+///
+/// let bytes = encode_osc_bundle(&bundle).expect("encode bundle");
+/// let decoded = decode_osc_bundle(&bytes).expect("decode bundle");
+/// assert_eq!(decoded.messages.len(), 1);
+/// ```
+pub fn encode_osc_bundle(bundle: &OscBundle) -> std::result::Result<Vec<u8>, KepCodecError> {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(OSC_BUNDLE_HEADER);
+    bytes.extend_from_slice(&OSC_IMMEDIATE_TIMETAG.to_be_bytes());
+
+    for message in &bundle.messages {
+        let packet = encode_osc_packet(message)?;
+        let packet_len = i32::try_from(packet.len())
+            .map_err(|_| KepCodecError::InvalidOsc("bundle element is too large"))?;
+        bytes.extend_from_slice(&packet_len.to_be_bytes());
+        bytes.extend_from_slice(&packet);
+    }
+
+    Ok(bytes)
+}
+
 /// Decodes a single OSC packet binary into an OSC-IR message.
 pub fn decode_osc_packet(bytes: &[u8]) -> std::result::Result<OscMessage, KepCodecError> {
     let (address, mut offset) = read_osc_string(bytes, 0)?;
@@ -180,6 +221,58 @@ pub fn decode_osc_packet(bytes: &[u8]) -> std::result::Result<OscMessage, KepCod
     }
 
     Ok(message)
+}
+
+/// Decodes an OSC bundle packet binary into an OSC-IR bundle.
+///
+/// This helper accepts bundles containing message elements. Nested bundle
+/// elements are rejected until `OscBundle` grows an explicit nested-bundle
+/// representation.
+///
+/// # Examples
+///
+/// ```
+/// use kitu_osc_ir::{OscBundle, OscMessage};
+/// use kitu_transport::{decode_osc_bundle, encode_osc_bundle};
+///
+/// let mut bundle = OscBundle::new();
+/// bundle.push(OscMessage::new("/tick"));
+///
+/// let bytes = encode_osc_bundle(&bundle).expect("encode bundle");
+/// let decoded = decode_osc_bundle(&bytes).expect("decode bundle");
+/// assert_eq!(decoded.messages[0].address, "/tick");
+/// ```
+pub fn decode_osc_bundle(bytes: &[u8]) -> std::result::Result<OscBundle, KepCodecError> {
+    if bytes.len() < 16 {
+        return Err(KepCodecError::InvalidOsc("bundle packet is too short"));
+    }
+    if bytes.get(..8) != Some(OSC_BUNDLE_HEADER) {
+        return Err(KepCodecError::InvalidOsc("missing OSC bundle header"));
+    }
+
+    let mut offset = 16;
+    let mut bundle = OscBundle::new();
+    while offset < bytes.len() {
+        let element_len = read_i32(bytes, offset)?;
+        offset += 4;
+        let element_len = usize::try_from(element_len)
+            .map_err(|_| KepCodecError::InvalidOsc("bundle element size is negative"))?;
+        let element_end = offset
+            .checked_add(element_len)
+            .ok_or(KepCodecError::InvalidOsc("bundle element size overflows"))?;
+        let element = bytes
+            .get(offset..element_end)
+            .ok_or(KepCodecError::InvalidOsc("bundle element is truncated"))?;
+        if element.get(..8) == Some(OSC_BUNDLE_HEADER) {
+            return Err(KepCodecError::InvalidOsc(
+                "nested OSC bundles are not supported",
+            ));
+        }
+        bundle.push(decode_osc_packet(element)?);
+        offset = element_end;
+    }
+
+    Ok(bundle)
 }
 
 fn write_osc_string(bytes: &mut Vec<u8>, value: &str) {
@@ -382,5 +475,71 @@ mod tests {
         let decoded = decode_osc_packet(&encoded).expect("decode OSC packet");
 
         assert_eq!(decoded, message);
+    }
+
+    #[test]
+    fn osc_bundle_round_trips_messages() {
+        let mut first = OscMessage::new("/input/move");
+        first.push_arg(OscArg::Str("player:local".to_string()));
+        first.push_arg(OscArg::Float(1.0));
+
+        let mut second = OscMessage::new("/input/jump");
+        second.push_arg(OscArg::Bool(true));
+
+        let mut bundle = OscBundle::new();
+        bundle.push(first);
+        bundle.push(second);
+
+        let encoded = encode_osc_bundle(&bundle).expect("encode OSC bundle");
+        assert_eq!(&encoded[..8], OSC_BUNDLE_HEADER);
+        assert_eq!(
+            u64::from_be_bytes(encoded[8..16].try_into().expect("timetag bytes")),
+            OSC_IMMEDIATE_TIMETAG
+        );
+
+        let decoded = decode_osc_bundle(&encoded).expect("decode OSC bundle");
+
+        assert_eq!(decoded, bundle);
+    }
+
+    #[test]
+    fn osc_bundle_rejects_truncated_element() {
+        let mut encoded = Vec::new();
+        encoded.extend_from_slice(OSC_BUNDLE_HEADER);
+        encoded.extend_from_slice(&OSC_IMMEDIATE_TIMETAG.to_be_bytes());
+        encoded.extend_from_slice(&64_i32.to_be_bytes());
+        encoded.extend_from_slice(b"/a\0\0");
+
+        let err = decode_osc_bundle(&encoded).expect_err("truncated element should fail");
+
+        assert!(err.to_string().contains("bundle element is truncated"));
+    }
+
+    #[test]
+    fn osc_bundle_rejects_nested_bundle_elements() {
+        let nested = encode_osc_bundle(&OscBundle::new()).expect("encode nested bundle");
+        let mut encoded = Vec::new();
+        encoded.extend_from_slice(OSC_BUNDLE_HEADER);
+        encoded.extend_from_slice(&OSC_IMMEDIATE_TIMETAG.to_be_bytes());
+        encoded.extend_from_slice(&(nested.len() as i32).to_be_bytes());
+        encoded.extend_from_slice(&nested);
+
+        let err = decode_osc_bundle(&encoded).expect_err("nested bundle should fail");
+
+        assert!(err
+            .to_string()
+            .contains("nested OSC bundles are not supported"));
+    }
+
+    #[test]
+    fn osc_bundle_rejects_negative_element_size() {
+        let mut encoded = Vec::new();
+        encoded.extend_from_slice(OSC_BUNDLE_HEADER);
+        encoded.extend_from_slice(&OSC_IMMEDIATE_TIMETAG.to_be_bytes());
+        encoded.extend_from_slice(&(-1_i32).to_be_bytes());
+
+        let err = decode_osc_bundle(&encoded).expect_err("negative element size should fail");
+
+        assert!(err.to_string().contains("bundle element size is negative"));
     }
 }

--- a/crates/kitu-transport/src/lib.rs
+++ b/crates/kitu-transport/src/lib.rs
@@ -174,6 +174,16 @@ pub fn encode_osc_bundle(bundle: &OscBundle) -> std::result::Result<Vec<u8>, Kep
 
 /// Decodes a single OSC packet binary into an OSC-IR message.
 pub fn decode_osc_packet(bytes: &[u8]) -> std::result::Result<OscMessage, KepCodecError> {
+    let (message, offset) = decode_osc_packet_with_offset(bytes)?;
+    if offset != bytes.len() {
+        return Err(KepCodecError::InvalidOsc("OSC packet has trailing bytes"));
+    }
+    Ok(message)
+}
+
+fn decode_osc_packet_with_offset(
+    bytes: &[u8],
+) -> std::result::Result<(OscMessage, usize), KepCodecError> {
     let (address, mut offset) = read_osc_string(bytes, 0)?;
     if address.is_empty() {
         return Err(KepCodecError::InvalidOsc("address must not be empty"));
@@ -220,7 +230,7 @@ pub fn decode_osc_packet(bytes: &[u8]) -> std::result::Result<OscMessage, KepCod
         return Err(KepCodecError::InvalidOsc("packet ended before arguments"));
     }
 
-    Ok(message)
+    Ok((message, offset))
 }
 
 /// Decodes an OSC bundle packet binary into an OSC-IR bundle.
@@ -552,6 +562,23 @@ mod tests {
         assert!(err
             .to_string()
             .contains("non-immediate OSC bundle timetags are not supported"));
+    }
+
+    #[test]
+    fn osc_bundle_rejects_trailing_bytes_inside_element() {
+        let message = encode_osc_packet(&OscMessage::new("/tick")).expect("encode OSC packet");
+        let mut element = message.clone();
+        element.extend_from_slice(&[0, 0, 0, 0]);
+
+        let mut encoded = Vec::new();
+        encoded.extend_from_slice(OSC_BUNDLE_HEADER);
+        encoded.extend_from_slice(&OSC_IMMEDIATE_TIMETAG.to_be_bytes());
+        encoded.extend_from_slice(&(element.len() as i32).to_be_bytes());
+        encoded.extend_from_slice(&element);
+
+        let err = decode_osc_bundle(&encoded).expect_err("trailing bytes should fail");
+
+        assert!(err.to_string().contains("OSC packet has trailing bytes"));
     }
 
     #[test]

--- a/doc/specs/kitu-envelope-protocol.md
+++ b/doc/specs/kitu-envelope-protocol.md
@@ -141,13 +141,18 @@ Applications may define additional meanings.
 
 Contains the serialized payload.
 
-For OSC messages:
+For OSC messages or OSC bundles:
 
 ```text
 p = OSC Packet Binary
 ```
 
-The OSC payload remains unmodified and follows standard OSC encoding rules.
+The OSC payload remains unmodified and follows standard OSC encoding rules. The
+current Rust helpers support single OSC messages and OSC bundles containing
+message elements. Bundle helpers use the OSC immediate timetag because Kitu
+currently models scheduling outside the OSC payload. Nested bundles, blobs,
+arrays, and additional scalar tags are intentionally left unsupported until a
+concrete client requires them.
 
 For JSON messages:
 

--- a/doc/specs/webtransport-gateway.md
+++ b/doc/specs/webtransport-gateway.md
@@ -158,6 +158,8 @@ When WebTransport succeeds, the browser reads a KEP `json` response envelope fro
 - `decode_kep_envelope`
 - `encode_osc_packet`
 - `decode_osc_packet`
+- `encode_osc_bundle`
+- `decode_osc_bundle`
 
 Supported OSC packet argument types:
 
@@ -166,6 +168,14 @@ Supported OSC packet argument types:
 - `f`: float32
 - `s`: string
 - `T` / `F`: bool
+
+Supported OSC packet shapes:
+
+- Single OSC messages.
+- OSC bundles containing message elements with the immediate timetag.
+
+Nested OSC bundles, blobs, arrays, and additional scalar tags are not supported
+until a concrete Web Admin, runtime, Unity, or replay path requires them.
 
 `apps/demo-game/src/bin/admin_host.rs` accepts KEP on the existing WebSocket endpoints:
 


### PR DESCRIPTION
## Summary

- Adds `encode_osc_bundle` and `decode_osc_bundle` to `kitu-transport`.
- Supports OSC bundles containing message elements with the OSC immediate timetag.
- Adds valid and invalid bundle tests, including truncated elements, nested bundles, and negative element sizes.
- Documents current OSC packet coverage in `crates/kitu-transport/README.md`, KEP docs, and the WebTransport gateway spec.

## Scope Decision

The actual near-term Kitu need is bundle packet support: the runtime and transport model already use `OscBundle`, while the wire helper only handled single OSC messages.

Blob and array support would require expanding `kitu_osc_ir::OscArg` plus JSON/WASM/admin conversions. No current Web Admin, runtime, Unity, or replay consumer requires those tags yet, so this PR documents them as intentionally unsupported until a concrete client path needs them.

Fixes #95

## Verification

- `devcontainer exec --workspace-folder . cargo fmt --all --check`
- `devcontainer exec --workspace-folder . cargo test -p kitu-transport`
- `devcontainer exec --workspace-folder . cargo clippy -p kitu-transport --all-targets -- -D warnings`

No gateway/demo-game consumer changed in this PR, so the additional gateway smoke/integration path was not required.
