### PR TITLE
Add shared calculation kernel adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kitu-calculation"
+version = "0.1.0"
+dependencies = [
+ "openformula-kernel",
+]
+
+[[package]]
 name = "kitu-cli"
 version = "0.1.0"
 dependencies = [
@@ -507,6 +514,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,6 +595,14 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openformula-kernel"
+version = "0.1.0"
+source = "git+https://github.com/Nagitch/openformula-kernel.git?rev=5448dcf6d130e4355da15aeed6c88e56a9a15673#5448dcf6d130e4355da15aeed6c88e56a9a15673"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/kitu-core",
+    "crates/kitu-calculation",
     "crates/kitu-ecs",
     "crates/kitu-osc-ir",
     "crates/kitu-app-actions",
@@ -29,4 +30,5 @@ publish = false
 
 [workspace.dependencies]
 anyhow = "1"
+openformula-kernel = { git = "https://github.com/Nagitch/openformula-kernel.git", rev = "5448dcf6d130e4355da15aeed6c88e56a9a15673", default-features = false }
 thiserror = "2"

--- a/crates/kitu-calculation/Cargo.toml
+++ b/crates/kitu-calculation/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "kitu-calculation"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Kitu adapter and namespaced extensions for the shared OpenFormula calculation kernel."
+license = "MIT"
+repository = "https://github.com/Nagitch/kitu-logic-processor"
+readme = "README.md"
+keywords = ["kitu", "openformula", "calculation"]
+categories = ["game-development", "mathematics"]
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
+
+[dependencies]
+openformula-kernel.workspace = true

--- a/crates/kitu-calculation/README.md
+++ b/crates/kitu-calculation/README.md
@@ -1,0 +1,14 @@
+# kitu-calculation
+
+Kitu's adapter for the version-pinned `openformula-kernel` crate. It exposes
+the shared typed scalar/function contract and provides explicit registration of
+product functions under the `KITU.*` namespace.
+
+The crate does not parse formula source, resolve references, own runtime state,
+or format results. Kitu runtime and scripting layers prepare arguments, inject
+any clock/random capabilities, and map calculation errors into their own source
+diagnostics.
+
+`KituCalculationKernel::standard()` installs only the OpenFormula-derived
+subset. Call `register_default_extensions()` to opt into `KITU.CLAMP` and
+future versioned Kitu extensions.

--- a/crates/kitu-calculation/src/lib.rs
+++ b/crates/kitu-calculation/src/lib.rs
@@ -1,0 +1,103 @@
+//! Kitu adapter for the shared typed calculation kernel.
+
+pub use openformula_kernel::{
+    Argument, CalcError, CalcErrorKind, CalcResult, CoercionPolicy, EvalContext, FunctionMetadata,
+    Number, PureContext, Value,
+};
+
+use openformula_kernel::extensions::register_kitu_examples;
+use openformula_kernel::FunctionRegistry;
+
+/// Kitu's registry boundary for standard and namespaced calculation functions.
+#[derive(Clone)]
+pub struct KituCalculationKernel {
+    registry: FunctionRegistry,
+}
+
+impl KituCalculationKernel {
+    /// Construct a registry containing only the shared standard subset.
+    #[must_use]
+    pub fn standard() -> Self {
+        Self {
+            registry: FunctionRegistry::standard(),
+        }
+    }
+
+    /// Explicitly install the versioned `KITU.*` extension set.
+    pub fn register_default_extensions(&mut self) -> CalcResult<()> {
+        register_kitu_examples(&mut self.registry)
+    }
+
+    /// Evaluate a function after the owning Kitu layer has resolved arguments.
+    pub fn evaluate(
+        &self,
+        name: &str,
+        arguments: &[Argument],
+        context: &mut dyn EvalContext,
+    ) -> CalcResult {
+        self.registry.evaluate(name, arguments, context)
+    }
+
+    /// Access compatibility metadata for a standard or installed extension.
+    #[must_use]
+    pub fn metadata(&self, name: &str) -> Option<&FunctionMetadata> {
+        self.registry.metadata(name)
+    }
+}
+
+impl Default for KituCalculationKernel {
+    fn default() -> Self {
+        Self::standard()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn standard_and_kitu_namespaces_are_explicit() {
+        let mut kernel = KituCalculationKernel::standard();
+        assert!(kernel.metadata("SUM").is_some());
+        assert!(kernel.metadata("KITU.CLAMP").is_none());
+
+        kernel
+            .register_default_extensions()
+            .expect("known extension registration");
+        let value = kernel
+            .evaluate(
+                "KITU.CLAMP",
+                &[
+                    Argument::scalar(12_i64),
+                    Argument::scalar(0_i64),
+                    Argument::scalar(10_i64),
+                ],
+                &mut PureContext,
+            )
+            .expect("Kitu extension calculation");
+        assert_eq!(value, Value::from(10_i64));
+    }
+
+    #[test]
+    fn standard_results_match_the_cross_product_contract() {
+        let kernel = KituCalculationKernel::standard();
+        let value = kernel
+            .evaluate(
+                "FLOOR",
+                &[
+                    Argument::scalar(Value::Number(
+                        Number::try_from_f64(0.3).expect("finite fixture"),
+                    )),
+                    Argument::scalar(Value::Number(
+                        Number::try_from_f64(0.1).expect("finite fixture"),
+                    )),
+                ],
+                &mut PureContext,
+            )
+            .expect("standard calculation");
+        let Value::Number(value) = value else {
+            panic!("FLOOR must return a number");
+        };
+        assert_eq!(value.as_f64(), 0.3);
+    }
+}

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -152,6 +152,7 @@ flowchart LR
 
     subgraph RuntimeCore[Authoritative Runtime Core]
         Core[kitu-core]
+        Calculation[kitu-calculation]
         ECS[kitu-ecs]
         Runtime[kitu-runtime]
         OscIR[kitu-osc-ir]
@@ -173,6 +174,7 @@ flowchart LR
     SQL --> SqlCrate
     TSQ1 --> TSQ1Crate
     Rhai --> RhaiCrate
+    Calculation --> Runtime
 
     TmdCrate --> Runtime
     SqlCrate --> Runtime
@@ -296,6 +298,7 @@ For dependency details, see `doc/crates-overview.md`. This section defines allow
 ```mermaid
 graph TD
     Core[kitu-core: errors ticks time]
+    Calculation[kitu-calculation: shared function adapter and KITU extensions]
     ECS[kitu-ecs: world and scheduling]
     Osc[kitu-osc-ir: message IR]
     Transport[kitu-transport: delivery abstraction]
@@ -310,6 +313,7 @@ graph TD
     Replay[kitu-replay-runner: deterministic playback]
 
     Core --> ECS
+    Calculation --> Runtime
     Core --> Osc
     Osc --> Transport
     ECS --> Runtime
@@ -327,6 +331,7 @@ graph TD
 ### Responsibility rules by boundary
 
 - `kitu-core`: foundational types only; no transport/runtime orchestration.
+- `kitu-calculation`: typed function adapter and `KITU.*` registration only; no parser, references, state, or presentation.
 - `kitu-osc-ir`: protocol-neutral message model; no game rules or transport coupling.
 - `kitu-transport`: sending/receiving and connectivity events only.
 - `kitu-runtime`: only crate allowed to own authoritative tick loop orchestration.

--- a/doc/crates-overview.md
+++ b/doc/crates-overview.md
@@ -9,6 +9,7 @@ Status note: some data/content crates are staged entry points. Their responsibil
 | Crate | Purpose | Key dependencies |
 | --- | --- | --- |
 | `kitu-core` | Foundational types (errors, ticks, timestamps) shared across all crates. | – |
+| `kitu-calculation` | Shared OpenFormula function adapter and explicit `KITU.*` extension registration. | `openformula-kernel` |
 | `kitu-ecs` | Minimal ECS wrapper and scheduler used by the runtime loop. | `kitu-core` |
 | `kitu-osc-ir` | Core OSC/IR message types that travel across transports. | `kitu-core` |
 | `kitu-transport` | Message transport abstraction (local channel, network adapters). | `kitu-core`, `kitu-osc-ir` |
@@ -26,6 +27,7 @@ Status note: some data/content crates are staged entry points. Their responsibil
 ```mermaid
 graph TD
     kitu_core["kitu-core"]
+    kitu_calculation["kitu-calculation"]
     kitu_ecs["kitu-ecs"]
     kitu_osc_ir["kitu-osc-ir"]
     kitu_transport["kitu-transport"]
@@ -37,6 +39,8 @@ graph TD
     kitu_shell["kitu-shell"]
     kitu_web_admin_backend["kitu-web-admin-backend"]
     kitu_unity_ffi["kitu-unity-ffi"]
+
+    kitu_calculation --> openformula_kernel["openformula-kernel"]
 
     kitu_ecs --> kitu_core
     kitu_osc_ir --> kitu_core
@@ -62,6 +66,10 @@ graph TD
 ### `kitu-core`
 - Defines cross-crate primitives such as `KituError`, the `Result` alias, and tick/timestamp handling.
 - Keep error variants and time utilities cohesive here so downstream crates do not redefine them.
+
+### `kitu-calculation`
+- Adapts the version-pinned shared calculation registry without taking ownership of parsing, references, runtime triggers, or presentation.
+- Keeps product functions explicitly registered under `KITU.*`; standard names retain their shared OpenFormula-derived behavior.
 
 ### `kitu-ecs`
 - Provides the lightweight ECS world, scheduling, and `System` trait used by the runtime loop.


### PR DESCRIPTION
## Summary

- pin the shared openformula-kernel 0.1.0 implementation from Nagitch/openformula-kernel#1
- add a focused kitu-calculation workspace crate
- expose standard typed function evaluation without moving parser, state, trigger, or presentation ownership
- require explicit registration for the KITU.CLAMP example extension
- document the new crate and architecture boundary

## Validation

- cargo fmt --all --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features
- rustdoc with warnings denied

Part of Nagitch/kitu-workspace#12.