### PR TITLE
chore: ignore OS junk files

### DIFF
--- a/kitu-integration-runner/unity-demo-game/.gitignore
+++ b/kitu-integration-runner/unity-demo-game/.gitignore
@@ -9,6 +9,17 @@
 /kitu-unity-demo-game/MemoryCaptures/
 /kitu-unity-demo-game/Recordings/
 
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+.AppleDouble
+ehthumbs.db
+Thumbs.db
+desktop.ini
+
 # Unity-generated IDE/project files.
 /kitu-unity-demo-game/.vscode/
 /kitu-unity-demo-game/*.csproj

--- a/tools/kitu-web-admin/frontend/.gitignore
+++ b/tools/kitu-web-admin/frontend/.gitignore
@@ -6,3 +6,14 @@ dist
 .env
 .env.*
 !.env.example
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+.AppleDouble
+ehthumbs.db
+Thumbs.db
+desktop.ini


### PR DESCRIPTION
## Summary
- Add OS-generated files to .gitignore in demo-game and web-admin frontend.
- Covers `.DS_Store`, `._*`, `.AppleDouble`, `.Spotlight-V100`, `.Trashes`, `Thumbs.db`, `ehthumbs.db`, `desktop.ini`.