### PR TITLE
Make Unity CLI setup and project connection reproducible

### DIFF
--- a/kitu-integration-runner/unity-demo-game/README.md
+++ b/kitu-integration-runner/unity-demo-game/README.md
@@ -36,7 +36,12 @@ curl -fsSL https://public-cdn.cloud.unity3d.com/hub/prod/cli/install.sh -o /tmp/
 UNITY_CLI_CHANNEL=beta UNITY_CLI_VERSION=1.0.0-beta.8 bash /tmp/unity-cli-install.sh
 ```
 
-Restart the terminal after installation, then run from this directory:
+The official installer installs a persistent CLI and configures the interactive
+shell's PATH. On macOS the default executable is `~/.unity/bin/unity`. Restart
+the terminal after installation, or load `~/.unity/env` in an existing macOS
+shell. Non-interactive shells do not necessarily read `.zshrc`.
+
+Then run from this directory:
 
 ```sh
 cd kitu-unity-demo-game
@@ -44,12 +49,44 @@ unity --version
 unity open .
 ```
 
+### Select the intended checkout
+
+Use `scripts/unity-cli.sh` when invoking the CLI from automation or elsewhere
+in the repository. It discovers the installed CLI from PATH, the default
+macOS location, or the default Linux location, and selects the Unity project
+next to the script. From the repository root:
+
+```sh
+./kitu-integration-runner/unity-demo-game/scripts/unity-cli.sh --version
+./kitu-integration-runner/unity-demo-game/scripts/unity-cli.sh command editor_status --json
+```
+
+`KITU_UNITY_CLI` can specify an absolute executable path for a custom CLI
+installation. `KITU_UNITY_PROJECT` can select a different checkout explicitly:
+
+```sh
+KITU_UNITY_PROJECT=/absolute/path/to/kitu-unity-demo-game \
+  ./kitu-integration-runner/unity-demo-game/scripts/unity-cli.sh command editor_status --json
+```
+
+Check the returned `projectPath` and `unityVersion` (`6000.6.0f1`) before
+performing scene operations. Git worktrees have separate project directories
+and Unity caches. The Hub entry for a regular checkout does not automatically
+switch to a worktree or receive its commits when a PR is created. Update the
+checkout registered in Hub to the merged commit, or explicitly add/open the
+worktree you want to use. Re-registering an old checkout in Hub does not update
+its files. The helper does not change Hub registration or Git branches.
+
+### Verify the Editor connection
+
 Install Editor `6000.6.0f1` through Unity Hub if it is missing, and activate a
 Unity license on the machine. Let the initial package import and script
 compilation finish. From a second terminal in the same project directory:
 
 ```sh
 unity command editor_status --json
+unity command eval --code 'return UnityEngine.Application.unityVersion;' --json
+unity command list_open_scenes --json
 unity command open_scene --path Assets/KituDemoApp/KituDemoAppMain.unity
 unity command editor_play
 unity command editor_status --json
@@ -61,6 +98,12 @@ The play/stop commands initiate transitions; wait until `editor_status` reports
 the requested state before the next scene operation. `unity command` lists the
 available commands. Pass `--project-path /absolute/path/to/kitu-unity-demo-game`
 before the command name when running outside the project directory.
+The same commands can be passed to `scripts/unity-cli.sh`. A successful
+connection reports the intended project, the expected Editor version, and no
+compilation/domain reload in progress. A missing Pipeline instance during the
+first import is not a successful connection: wait for compilation to finish
+and check again. `get_console_logs --severity error` should return an empty log
+list after the demo smoke check.
 
 The Pipeline dependency is already committed, so a fresh checkout does not
 need `unity pipeline install`. Its Editor connection metadata lives under the

--- a/kitu-integration-runner/unity-demo-game/scripts/unity-cli.sh
+++ b/kitu-integration-runner/unity-demo-game/scripts/unity-cli.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Run the installed Unity CLI against this checkout's demo project.
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+project_dir=${KITU_UNITY_PROJECT:-"$script_dir/../kitu-unity-demo-game"}
+if [ ! -f "$project_dir/ProjectSettings/ProjectVersion.txt" ]; then
+    printf 'Unity project not found: %s\n' "$project_dir" >&2
+    exit 1
+fi
+project_dir=$(CDPATH= cd -- "$project_dir" && pwd -P)
+
+if [ -n "${KITU_UNITY_CLI:-}" ]; then
+    cli=$KITU_UNITY_CLI
+    case "$cli" in
+        /*) ;;
+        *) printf 'KITU_UNITY_CLI must be an absolute executable path.\n' >&2; exit 1 ;;
+    esac
+elif command -v unity >/dev/null 2>&1; then
+    cli=$(command -v unity)
+elif [ -x "$HOME/.unity/bin/unity" ]; then
+    cli=$HOME/.unity/bin/unity
+elif [ -x "$HOME/.local/bin/unity" ]; then
+    cli=$HOME/.local/bin/unity
+else
+    printf 'Unity CLI is not installed. See unity-demo-game/README.md#unity-cli.\n' >&2
+    exit 127
+fi
+
+if [ ! -x "$cli" ]; then
+    printf 'Unity CLI is not executable: %s\n' "$cli" >&2
+    exit 126
+fi
+
+# A relative PATH entry must keep resolving after we change directories.
+case "$cli" in
+    /*) ;;
+    *) cli=$(CDPATH= cd -- "$(dirname -- "$cli")" && pwd -P)/$(basename -- "$cli") ;;
+esac
+
+# The CLI uses this for Pipeline commands; cwd also selects the project for
+# commands such as open/run/build. No Hub registry or global preference changes.
+export UNITY_PROJECT_PATH="$project_dir"
+cd "$project_dir"
+exec "$cli" "$@"

--- a/kitu-integration-runner/unity-demo-game/scripts/unity-cli.sh
+++ b/kitu-integration-runner/unity-demo-game/scripts/unity-cli.sh
@@ -18,9 +18,9 @@ if [ -n "${KITU_UNITY_CLI:-}" ]; then
     esac
 elif command -v unity >/dev/null 2>&1; then
     cli=$(command -v unity)
-elif [ -x "$HOME/.unity/bin/unity" ]; then
+elif [ -n "${HOME:-}" ] && [ -x "$HOME/.unity/bin/unity" ]; then
     cli=$HOME/.unity/bin/unity
-elif [ -x "$HOME/.local/bin/unity" ]; then
+elif [ -n "${HOME:-}" ] && [ -x "$HOME/.local/bin/unity" ]; then
     cli=$HOME/.local/bin/unity
 else
     printf 'Unity CLI is not installed. See unity-demo-game/README.md#unity-cli.\n' >&2


### PR DESCRIPTION
Make Unity CLI select the intended demo checkout reliably, including in non-interactive shells where `.zshrc` has not added the installed CLI to PATH. This follows the Unity 6.6 migration in #125.

Adds `scripts/unity-cli.sh`, which resolves the adjacent Unity project, discovers the installed CLI, and passes arguments through unchanged. `KITU_UNITY_PROJECT` selects another checkout and `KITU_UNITY_CLI` selects a custom executable. The README explains persistent installation, Hub versus worktree paths, and checks for the returned project path, Editor version, and runtime errors.

### Validation

- Updated the development host's persistent CLI to 1.0.0-beta.8 with the official checksum-verifying installer; a new interactive zsh resolves `unity` successfully.
- Updated the regular Hub-registered checkout to merged Unity 6000.6.0f1. Hub's stored version now matches 6.6.
- Used the helper to connect to that regular checkout: editor_status returned its exact path and 6000.6.0f1 with compilation finished.
- Version eval, scene inspection/open, Play Mode start/stop, and demo-controller/three-enemy inspection passed. Console errors: 0.
- Shell syntax, paths containing spaces, argument preservation, checkout selection, relative PATH entries, and error exits passed.
- Dev Container fmt, Clippy with warnings denied, and all Rust tests passed. git diff --check passed.

CLI beta.8 `open` still did not keep the Editor running in this execution environment. Direct Editor startup followed by CLI commands worked; the documented fallback remains. The helper does not modify Hub registration or Git branches. Host installation is a local setup action; this PR contains the reusable helper and instructions.

Closes #126.


### HOME-independent CLI discovery

Home-directory fallback paths are now probed only when `HOME` is non-empty. With `HOME` unset or empty and no CLI on `PATH`, the helper prints the installation guidance and exits 127 instead of failing on an unbound variable. Explicit CLI overrides and PATH discovery continue to work without `HOME`.

Validation: six shell-routing checks cover unset/empty `HOME`, explicit and PATH discovery without `HOME`, and both home-directory fallback locations. The installed CLI reports `1.0.0-beta.8`; shell syntax, `git diff --check`, and Dev Container fmt, Clippy, and all Cargo tests pass.
