### PR TITLE
Document architecture decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Implementation status:
 - The current repository contains the MVP runtime core, the player-move vertical slice, and early replay/tooling foundations.
 - Several data/content and tooling sections below describe target architecture rather than finished production features.
 - For the current implemented/partial/staged breakdown, use [doc/architecture.md](doc/architecture.md#current-implementation-staging).
+- For the rationale and tradeoffs behind accepted cross-cutting choices, use
+  the [architecture decision records](doc/adr/README.md).
 
 
 ## High-Level Architecture

--- a/doc/adr/0001-keep-authoritative-gameplay-in-the-rust-runtime.md
+++ b/doc/adr/0001-keep-authoritative-gameplay-in-the-rust-runtime.md
@@ -1,0 +1,56 @@
+# 0001: Keep authoritative gameplay in the Rust runtime
+
+- Status: Accepted
+- Decision date: 2026-04-05
+
+## Context
+
+Kitu must support a Unity-embedded single-player process, a standalone server,
+headless tests, replay tools, and browser administration without implementing
+game rules separately in every host. Unity is effective for presentation and
+device input, but tying authority to MonoBehaviours would make server, replay,
+and embedded behavior diverge. Letting tooling mutate its own copy of world
+state would create the same split.
+
+## Decision
+
+Make `kitu-runtime` and its Rust-owned ECS state authoritative for gameplay,
+tick progression, and world state. Use the same runtime implementation in
+standalone hosts, the demo application, replay tools, and the Unity embedding.
+
+Treat Unity and other clients as input and presentation boundaries. They submit
+intent through runtime-owned input queues and consume runtime output or state
+projections. Keep `kitu-unity-ffi` as a narrow translation adapter: it creates a
+runtime, submits inputs, advances ticks, and drains presentation events; it does
+not own gameplay rules. Shell and Web Admin operations that mutate state must
+likewise enter runtime-owned APIs or message paths.
+
+## Consequences
+
+- Equal runtime state and ordered inputs can exercise the same logic in Unity,
+  servers, CI, and replay.
+- Unity scenes, browser state, and operator tools cannot be the authoritative
+  source for gameplay outcomes.
+- Hosts must translate local input and render the resulting projections, which
+  can add latency compared with direct client-side mutation.
+- Client prediction may be added later only as explicitly non-authoritative
+  behavior with reconciliation rules.
+- ABI, network, and tool adapters stay small but must preserve runtime timing
+  and validation semantics.
+
+## Alternatives considered
+
+- **Put gameplay in Unity**: gives direct access to presentation objects but
+  duplicates or excludes headless and server behavior.
+- **Maintain separate embedded and server runtimes**: permits specialization
+  but makes deterministic equivalence an ongoing integration problem.
+- **Let tools patch ECS state directly**: convenient for debugging, but bypasses
+  validation, event ordering, and replayable intent.
+
+## References
+
+- [Kitu architecture](../architecture.md)
+- [Player-move runtime/host boundary](../specs/vertical-slice-player-move.md)
+- [`kitu-unity-ffi` boundary](../../crates/kitu-unity-ffi/README.md)
+- Pull requests [#19](https://github.com/Nagitch/kitu-logic-processor/pull/19) and
+  [#32](https://github.com/Nagitch/kitu-logic-processor/pull/32)

--- a/doc/adr/0002-use-a-fixed-step-commit-and-publish-tick-pipeline.md
+++ b/doc/adr/0002-use-a-fixed-step-commit-and-publish-tick-pipeline.md
@@ -1,0 +1,61 @@
+# 0002: Use a fixed-step commit-and-publish tick pipeline
+
+- Status: Accepted
+- Decision date: 2026-03-08
+
+## Context
+
+Runtime results must not depend on when a transport happens to be polled during
+a host frame. Inputs can arrive from FFI, local channels, network adapters, or
+replay, and tools need an exact tick on which each input becomes authoritative
+and each output becomes visible. A variable-step loop or immediate transport
+mutation would make ordering and replay depend on host timing.
+
+## Decision
+
+Run authoritative simulation at a configured fixed tick rate. `update(dt)` is
+only an accumulator that executes zero or more complete `tick_once()` calls.
+Reject non-finite, negative, or unrepresentable deltas.
+
+For tick `N`, preserve this phase order:
+
+1. commit the pending FIFO input queue as the immutable batch for `N`;
+2. validate and collect runtime-owned boundary inputs;
+3. dispatch ECS systems deterministically;
+4. apply runtime-owned slice updates and stage outputs;
+5. publish staged outputs to the externally visible FIFO buffer;
+6. drain transport messages into the pending queue for `N+1`; and
+7. increment the monotonic tick as the final phase.
+
+Inputs observed while tick `N` executes are never applied during `N`. A failed
+validation must not partially apply that input batch or advance the tick.
+
+## Consequences
+
+- Simulation and replay observe the same input commit and output visibility
+  barriers regardless of transport timing.
+- Rendering may interpolate externally, but wall-clock jitter does not change
+  authoritative step size.
+- Every new scripting, timeline, reload, or tooling hook needs an explicit safe
+  phase instead of mutating state asynchronously.
+- Hosts may see one-tick input latency, and large host deltas may execute
+  multiple ticks before returning.
+- FIFO queues and failure behavior are part of the runtime contract and require
+  ordering and atomicity tests.
+
+## Alternatives considered
+
+- **Variable-step simulation**: simpler host integration, but results vary with
+  frame rate and make replay harder to compare.
+- **Apply transport messages immediately**: lowers latency but makes state
+  depend on poll timing within a tick.
+- **Poll transport before current-tick dispatch**: can apply fresh inputs
+  sooner, but removes the stable `N` receive to `N+1` apply boundary.
+- **Expose staged outputs immediately**: allows re-entrant observation of
+  partial tick results.
+
+## References
+
+- [Runtime execution contract](../specs/runtime-execution-contract.md)
+- [`kitu-runtime`](../../crates/kitu-runtime/README.md)
+- Pull request [#22](https://github.com/Nagitch/kitu-logic-processor/pull/22)

--- a/doc/adr/0003-keep-osc-ir-semantics-independent-of-wire-transport.md
+++ b/doc/adr/0003-keep-osc-ir-semantics-independent-of-wire-transport.md
@@ -1,0 +1,63 @@
+# 0003: Keep OSC-IR semantics independent of wire transport
+
+- Status: Accepted
+- Decision date: 2026-06-23
+
+## Context
+
+Runtime messages cross local channels, a C ABI, WebSocket JSON, WebTransport,
+tests, and replay artifacts. If address and argument semantics are owned by a
+wire protocol, changing transport can change gameplay behavior. Conversely,
+gateways and brokers need routing and correlation metadata that should not be
+inserted into OSC addresses or payload bytes.
+
+## Decision
+
+Use `kitu-osc-ir` messages and bundles as the logical application event model.
+OSC-style addresses are API contracts, not network routes: `/input/*` carries
+intent into the runtime, while `/render/*` and `/ui/*` carry authoritative
+projections outward. Keep gameplay interpretation out of transport adapters.
+
+Let each boundary serialize the same logical model as appropriate: native
+calls, JSON, OSC packet bytes, or another adapter representation. For network
+paths that need metadata, wrap application payload bytes in the MessagePack
+Kitu Envelope Protocol (KEP). Keep KEP route, correlation, and flags separate
+from the unchanged OSC payload. Frame KEP according to transport—one envelope
+per WebSocket message or datagram, and big-endian length-prefixed envelopes on
+WebTransport streams.
+
+Only claim support for the OSC argument tags and packet shapes implemented by
+the shared codec. Expand that subset when a concrete runtime or client path
+requires it.
+
+## Consequences
+
+- Runtime, Unity, Web Admin, gateway, and replay can share address semantics
+  without depending on one network stack.
+- Gateways may route and correlate envelopes without rewriting gameplay
+  payloads.
+- Multiple serializers must be tested against the same logical messages, and
+  unsupported OSC shapes must fail explicitly.
+- KEP metadata is not authoritative simulation time; transport timestamps and
+  routes cannot bypass the runtime input contract.
+- Application address versioning remains separate from transport endpoint
+  naming.
+
+## Alternatives considered
+
+- **Use WebSocket JSON as the canonical model**: easy for the browser, but
+  couples the runtime contract to one transport and language representation.
+- **Put routing into OSC address prefixes**: avoids an envelope but mixes
+  infrastructure topology with application APIs.
+- **Use KEP fields as gameplay commands**: makes transport adapters interpret
+  domain semantics and weakens replay portability.
+- **Adopt every OSC type immediately**: broad compatibility, but expands codec
+  and validation scope before Kitu has consumers for it.
+
+## References
+
+- [OSC address ownership](../specs/osc-addressing.md)
+- [Kitu Envelope Protocol](../specs/kitu-envelope-protocol.md)
+- [`kitu-osc-ir`](../../crates/kitu-osc-ir/README.md)
+- [`kitu-transport`](../../crates/kitu-transport/README.md)
+- Pull request [#87](https://github.com/Nagitch/kitu-logic-processor/pull/87)

--- a/doc/adr/0004-keep-webtransport-behind-an-experimental-edge-gateway.md
+++ b/doc/adr/0004-keep-webtransport-behind-an-experimental-edge-gateway.md
@@ -1,0 +1,58 @@
+# 0004: Keep WebTransport behind an experimental edge gateway
+
+- Status: Accepted
+- Decision date: 2026-06-27
+
+## Context
+
+WebTransport offers browser-accessible HTTP/3 streams and datagrams, but the
+MVP already has stable, ordered WebSocket paths for Web Admin, Unity, local
+integration tests, and authoritative replay validation. Replacing those paths
+would enlarge the runtime and TLS blast radius before WebTransport behavior and
+production requirements are established. Unreliable datagrams also cannot
+satisfy deterministic command ordering.
+
+## Decision
+
+Keep the existing application server authoritative for OSC handling and
+application logic. Terminate WebTransport in a separate local-development edge
+gateway. Validate KEP there and relay it to the existing application WebSocket
+endpoint as binary KEP messages over the internal network. Reuse one serialized
+internal relay per WebTransport session and preserve ordered response frames.
+
+Retain WebSocket as the MVP Unity/runtime transport and as the browser fallback.
+Send authoritative OSC actions and persistent mutations only over reliable
+streams or WebSocket. Restrict WebTransport datagrams to small, loss-tolerant
+JSON probes, telemetry, or replaceable preview state. Do not retry a request on
+WebSocket after its WebTransport write may have succeeded, because duplicate
+mutations are worse than an explicit failure.
+
+## Consequences
+
+- WebTransport can be evaluated without making the runtime or application host
+  depend on QUIC/HTTP3 and browser certificate behavior.
+- Existing WebSocket clients, tests, and fallback remain valid comparison paths.
+- The gateway adds a hop, session relay state, TLS setup, and Docker integration
+  work.
+- Datagram users must tolerate loss, duplication, and reordering; they cannot
+  rely on replay or acknowledgement semantics.
+- Promoting WebTransport to an authoritative runtime transport requires a new
+  decision with ordering, delivery, deployment, and compatibility evidence.
+
+## Alternatives considered
+
+- **Replace WebSocket with WebTransport immediately**: removes fallback
+  duplication but broadens migration and reliability risk.
+- **Embed WebTransport in `kitu-runtime`**: reduces a hop but couples simulation
+  orchestration to one transport and TLS stack.
+- **Add a new internal TCP or gRPC service**: cleaner separation for a mature
+  gateway, but creates a new app-server protocol before the experiment needs it.
+- **Use datagrams for OSC commands**: lower overhead, but loss and reordering
+  violate authoritative action requirements.
+
+## References
+
+- [WebTransport gateway experiment](../specs/webtransport-gateway.md)
+- [KEP transport mappings](../specs/kitu-envelope-protocol.md#transport-mapping)
+- Pull requests [#96](https://github.com/Nagitch/kitu-logic-processor/pull/96)
+  and [#98](https://github.com/Nagitch/kitu-logic-processor/pull/98)

--- a/doc/adr/0005-separate-reusable-framework-crates-from-applications.md
+++ b/doc/adr/0005-separate-reusable-framework-crates-from-applications.md
@@ -1,0 +1,58 @@
+# 0005: Separate reusable framework crates from applications
+
+- Status: Accepted
+- Decision date: 2026-06-16
+
+## Context
+
+The repository contains reusable runtime capabilities and a concrete demo game
+used for vertical-slice development. When an application host, project actions,
+content, Compose topology, and scenarios live in generic framework or tooling
+packages, reusable crates begin to depend on one game's policy and fixtures.
+That also makes it unclear whether a feature is an engine capability or an
+example application's choice.
+
+## Decision
+
+Keep reusable primitives, runtime behavior, and integration libraries under
+`crates/`, and reusable operator/development utilities under `tools/`. Put each
+concrete product under `apps/`. Application packages may depend on framework
+crates; framework crates must not depend on applications.
+
+Make `apps/demo-game` the reference application. It owns its runtime
+construction, project action manifest, admin host binary, Compose stack, and
+application-specific scenario fixtures. Keep shared action catalog types and
+general actions in `kitu-app-actions`, while loading project-owned definitions
+into the runtime at application construction.
+
+## Consequences
+
+- Framework crates can be reused without importing demo-game policy, content,
+  servers, or test fixtures.
+- A vertical slice can still prove the complete framework through one concrete
+  application and its scenario tests.
+- Moving behavior into `apps/` makes it intentionally unavailable to other
+  applications until extracted behind a reusable contract.
+- Changes spanning framework and application layers need separate reasoning
+  about which side owns the behavior.
+- Application manifests and scenarios can evolve independently while shared
+  catalog validation remains centralized.
+
+## Alternatives considered
+
+- **Keep the demo host under Web Admin tools**: convenient initially, but the
+  host constructs a game runtime and owns application state rather than a
+  reusable frontend tool.
+- **Put demo behavior in runtime crates**: simplifies the example, but turns one
+  game's actions and content into framework dependencies.
+- **Use a separate repository for every app immediately**: enforces isolation,
+  but makes coordinated vertical-slice development and CI more expensive at the
+  current stage.
+
+## References
+
+- [Application conventions](../../apps/README.md)
+- [Demo game](../../apps/demo-game/README.md)
+- [`kitu-app-actions`](../../crates/kitu-app-actions/README.md)
+- Pull requests [#61](https://github.com/Nagitch/kitu-logic-processor/pull/61)
+  and [#77](https://github.com/Nagitch/kitu-logic-processor/pull/77)

--- a/doc/adr/0006-replay-ordered-inputs-through-the-runtime-boundary.md
+++ b/doc/adr/0006-replay-ordered-inputs-through-the-runtime-boundary.md
@@ -1,0 +1,55 @@
+# 0006: Replay ordered inputs through the runtime boundary
+
+- Status: Accepted
+- Decision date: 2026-06-16
+
+## Context
+
+Deterministic testing and debugging need to reproduce behavior outside Unity
+and without a live network. Capturing final ECS snapshots alone cannot explain
+how state was reached, and directly patching components during replay bypasses
+the validation, queue timing, and systems used in production. Comparing wire
+bytes would also bind fixtures to one transport serialization.
+
+## Decision
+
+Define replay scenarios as a schema-versioned initial context plus ordered,
+tick-indexed inbound logical messages. Feed those messages through the same
+runtime `enqueue_input` and `tick_once` boundary used by live adapters. Do not
+patch ECS or runtime-owned state directly.
+
+Capture and compare logical outbound messages after the runtime output barrier,
+not concrete WebSocket, KEP, JSON, or FFI bytes. Store checked-in
+`scenario.json` and `expected.json` contracts; write generated summaries and
+future event/diff reports outside the scenario tree. Exclude wall-clock time
+from pass/fail semantics and permit deterministic sentinel timestamps in smoke
+summaries.
+
+## Consequences
+
+- Replay validates runtime authority, tick timing, parsing, state mutation, and
+  outputs together rather than simulating their effects.
+- The same scenario can be driven by a local runner, CI, or a future transport
+  adapter without changing expected logical behavior.
+- Fixtures must declare stable fields and avoid depending on incidental wire or
+  wall-clock details.
+- Reproducing nondeterministic external systems requires them to be modeled as
+  ordered boundary inputs or controlled content versions.
+- The current smoke runner proves the player-move path; broader replay coverage
+  and richer reports remain incremental work under the same contract.
+
+## Alternatives considered
+
+- **Snapshot and restore ECS state directly**: fast for tests, but bypasses the
+  production input path and can encode internal component layout.
+- **Record network packets byte-for-byte**: exact for one adapter, but fragile
+  across serialization changes and unsuitable for FFI/local-channel runs.
+- **Use wall-clock timestamps to schedule replay**: mirrors capture timing but
+  reintroduces host jitter and slows deterministic tests.
+
+## References
+
+- [Integration/replay framework](../specs/integration-replay-framework.md)
+- [Integration runner](../../kitu-integration-runner/README.md)
+- [Replay runner](../../tools/README.md)
+- Pull request [#62](https://github.com/Nagitch/kitu-logic-processor/pull/62)

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -1,0 +1,36 @@
+# Architecture Decision Records
+
+This directory records accepted decisions that constrain multiple Kitu crates,
+hosts, or transports. [`doc/architecture.md`](../architecture.md) remains the
+current architecture source of truth, and documents under
+[`doc/specs/`](../specs/) remain normative for detailed protocols and runtime
+behavior. ADRs preserve the context, alternatives, and consequences behind
+those contracts.
+
+The initial records are retrospective. Their decision dates identify when the
+decision became established in merged documentation and implementation. They
+were recorded as ADRs on 2026-08-18.
+
+## Status lifecycle
+
+- **Proposed**: under discussion and not yet an implementation constraint.
+- **Accepted**: implementations and specifications are expected to preserve the
+  decision.
+- **Deprecated**: retained for history but no longer recommended for new work.
+- **Superseded**: replaced by a linked later ADR.
+
+Accepted records are immutable except for typo and link corrections. Replace a
+decision by adding a new ADR and marking the old record superseded. New records
+start from [`template.md`](template.md), use the next four-digit number, and
+distinguish implemented behavior from staged architecture.
+
+## Index
+
+| ADR | Status | Decision |
+| --- | --- | --- |
+| [0001](0001-keep-authoritative-gameplay-in-the-rust-runtime.md) | Accepted | Keep authoritative gameplay in the Rust runtime |
+| [0002](0002-use-a-fixed-step-commit-and-publish-tick-pipeline.md) | Accepted | Use a fixed-step commit-and-publish tick pipeline |
+| [0003](0003-keep-osc-ir-semantics-independent-of-wire-transport.md) | Accepted | Keep OSC-IR semantics independent of wire transport |
+| [0004](0004-keep-webtransport-behind-an-experimental-edge-gateway.md) | Accepted | Keep WebTransport behind an experimental edge gateway |
+| [0005](0005-separate-reusable-framework-crates-from-applications.md) | Accepted | Separate reusable framework crates from applications |
+| [0006](0006-replay-ordered-inputs-through-the-runtime-boundary.md) | Accepted | Replay ordered inputs through the runtime boundary |

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -19,10 +19,12 @@ were recorded as ADRs on 2026-08-18.
 - **Deprecated**: retained for history but no longer recommended for new work.
 - **Superseded**: replaced by a linked later ADR.
 
-Accepted records are immutable except for typo and link corrections. Replace a
-decision by adding a new ADR and marking the old record superseded. New records
-start from [`template.md`](template.md), use the next four-digit number, and
-distinguish implemented behavior from staged architecture.
+Accepted records are immutable except for typo and link corrections and the
+lifecycle metadata needed to deprecate or supersede them. Replace a decision by
+adding a new ADR, changing the old record's status to **Superseded**, and linking
+the two records without rewriting the old decision. New records start from
+[`template.md`](template.md), use the next four-digit number, and distinguish
+implemented behavior from staged architecture.
 
 ## Index
 

--- a/doc/adr/template.md
+++ b/doc/adr/template.md
@@ -1,0 +1,28 @@
+# NNNN: Decision title
+
+- Status: Proposed
+- Decision date: YYYY-MM-DD
+
+## Context
+
+Describe the forces, constraints, and cross-boundary problem that require a
+decision. Identify which behavior is implemented and which remains staged.
+
+## Decision
+
+State the chosen architecture and the authority, dependency, timing, or
+compatibility boundaries that implementations must preserve.
+
+## Consequences
+
+- Record important benefits.
+- Record costs, limitations, compatibility effects, and follow-up obligations.
+
+## Alternatives considered
+
+- **Alternative**: explain briefly why it was not selected.
+
+## References
+
+- Link to the public issue, pull request, specification, test, or implementation
+  that establishes the decision.

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -3,6 +3,8 @@
 This document is the primary architecture source of truth for `kitu-logic-processor`.
 It defines the current MVP architecture, explicit architectural decisions, current assumptions, and open questions.
 For a quick crate index, use [`doc/crates-overview.md`](./crates-overview.md).
+For the context, alternatives, and consequences behind accepted cross-cutting
+decisions, use the [`doc/adr` index](./adr/README.md).
 
 ## Table of contents
 


### PR DESCRIPTION
## Summary

- establish an ADR index, lifecycle, and reusable template
- record six accepted retrospective decisions covering Rust runtime authority, the fixed-step tick pipeline, transport-neutral OSC-IR/KEP boundaries, the experimental WebTransport gateway, framework/application separation, and deterministic replay
- link ADRs from the root README and the primary architecture document

## Why

Kitu already has detailed architecture and protocol specifications, but the rationale, rejected alternatives, and long-term consequences of its cross-cutting decisions were distributed across docs, implementation history, and integration work. These ADRs preserve that context while leaving the existing architecture and specs normative.

## Impact

Documentation only. No runtime, protocol, FFI, transport, application, or replay behavior changes. Staged TMD, TSQ1, SQLite, and Rhai integration choices are intentionally not marked as accepted implementation decisions.

## Validation

- `git diff --cached --check`
- verified all relative Markdown links in `doc/adr`, `README.md`, and `doc/architecture.md` resolve locally