### PR TITLE
feat(arena): independent runtime clock and Unity client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,6 +391,8 @@ dependencies = [
  "anyhow",
  "axum",
  "kitu-app-actions",
+ "kitu-core",
+ "kitu-ecs",
  "kitu-osc-ir",
  "kitu-runtime",
  "kitu-transport",

--- a/apps/demo-game/Cargo.toml
+++ b/apps/demo-game/Cargo.toml
@@ -18,6 +18,8 @@ axum = { version = "0.8", features = ["ws"] }
 kitu-app-actions = { path = "../../crates/kitu-app-actions" }
 kitu-osc-ir = { path = "../../crates/kitu-osc-ir" }
 kitu-runtime = { path = "../../crates/kitu-runtime" }
+kitu-core = { path = "../../crates/kitu-core" }
+kitu-ecs = { path = "../../crates/kitu-ecs" }
 kitu-transport = { path = "../../crates/kitu-transport" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/apps/demo-game/src/arena.rs
+++ b/apps/demo-game/src/arena.rs
@@ -1,0 +1,339 @@
+//! Authoritative Arena application, incrementally ported against the C# oracle.
+//!
+//! This stage implements lifecycle, movement, aim and pause. Inventory/combat
+//! commands are explicitly rejected until their migration stages are complete.
+
+use std::collections::HashMap;
+
+use kitu_core::{KituError, Result};
+use kitu_ecs::EcsWorld;
+use kitu_osc_ir::{OscArg, OscBundle, OscMessage};
+use kitu_runtime::{ApplicationTick, InputMetadata, RuntimeApplication, RuntimeInput};
+use serde::{Deserialize, Serialize};
+
+use crate::DemoRuntime;
+
+/// Stage-independent Arena OSC contract version.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// A ground-plane vector; `y` maps to Unity world Z for reference compatibility.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct Vec2 {
+    /// World X component.
+    pub x: f32,
+    /// World Z component.
+    pub y: f32,
+}
+
+impl Vec2 {
+    fn length(self) -> f32 {
+        (self.x * self.x + self.y * self.y).sqrt()
+    }
+    fn normalized(self) -> Self {
+        let length = self.length();
+        if length > 0.00001 {
+            Self {
+                x: self.x / length,
+                y: self.y / length,
+            }
+        } else {
+            Self::default()
+        }
+    }
+}
+
+/// Detached state shared by the host, Unity and command-line inspectors.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArenaState {
+    /// Last completed source tick; -1 before the first update.
+    pub tick: i64,
+    /// Number of gameplay steps, excluding paused/opening/results ticks.
+    pub simulation_steps: u64,
+    /// Reference ArenaPhase discriminant (opening=0, preparation=1).
+    pub phase: i32,
+    /// Runtime-owned pause/interaction overlay.
+    pub overlay: String,
+    /// Current floor; preparation is zero.
+    pub floor: i32,
+    /// Gameplay elapsed seconds, accumulated using reference f32 arithmetic.
+    pub elapsed: f32,
+    /// Authoritative player ground-plane position.
+    pub player_position: Vec2,
+    /// Last valid normalized aim direction.
+    pub aim_direction: Vec2,
+}
+
+impl Default for ArenaState {
+    fn default() -> Self {
+        Self {
+            tick: -1,
+            simulation_steps: 0,
+            phase: 0,
+            overlay: "none".into(),
+            floor: 0,
+            elapsed: 0.0,
+            player_position: Vec2::default(),
+            aim_direction: Vec2 { x: 0.0, y: 1.0 },
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+struct Controls {
+    movement: Vec2,
+    has_aim: bool,
+    aim: Vec2,
+    fire_a: bool,
+    fire_b: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum Command {
+    Start,
+    Menu,
+    Pause,
+    Resume,
+    Disconnect,
+    Frame(Controls),
+    Unsupported,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Outcome {
+    sequence: u64,
+    source: String,
+    id: u64,
+    tick: i64,
+    applied_tick: i64,
+    accepted: bool,
+    duplicate: bool,
+    code: String,
+}
+
+#[derive(Default)]
+struct ArenaSession {
+    state: ArenaState,
+    controls: Controls,
+    seen: HashMap<(String, u64), (OscMessage, Outcome)>,
+    frames: HashMap<String, u64>,
+}
+
+struct ArenaApplication;
+
+/// Installs Arena state and behavior in an unstarted demo runtime.
+pub fn install(runtime: &mut DemoRuntime) -> Result<()> {
+    runtime.install_application(ArenaApplication)?;
+    runtime.world_mut().insert_resource(ArenaSession::default());
+    Ok(())
+}
+
+/// Validates one Arena envelope before a network adapter admits it to the runtime.
+///
+/// # Errors
+/// Rejects missing identity/version, malformed payloads and non-finite coordinates.
+pub fn validate_input(message: &OscMessage, metadata: &InputMetadata) -> Result<()> {
+    if metadata.schema_version != SCHEMA_VERSION
+        || metadata.message_id == 0
+        || metadata.source.is_empty()
+        || metadata.source.len() > 128
+    {
+        return Err(KituError::InvalidInput(
+            "invalid Arena envelope identity or schema",
+        ));
+    }
+    parse(message).map(|_| ())
+}
+
+fn parse(message: &OscMessage) -> Result<Command> {
+    let command = match message.address.as_str() {
+        "/input/arena/start" => Command::Start,
+        "/input/arena/menu" => Command::Menu,
+        "/input/arena/pause" => Command::Pause,
+        "/input/arena/resume" => Command::Resume,
+        "/input/arena/disconnect" => Command::Disconnect,
+        "/input/arena/frame" => {
+            if let [OscArg::Float(x), OscArg::Float(y), OscArg::Bool(has_aim), OscArg::Float(ax), OscArg::Float(ay), OscArg::Bool(fire_a), OscArg::Bool(fire_b)] =
+                message.args.as_slice()
+            {
+                if [x, y, ax, ay].into_iter().all(|v| v.is_finite()) {
+                    return Ok(Command::Frame(Controls {
+                        movement: Vec2 { x: *x, y: *y },
+                        has_aim: *has_aim,
+                        aim: Vec2 { x: *ax, y: *ay },
+                        fire_a: *fire_a,
+                        fire_b: *fire_b,
+                    }));
+                }
+            }
+            return Err(KituError::InvalidInput(
+                "Arena frame expects finite move/aim coordinates and boolean controls",
+            ));
+        }
+        _ => return Ok(Command::Unsupported),
+    };
+    if !message.args.is_empty() {
+        return Err(KituError::InvalidInput(
+            "Arena control expects no payload arguments",
+        ));
+    }
+    Ok(command)
+}
+
+impl RuntimeApplication for ArenaApplication {
+    fn validate_inputs(&self, inputs: &[RuntimeInput]) -> Result<()> {
+        for input in inputs {
+            for message in &input.bundle.messages {
+                if !message.address.starts_with("/input/arena/") {
+                    continue;
+                }
+                if input.bundle.messages.len() != 1 {
+                    return Err(KituError::InvalidInput(
+                        "Arena envelopes contain exactly one command",
+                    ));
+                }
+                let metadata = input.metadata.as_ref().ok_or(KituError::InvalidInput(
+                    "Arena input requires envelope metadata",
+                ))?;
+                validate_input(message, metadata)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn tick(&mut self, world: &mut EcsWorld, context: ApplicationTick<'_>) -> Vec<OscBundle> {
+        let session = world
+            .resource_mut::<ArenaSession>()
+            .expect("Arena resource installed with application");
+        let mut output = OscBundle::new();
+        for input in context.inputs {
+            for message in &input.bundle.messages {
+                if !message.address.starts_with("/input/arena/") {
+                    continue;
+                }
+                let meta = input.metadata.as_ref().expect("validated metadata");
+                let command = parse(message).expect("validated command");
+                if let Command::Frame(controls) = command {
+                    let previous = session.frames.entry(meta.source.clone()).or_default();
+                    if meta.message_id > *previous {
+                        *previous = meta.message_id;
+                        if session.state.overlay == "none" {
+                            session.controls = controls;
+                        }
+                    }
+                    continue;
+                }
+                let key = (meta.source.clone(), meta.message_id);
+                let tick = context.tick.get() as i64;
+                let outcome = if let Some((original, previous)) = session.seen.get(&key) {
+                    let mut outcome = previous.clone();
+                    outcome.tick = tick;
+                    outcome.duplicate = true;
+                    if original != message {
+                        outcome.accepted = false;
+                        outcome.code = "id_conflict".into();
+                        outcome.applied_tick = -1;
+                    }
+                    outcome
+                } else {
+                    let code = execute(session, command);
+                    let outcome = Outcome {
+                        sequence: input.sequence,
+                        source: meta.source.clone(),
+                        id: meta.message_id,
+                        tick,
+                        applied_tick: tick,
+                        accepted: code == "ok",
+                        duplicate: false,
+                        code: code.into(),
+                    };
+                    session.seen.insert(key, (message.clone(), outcome.clone()));
+                    outcome
+                };
+                output.push(json_message("/ui/arena/command", &outcome));
+            }
+        }
+        if session.state.phase == 1 && session.state.overlay == "none" {
+            let mut movement = session.controls.movement;
+            if movement.x * movement.x + movement.y * movement.y > 1.0 {
+                movement = movement.normalized();
+            }
+            session.state.player_position.x = (session.state.player_position.x
+                + movement.x * (5.0 * context.dt))
+                .clamp(-9.5, 9.5);
+            session.state.player_position.y = (session.state.player_position.y
+                + movement.y * (5.0 * context.dt))
+                .clamp(-9.5, 9.5);
+            if session.controls.has_aim {
+                let direction = Vec2 {
+                    x: session.controls.aim.x - session.state.player_position.x,
+                    y: session.controls.aim.y - session.state.player_position.y,
+                };
+                if direction.x * direction.x + direction.y * direction.y > 0.000001 {
+                    session.state.aim_direction = direction.normalized();
+                }
+            }
+            session.state.elapsed += context.dt;
+            session.state.simulation_steps += 1;
+        }
+        session.state.tick = context.tick.get() as i64;
+        output.push(json_message("/ui/arena/state", &session.state));
+        vec![output]
+    }
+
+    fn snapshot(&self, world: &EcsWorld) -> Vec<OscBundle> {
+        let session = world
+            .resource::<ArenaSession>()
+            .expect("Arena resource installed with application");
+        let mut output = OscBundle::new();
+        output.push(json_message("/ui/arena/state", &session.state));
+        vec![output]
+    }
+}
+
+fn execute(session: &mut ArenaSession, command: Command) -> &'static str {
+    match command {
+        Command::Start if session.state.phase == 0 || session.state.phase == 5 => {
+            let simulation_steps = session.state.simulation_steps;
+            session.state = ArenaState {
+                phase: 1,
+                player_position: Vec2 { x: 0.0, y: -7.0 },
+                simulation_steps,
+                ..ArenaState::default()
+            };
+        }
+        Command::Menu => {
+            let simulation_steps = session.state.simulation_steps;
+            session.state = ArenaState {
+                player_position: Vec2 { x: 0.0, y: -7.0 },
+                simulation_steps,
+                ..ArenaState::default()
+            };
+        }
+        Command::Pause | Command::Disconnect
+            if session.state.phase != 0 && session.state.phase != 5 =>
+        {
+            session.state.overlay = "pause".into()
+        }
+        Command::Resume
+            if session.state.overlay == "pause"
+                && session.state.phase != 0
+                && session.state.phase != 5 =>
+        {
+            session.state.overlay = "none".into()
+        }
+        Command::Unsupported => return "not_yet_implemented",
+        _ => return "invalid_state",
+    }
+    session.controls = Controls::default();
+    "ok"
+}
+
+fn json_message(address: &str, value: &impl Serialize) -> OscMessage {
+    let mut message = OscMessage::new(address);
+    message.push_arg(OscArg::Str(
+        serde_json::to_string(value).expect("finite serializable Arena state"),
+    ));
+    message
+}

--- a/apps/demo-game/src/arena.rs
+++ b/apps/demo-game/src/arena.rs
@@ -117,7 +117,7 @@ struct ArenaSession {
     state: ArenaState,
     controls: Controls,
     seen: HashMap<(String, u64), (OscMessage, Outcome)>,
-    frames: HashMap<String, u64>,
+    high_water: HashMap<String, u64>,
 }
 
 struct ArenaApplication;
@@ -171,7 +171,37 @@ fn parse(message: &OscMessage) -> Result<Command> {
                 "Arena frame expects finite move/aim coordinates and boolean controls",
             ));
         }
-        _ => return Ok(Command::Unsupported),
+        "/input/arena/inventory" | "/input/arena/chest" | "/input/arena/close" => {
+            Command::Unsupported
+        }
+        "/input/arena/take"
+        | "/input/arena/discard"
+        | "/input/arena/upgrade"
+        | "/input/arena/unequip" => {
+            return match message.args.as_slice() {
+                [OscArg::Int(_), OscArg::Int(_)] => Ok(Command::Unsupported),
+                _ => Err(KituError::InvalidInput(
+                    "Arena operation expects two ordered i32 arguments",
+                )),
+            };
+        }
+        "/input/arena/equip" => {
+            return match message.args.as_slice() {
+                [OscArg::Int(_), OscArg::Int(_), OscArg::Int(_)] => Ok(Command::Unsupported),
+                _ => Err(KituError::InvalidInput(
+                    "Arena equip expects three ordered i32 arguments",
+                )),
+            };
+        }
+        "/input/arena/use" => {
+            return match message.args.as_slice() {
+                [OscArg::Int(_)] => Ok(Command::Unsupported),
+                _ => Err(KituError::InvalidInput(
+                    "Arena use expects an i32 equipment slot",
+                )),
+            };
+        }
+        _ => return Err(KituError::InvalidInput("unknown Arena command")),
     };
     if !message.args.is_empty() {
         return Err(KituError::InvalidInput(
@@ -214,18 +244,28 @@ impl RuntimeApplication for ArenaApplication {
                 }
                 let meta = input.metadata.as_ref().expect("validated metadata");
                 let command = parse(message).expect("validated command");
+                let key = (meta.source.clone(), meta.message_id);
+                let tick = context.tick.get() as i64;
                 if let Command::Frame(controls) = command {
-                    let previous = session.frames.entry(meta.source.clone()).or_default();
-                    if meta.message_id > *previous {
-                        *previous = meta.message_id;
-                        if session.state.overlay == "none" {
-                            session.controls = controls;
+                    if let Some((_, original)) = session.seen.get(&key) {
+                        let mut conflict = original.clone();
+                        conflict.tick = tick;
+                        conflict.applied_tick = -1;
+                        conflict.accepted = false;
+                        conflict.duplicate = true;
+                        conflict.code = "id_conflict".into();
+                        output.push(json_message("/ui/arena/command", &conflict));
+                    } else {
+                        let previous = session.high_water.entry(meta.source.clone()).or_default();
+                        if meta.message_id > *previous {
+                            *previous = meta.message_id;
+                            if session.state.overlay == "none" {
+                                session.controls = controls;
+                            }
                         }
                     }
                     continue;
                 }
-                let key = (meta.source.clone(), meta.message_id);
-                let tick = context.tick.get() as i64;
                 let outcome = if let Some((original, previous)) = session.seen.get(&key) {
                     let mut outcome = previous.clone();
                     outcome.tick = tick;
@@ -236,7 +276,25 @@ impl RuntimeApplication for ArenaApplication {
                         outcome.applied_tick = -1;
                     }
                     outcome
+                } else if meta.message_id
+                    <= session.high_water.get(&meta.source).copied().unwrap_or(0)
+                {
+                    // A first-seen discrete ID below the producer high-water mark
+                    // may belong to a frame. Never reuse it for a state mutation.
+                    Outcome {
+                        sequence: input.sequence,
+                        source: meta.source.clone(),
+                        id: meta.message_id,
+                        tick,
+                        applied_tick: -1,
+                        accepted: false,
+                        duplicate: true,
+                        code: "id_conflict".into(),
+                    }
                 } else {
+                    session
+                        .high_water
+                        .insert(meta.source.clone(), meta.message_id);
                     let code = execute(session, command);
                     let outcome = Outcome {
                         sequence: input.sequence,

--- a/apps/demo-game/src/bin/admin_host.rs
+++ b/apps/demo-game/src/bin/admin_host.rs
@@ -17,8 +17,9 @@ use axum::{
     Json, Router,
 };
 use kitu_app_actions::{ActionValue, AppActionCatalog, AppActionDefinition};
-use kitu_demo_game::{build_demo_runtime, DemoRuntime};
+use kitu_demo_game::{arena, build_arena_runtime, DemoRuntime};
 use kitu_osc_ir::{OscArg, OscMessage};
+use kitu_runtime::InputMetadata;
 use kitu_transport::{
     decode_kep_envelope, decode_osc_packet, encode_kep_envelope, KepEnvelope, KEP_PAYLOAD_OSC,
 };
@@ -40,14 +41,26 @@ struct GameState {
     runtime: DemoRuntime,
     next_log_id: u64,
     logs: Vec<DebugLogEntry>,
+    runtime_id: String,
+    next_connection_id: u64,
+    controller: Option<(u64, String)>,
 }
 
 impl GameState {
     fn new() -> Result<Self> {
         Ok(Self {
-            runtime: build_demo_runtime()?,
+            runtime: build_arena_runtime()?,
             next_log_id: 1,
             logs: Vec::new(),
+            runtime_id: format!(
+                "{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)?
+                    .as_nanos()
+            ),
+            next_connection_id: 1,
+            controller: None,
         })
     }
 
@@ -129,6 +142,17 @@ struct ClientOscMessage {
     args: Vec<JsonOscArg>,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ArenaClientEnvelope {
+    schema_version: u32,
+    session_id: String,
+    client_id: String,
+    message_id: u64,
+    #[serde(flatten)]
+    message: ClientOscMessage,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", content = "value", rename_all = "lowercase")]
 enum JsonOscArg {
@@ -157,6 +181,11 @@ struct ActionRunResponse {
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
 enum ServerEvent {
+    ArenaSession {
+        id: String,
+        #[serde(rename = "schemaVersion")]
+        schema_version: u32,
+    },
     Connected {
         protocol: &'static str,
         tick: u64,
@@ -193,6 +222,26 @@ async fn main() -> Result<()> {
         inner: Arc::new(Mutex::new(GameState::new()?)),
         events,
     };
+
+    let clock_state = state.clone();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs_f64(1.0 / 60.0));
+        // Fixed-step catch-up is independent of websocket message count.
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Burst);
+        loop {
+            interval.tick().await;
+            match advance_runtime_tick(&clock_state) {
+                Ok(events) => {
+                    for event in events {
+                        let _ = clock_state.events.send(event);
+                    }
+                }
+                Err(error) => {
+                    broadcast_error(&clock_state, format!("runtime tick failed: {error:#}"))
+                }
+            }
+        }
+    });
 
     let app = Router::new()
         .route("/health", get(health))
@@ -343,65 +392,129 @@ async fn ws_loop(mut socket: WebSocket, state: AppState) {
 }
 
 async fn runtime_ws_loop(mut socket: WebSocket, state: AppState) {
-    if let Err(err) = send_initial_runtime_state(&mut socket, &state).await {
+    let connection_id = {
+        let Ok(mut guard) = state.inner.lock() else {
+            return;
+        };
+        let id = guard.next_connection_id;
+        guard.next_connection_id += 1;
+        id
+    };
+    if let Err(err) = send_initial_runtime_state(&mut socket, &state, WsOutputMode::Json).await {
         error!("failed to send initial runtime state: {err}");
         return;
     }
-
     let mut receiver = state.events.subscribe();
     let mut output_mode = WsOutputMode::Json;
-
     loop {
         tokio::select! {
-            maybe_message = socket.recv() => {
-                match maybe_message {
+            incoming = socket.recv() => {
+                match incoming {
                     Some(Ok(Message::Text(text))) => {
-                        match serde_json::from_str::<ClientOscMessage>(&text) {
-                            Ok(message) => {
-                                if let Err(err) = handle_runtime_osc(&state, message) {
-                                    broadcast_error(&state, err.to_string());
+                        let result = match serde_json::from_str::<ClientOscMessage>(&text) {
+                            Ok(message) if message.address.starts_with("/input/arena/") => {
+                                match serde_json::from_str::<ArenaClientEnvelope>(&text) {
+                                    Ok(envelope) => enqueue_arena_request(&state, connection_id, envelope),
+                                    Err(error) => Err(error.into()),
                                 }
                             }
-                            Err(err) => broadcast_error(&state, format!("invalid runtime client message: {err}")),
+                            Ok(message) => handle_runtime_osc(&state, message),
+                            Err(error) => Err(error.into()),
+                        };
+                        if let Err(error) = result {
+                            let _ = send_event(&mut socket, &ServerEvent::Error { message: error.to_string() }).await;
                         }
                     }
                     Some(Ok(Message::Binary(bytes))) => {
                         output_mode = WsOutputMode::Kep;
-                        match decode_kep_osc_message(&bytes) {
-                            Ok(message) => {
-                                if let Err(err) = handle_runtime_osc_message(&state, message) {
-                                    broadcast_error(&state, err.to_string());
-                                }
-                            }
-                            Err(err) => broadcast_error(&state, format!("invalid runtime KEP message: {err:#}")),
-                        }
+                        let result = decode_kep_osc_message(&bytes).and_then(|message| {
+                            anyhow::ensure!(!message.address.starts_with("/input/arena/"), "Arena requires its versioned JSON envelope in this stage");
+                            handle_runtime_osc_message(&state, message)
+                        });
+                        if let Err(error) = result { broadcast_error(&state, error.to_string()); }
                     }
                     Some(Ok(Message::Close(_))) | None => break,
+                    Some(Err(error)) => { error!("runtime websocket receive error: {error}"); break; }
                     Some(Ok(_)) => {}
-                    Some(Err(err)) => {
-                        error!("runtime websocket receive error: {err}");
-                        break;
-                    }
                 }
             }
             event = receiver.recv() => {
                 match event {
                     Ok(event) => {
-                        if let Err(err) = send_event_with_mode(&mut socket, &event, output_mode).await {
-                            error!("runtime websocket send error: {err}");
-                            break;
-                        }
+                        if send_event_with_mode(&mut socket, &event, output_mode).await.is_err() { break; }
                     }
                     Err(broadcast::error::RecvError::Lagged(_)) => {
-                        if let Ok(snapshot) = snapshot(&state) {
-                            let _ = send_event_with_mode(&mut socket, &ServerEvent::State { snapshot }, output_mode).await;
-                        }
+                        // A complete projection replaces dropped transient presentation updates.
+                        if send_initial_runtime_state(&mut socket, &state, output_mode).await.is_err() { break; }
                     }
                     Err(broadcast::error::RecvError::Closed) => break,
                 }
             }
         }
     }
+    release_arena_controller(&state, connection_id);
+}
+
+fn enqueue_arena_request(
+    state: &AppState,
+    connection_id: u64,
+    envelope: ArenaClientEnvelope,
+) -> Result<()> {
+    let message = envelope.message.to_osc_message();
+    anyhow::ensure!(
+        message.address != "/input/arena/disconnect",
+        "disconnect is a host-originated control"
+    );
+    anyhow::ensure!(
+        !envelope.client_id.starts_with("host:"),
+        "reserved producer identity"
+    );
+    let metadata = InputMetadata {
+        source: envelope.client_id.clone(),
+        message_id: envelope.message_id,
+        schema_version: envelope.schema_version,
+    };
+    arena::validate_input(&message, &metadata)?;
+    let mut guard = state
+        .inner
+        .lock()
+        .map_err(|_| anyhow::anyhow!("state lock poisoned"))?;
+    anyhow::ensure!(
+        envelope.session_id == guard.runtime_id,
+        "Arena runtime session changed; synchronize before sending input"
+    );
+    if let Some((owner, source)) = &guard.controller {
+        anyhow::ensure!(
+            *owner == connection_id && source == &envelope.client_id,
+            "Arena already has an active controller"
+        );
+    } else {
+        guard.controller = Some((connection_id, envelope.client_id));
+    }
+    let mut bundle = kitu_osc_ir::OscBundle::new();
+    bundle.push(message);
+    guard.runtime.try_enqueue_input(bundle, Some(metadata))?;
+    Ok(())
+}
+
+fn release_arena_controller(state: &AppState, connection_id: u64) {
+    let Ok(mut guard) = state.inner.lock() else {
+        return;
+    };
+    if guard.controller.as_ref().map(|(id, _)| *id) != Some(connection_id) {
+        return;
+    }
+    guard.controller = None;
+    let mut bundle = kitu_osc_ir::OscBundle::new();
+    bundle.push(OscMessage::new("/input/arena/disconnect"));
+    guard.runtime.enqueue_tagged_input(
+        bundle,
+        InputMetadata {
+            source: "host:controller".into(),
+            message_id: connection_id,
+            schema_version: arena::SCHEMA_VERSION,
+        },
+    );
 }
 
 async fn send_initial_state(socket: &mut WebSocket, state: &AppState) -> Result<()> {
@@ -436,7 +549,11 @@ async fn send_initial_state(socket: &mut WebSocket, state: &AppState) -> Result<
     Ok(())
 }
 
-async fn send_initial_runtime_state(socket: &mut WebSocket, state: &AppState) -> Result<()> {
+async fn send_initial_runtime_state(
+    socket: &mut WebSocket,
+    state: &AppState,
+    mode: WsOutputMode,
+) -> Result<()> {
     let tick = {
         let guard = state
             .inner
@@ -445,22 +562,56 @@ async fn send_initial_runtime_state(socket: &mut WebSocket, state: &AppState) ->
         guard.runtime.current_tick().get()
     };
 
-    send_event(
+    send_event_with_mode(
         socket,
         &ServerEvent::Connected {
             protocol: "kitu-runtime-osc-ir-json-v1",
             tick,
         },
+        mode,
     )
     .await?;
-    send_event(
+    send_event_with_mode(
         socket,
         &ServerEvent::State {
             snapshot: snapshot(state)?,
         },
+        mode,
     )
     .await?;
 
+    let (session_id, projection) = {
+        let guard = state
+            .inner
+            .lock()
+            .map_err(|_| anyhow::anyhow!("state lock poisoned"))?;
+        (
+            guard.runtime_id.clone(),
+            guard.runtime.inspect_application(),
+        )
+    };
+    send_event_with_mode(
+        socket,
+        &ServerEvent::ArenaSession {
+            id: session_id,
+            schema_version: arena::SCHEMA_VERSION,
+        },
+        mode,
+    )
+    .await?;
+    for bundle in projection {
+        for message in bundle.messages {
+            send_event_with_mode(
+                socket,
+                &ServerEvent::Osc {
+                    address: message.address,
+                    args: message.args.into_iter().map(JsonOscArg::from).collect(),
+                },
+                mode,
+            )
+            .await?;
+        }
+    }
     Ok(())
 }
 
@@ -518,6 +669,10 @@ fn handle_runtime_osc_message(state: &AppState, osc_message: OscMessage) -> Resu
 }
 
 fn run_runtime_osc_request(state: &AppState, osc_message: OscMessage) -> Result<Vec<ServerEvent>> {
+    anyhow::ensure!(
+        !osc_message.address.starts_with("/input/arena/"),
+        "Arena input requires the versioned /ws/runtime connection"
+    );
     let mut bundle = kitu_osc_ir::OscBundle::new();
     bundle.push(osc_message.clone());
 
@@ -527,7 +682,7 @@ fn run_runtime_osc_request(state: &AppState, osc_message: OscMessage) -> Result<
         .map_err(|_| anyhow::anyhow!("state lock poisoned"))?;
     let mut outgoing_events = Vec::new();
 
-    guard.runtime.enqueue_input(bundle);
+    guard.runtime.try_enqueue_input(bundle, None)?;
     outgoing_events.push(ServerEvent::Log {
         entry: guard.push_log(
             LogLevel::Info,
@@ -536,21 +691,28 @@ fn run_runtime_osc_request(state: &AppState, osc_message: OscMessage) -> Result<
         ),
     });
 
+    Ok(outgoing_events)
+}
+
+fn advance_runtime_tick(state: &AppState) -> Result<Vec<ServerEvent>> {
+    let mut guard = state
+        .inner
+        .lock()
+        .map_err(|_| anyhow::anyhow!("state lock poisoned"))?;
     guard.runtime.tick_once().context("tick Kitu runtime")?;
+    let mut events = Vec::new();
     for bundle in guard.runtime.drain_output_buffer() {
         for message in bundle.messages {
-            outgoing_events.push(ServerEvent::Osc {
-                address: message.address.clone(),
+            events.push(ServerEvent::Osc {
+                address: message.address,
                 args: message.args.into_iter().map(JsonOscArg::from).collect(),
             });
         }
     }
-
-    outgoing_events.push(ServerEvent::State {
+    events.push(ServerEvent::State {
         snapshot: guard.snapshot(),
     });
-
-    Ok(outgoing_events)
+    Ok(events)
 }
 
 fn decode_kep_osc_message(bytes: &[u8]) -> Result<OscMessage> {
@@ -605,7 +767,6 @@ fn run_app_action_request(
         Some(osc_message.address.clone()),
     );
 
-    guard.runtime.tick_once().context("tick Kitu runtime")?;
     for bundle in guard.runtime.drain_output_buffer() {
         for message in bundle.messages {
             outgoing_events.push(ServerEvent::Osc {
@@ -819,6 +980,77 @@ mod tests {
         }
     }
 
+    fn arena_request(state: &AppState, id: u64, address: &str) -> ArenaClientEnvelope {
+        ArenaClientEnvelope {
+            schema_version: arena::SCHEMA_VERSION,
+            session_id: state.inner.lock().unwrap().runtime_id.clone(),
+            client_id: "test-controller".into(),
+            message_id: id,
+            message: ClientOscMessage {
+                address: address.into(),
+                args: vec![],
+            },
+        }
+    }
+
+    fn arena_projection(state: &AppState) -> arena::ArenaState {
+        let guard = state.inner.lock().unwrap();
+        let projection = guard.runtime.inspect_application();
+        let OscArg::Str(json) = &projection[0].messages[0].args[0] else {
+            panic!("state JSON");
+        };
+        serde_json::from_str(json).unwrap()
+    }
+
+    #[test]
+    fn arena_admission_never_advances_time_and_disconnect_requires_resume() {
+        let state = test_state();
+        for _ in 0..20 {
+            enqueue_arena_request(&state, 1, arena_request(&state, 1, "/input/arena/start"))
+                .unwrap();
+        }
+        assert_eq!(arena_projection(&state).simulation_steps, 0);
+        for _ in 0..60 {
+            advance_runtime_tick(&state).unwrap();
+        }
+        assert_eq!(arena_projection(&state).simulation_steps, 60);
+        let before = arena_projection(&state).elapsed;
+        release_arena_controller(&state, 99); // An observer cannot pause the controller.
+        assert!(state.inner.lock().unwrap().controller.is_some());
+        release_arena_controller(&state, 1);
+        advance_runtime_tick(&state).unwrap();
+        assert_eq!(arena_projection(&state).overlay, "pause");
+        assert_eq!(arena_projection(&state).elapsed, before);
+        // Reconnect can synchronize and issue commands, but only resume runs time.
+        enqueue_arena_request(&state, 2, arena_request(&state, 2, "/input/arena/pause")).unwrap();
+        advance_runtime_tick(&state).unwrap();
+        assert_eq!(arena_projection(&state).elapsed, before);
+        enqueue_arena_request(&state, 2, arena_request(&state, 3, "/input/arena/resume")).unwrap();
+        advance_runtime_tick(&state).unwrap();
+        assert_eq!(arena_projection(&state).simulation_steps, 61);
+    }
+
+    #[test]
+    fn invalid_or_competing_arena_envelopes_do_not_claim_or_poison_the_queue() {
+        let state = test_state();
+        let mut request = arena_request(&state, 1, "/input/arena/start");
+        request.session_id = "stale runtime".into();
+        assert!(enqueue_arena_request(&state, 1, request).is_err());
+        assert!(state.inner.lock().unwrap().controller.is_none());
+        enqueue_arena_request(&state, 1, arena_request(&state, 1, "/input/arena/start")).unwrap();
+        assert!(
+            enqueue_arena_request(&state, 2, arena_request(&state, 2, "/input/arena/menu"))
+                .is_err()
+        );
+        let mut malformed = arena_request(&state, 3, "/input/arena/frame");
+        malformed.message.args.push(JsonOscArg::Float(f32::NAN));
+        assert!(enqueue_arena_request(&state, 1, malformed).is_err());
+        assert!(handle_client_osc_message(&state, OscMessage::new("/input/arena/menu")).is_err());
+        advance_runtime_tick(&state).unwrap();
+        assert_eq!(arena_projection(&state).phase, 1);
+        assert_eq!(arena_projection(&state).simulation_steps, 1);
+    }
+
     #[test]
     fn runtime_osc_request_executes_player_move_slice() {
         let state = test_state();
@@ -831,7 +1063,12 @@ mod tests {
             ],
         };
 
-        let events = run_runtime_osc_request(&state, request.to_osc_message()).unwrap();
+        let admitted = run_runtime_osc_request(&state, request.to_osc_message()).unwrap();
+        assert!(admitted
+            .iter()
+            .all(|event| matches!(event, ServerEvent::Log { .. })));
+        assert_eq!(state.inner.lock().unwrap().runtime.current_tick().get(), 0);
+        let events = advance_runtime_tick(&state).unwrap();
         let render = events
             .iter()
             .find_map(|event| match event {
@@ -927,6 +1164,9 @@ mod tests {
         message.push_arg(OscArg::Float(2.0));
 
         handle_client_osc_message(&state, message).unwrap();
+        for event in advance_runtime_tick(&state).unwrap() {
+            let _ = state.events.send(event);
+        }
 
         let mut saw_state = false;
         while let Ok(event) = receiver.try_recv() {

--- a/apps/demo-game/src/bin/admin_host.rs
+++ b/apps/demo-game/src/bin/admin_host.rs
@@ -1037,6 +1037,15 @@ mod tests {
         request.session_id = "stale runtime".into();
         assert!(enqueue_arena_request(&state, 1, request).is_err());
         assert!(state.inner.lock().unwrap().controller.is_none());
+        assert!(
+            enqueue_arena_request(&state, 1, arena_request(&state, 1, "/input/arena/take"))
+                .is_err()
+        );
+        assert!(
+            enqueue_arena_request(&state, 1, arena_request(&state, 1, "/input/arena/unknown"))
+                .is_err()
+        );
+        assert!(state.inner.lock().unwrap().controller.is_none());
         enqueue_arena_request(&state, 1, arena_request(&state, 1, "/input/arena/start")).unwrap();
         assert!(
             enqueue_arena_request(&state, 2, arena_request(&state, 2, "/input/arena/menu"))

--- a/apps/demo-game/src/lib.rs
+++ b/apps/demo-game/src/lib.rs
@@ -7,6 +7,8 @@ use anyhow::{Context, Result};
 use kitu_runtime::{build_runtime, Runtime};
 use kitu_transport::LocalChannel;
 
+pub mod arena;
+
 /// Stable app identifier used in project-scoped app actions.
 pub const APP_ID: &str = "demo-game";
 
@@ -22,6 +24,20 @@ pub fn build_demo_runtime() -> Result<DemoRuntime> {
     runtime
         .load_project_app_actions_from_toml(APP_ID, APP_ACTIONS_TOML)
         .context("load demo-game app actions")?;
+    Ok(runtime)
+}
+
+/// Builds the same demo runtime with the authoritative Arena application installed.
+///
+/// # Examples
+/// ```
+/// let mut runtime = kitu_demo_game::build_arena_runtime().unwrap();
+/// assert!(!runtime.inspect_application().is_empty());
+/// runtime.tick_once().unwrap();
+/// ```
+pub fn build_arena_runtime() -> Result<DemoRuntime> {
+    let mut runtime = build_demo_runtime()?;
+    arena::install(&mut runtime)?;
     Ok(runtime)
 }
 

--- a/apps/demo-game/tests/arena_lifecycle.rs
+++ b/apps/demo-game/tests/arena_lifecycle.rs
@@ -1,0 +1,199 @@
+use kitu_demo_game::{arena::ArenaState, build_arena_runtime, DemoRuntime};
+use kitu_osc_ir::{OscArg, OscBundle, OscMessage};
+use kitu_runtime::InputMetadata;
+
+fn input(runtime: &mut DemoRuntime, id: u64, suffix: &str, args: Vec<OscArg>) {
+    let mut bundle = OscBundle::new();
+    let mut message = OscMessage::new(format!("/input/arena/{suffix}"));
+    message.args = args;
+    bundle.push(message);
+    runtime.enqueue_tagged_input(
+        bundle,
+        InputMetadata {
+            source: "test".into(),
+            message_id: id,
+            schema_version: 1,
+        },
+    );
+}
+
+fn state(runtime: &DemoRuntime) -> ArenaState {
+    let projection = runtime.inspect_application();
+    let OscArg::Str(json) = &projection[0].messages[0].args[0] else {
+        panic!("JSON projection");
+    };
+    serde_json::from_str(json).unwrap()
+}
+
+fn frame(x: f32, y: f32) -> Vec<OscArg> {
+    vec![
+        OscArg::Float(x),
+        OscArg::Float(y),
+        OscArg::Bool(true),
+        OscArg::Float(0.0),
+        OscArg::Float(0.0),
+        OscArg::Bool(false),
+        OscArg::Bool(false),
+    ]
+}
+
+#[test]
+fn fixed_steps_match_reference_movement_clamp_and_aim_and_pause_clears_controls() {
+    let mut runtime = build_arena_runtime().unwrap();
+    input(&mut runtime, 1, "start", vec![]);
+    input(&mut runtime, 2, "frame", frame(1.0, 1.0));
+    let dt = 1.0_f32 / 60.0;
+    let mut expected_x = 0.0_f32;
+    let mut expected_y = -7.0_f32;
+    let mut elapsed = 0.0_f32;
+    for _ in 0..400 {
+        expected_x = (expected_x + (1.0 / 2.0_f32.sqrt()) * (5.0 * dt)).clamp(-9.5, 9.5);
+        expected_y = (expected_y + (1.0 / 2.0_f32.sqrt()) * (5.0 * dt)).clamp(-9.5, 9.5);
+        elapsed += dt;
+        runtime.tick_once().unwrap();
+        runtime.drain_output_buffer();
+    }
+    let moving = state(&runtime);
+    assert_eq!(moving.simulation_steps, 400);
+    assert_eq!(moving.elapsed, elapsed);
+    assert_eq!(moving.player_position.x, expected_x);
+    assert_eq!(moving.player_position.y, expected_y);
+    assert!((moving.aim_direction.x + 1.0 / 2.0_f32.sqrt()).abs() < 1e-4);
+    input(&mut runtime, 3, "pause", vec![]);
+    for _ in 0..120 {
+        runtime.tick_once().unwrap();
+        runtime.drain_output_buffer();
+    }
+    assert_eq!(state(&runtime).elapsed, elapsed);
+    assert_eq!(state(&runtime).tick, 519);
+    input(&mut runtime, 4, "resume", vec![]);
+    runtime.tick_once().unwrap();
+    assert_eq!(state(&runtime).player_position, moving.player_position);
+    assert_eq!(state(&runtime).simulation_steps, 401);
+    // A fresh frame moves; out-of-order delivery cannot reintroduce stale movement.
+    input(&mut runtime, 6, "frame", frame(-1.0, 0.0));
+    input(&mut runtime, 5, "frame", frame(1.0, 0.0));
+    runtime.tick_once().unwrap();
+    assert!(state(&runtime).player_position.x < moving.player_position.x);
+}
+
+#[test]
+fn invalid_batch_is_atomic_and_command_retries_retain_their_original_result() {
+    let mut runtime = build_arena_runtime().unwrap();
+    input(&mut runtime, 1, "start", vec![]);
+    input(&mut runtime, 2, "frame", frame(f32::NAN, 0.0));
+    assert!(runtime.tick_once().is_err());
+    assert_eq!(state(&runtime).phase, 0);
+    input(&mut runtime, 1, "start", vec![]);
+    runtime.tick_once().unwrap();
+    runtime.drain_output_buffer();
+    input(&mut runtime, 1, "start", vec![]);
+    input(&mut runtime, 1, "menu", vec![]);
+    runtime.tick_once().unwrap();
+    let outcomes: Vec<serde_json::Value> = runtime
+        .drain_output_buffer()
+        .into_iter()
+        .flat_map(|bundle| bundle.messages)
+        .filter(|message| message.address == "/ui/arena/command")
+        .map(|message| {
+            let OscArg::Str(json) = &message.args[0] else {
+                panic!("JSON outcome")
+            };
+            serde_json::from_str(json).unwrap()
+        })
+        .collect();
+    assert_eq!(outcomes[0]["appliedTick"], 0);
+    assert_eq!(outcomes[0]["duplicate"], true);
+    assert_eq!(outcomes[1]["code"], "id_conflict");
+    assert_eq!(outcomes[1]["appliedTick"], -1);
+    assert_eq!(state(&runtime).phase, 1);
+    assert_eq!(state(&runtime).simulation_steps, 2);
+}
+
+#[test]
+fn resetting_legacy_world_objects_preserves_application_state_and_control_queue() {
+    let mut runtime = build_arena_runtime().unwrap();
+    input(&mut runtime, 1, "start", vec![]);
+    runtime.tick_once().unwrap();
+    input(&mut runtime, 2, "disconnect", vec![]);
+    runtime.reset_world_objects();
+    runtime.tick_once().unwrap();
+    assert_eq!(state(&runtime).phase, 1);
+    assert_eq!(state(&runtime).overlay, "pause");
+    assert_eq!(state(&runtime).simulation_steps, 1);
+}
+
+#[test]
+fn stock_reference_approach_matches_frozen_csharp_checkpoints() {
+    let reference = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../kitu-integration-runner/scenarios/arena/reference/stock-eleven-death-retry");
+    let scenario: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(reference.join("scenario.json")).unwrap())
+            .unwrap();
+    let checkpoints: Vec<serde_json::Value> =
+        std::fs::read_to_string(reference.join("expected.ndjson"))
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+    let mut runtime = build_arena_runtime().unwrap();
+    let mut compared = 0;
+    // This migration slice ends before the first chest interaction (tick 75).
+    // Inputs and expected coordinates come from the unchanged C# capture, not a new bot.
+    for step in scenario["steps"].as_array().unwrap().iter().take(75) {
+        let tick = step["tick"].as_u64().unwrap();
+        for command in step["commands"].as_array().unwrap() {
+            input(
+                &mut runtime,
+                command["id"].as_u64().unwrap(),
+                "start",
+                vec![],
+            );
+            assert_eq!(command["address"], "/input/arena/start");
+        }
+        let f = &step["frame"];
+        input(
+            &mut runtime,
+            100_000 + tick,
+            "frame",
+            vec![
+                OscArg::Float(f["Move"]["x"].as_f64().unwrap() as f32),
+                OscArg::Float(f["Move"]["y"].as_f64().unwrap() as f32),
+                OscArg::Bool(f["HasAim"].as_bool().unwrap()),
+                OscArg::Float(f["AimPoint"]["x"].as_f64().unwrap() as f32),
+                OscArg::Float(f["AimPoint"]["y"].as_f64().unwrap() as f32),
+                OscArg::Bool(false),
+                OscArg::Bool(false),
+            ],
+        );
+        runtime.tick_once().unwrap();
+        runtime.drain_output_buffer();
+        if let Some(expected) = checkpoints.iter().find(|value| value["tick"] == tick) {
+            let actual = state(&runtime);
+            for (name, value) in [
+                ("tick", actual.tick),
+                ("simulationSteps", actual.simulation_steps as i64),
+                ("phase", actual.phase as i64),
+                ("floor", actual.floor as i64),
+            ] {
+                assert_eq!(expected[name], value, "tick {tick}: {name}");
+            }
+            assert_eq!(expected["overlay"], actual.overlay);
+            for (path, value) in [
+                ("/elapsed", actual.elapsed),
+                ("/playerPosition/x", actual.player_position.x),
+                ("/playerPosition/y", actual.player_position.y),
+                ("/aimDirection/x", actual.aim_direction.x),
+                ("/aimDirection/y", actual.aim_direction.y),
+            ] {
+                assert!(
+                    (expected.pointer(path).unwrap().as_f64().unwrap() - value as f64).abs()
+                        <= 1e-4,
+                    "tick {tick}: {path}"
+                );
+            }
+            compared += 1;
+        }
+    }
+    assert_eq!(compared, 2);
+}

--- a/apps/demo-game/tests/arena_lifecycle.rs
+++ b/apps/demo-game/tests/arena_lifecycle.rs
@@ -197,3 +197,74 @@ fn stock_reference_approach_matches_frozen_csharp_checkpoints() {
     }
     assert_eq!(compared, 2);
 }
+
+#[test]
+fn message_identity_is_shared_across_frames_and_discrete_commands() {
+    let mut runtime = build_arena_runtime().unwrap();
+    input(&mut runtime, 1, "start", vec![]);
+    input(&mut runtime, 2, "frame", frame(1.0, 0.0));
+    runtime.tick_once().unwrap();
+    let before = state(&runtime).player_position.x;
+    runtime.drain_output_buffer();
+    input(&mut runtime, 2, "menu", vec![]); // Frame ID cannot become an operation.
+    input(&mut runtime, 1, "frame", frame(-1.0, 0.0)); // Operation ID cannot replace controls.
+    runtime.tick_once().unwrap();
+    assert_eq!(state(&runtime).phase, 1);
+    assert!(state(&runtime).player_position.x > before);
+    let conflicts = runtime
+        .drain_output_buffer()
+        .into_iter()
+        .flat_map(|b| b.messages)
+        .filter(|m| m.address == "/ui/arena/command")
+        .count();
+    assert_eq!(conflicts, 2);
+    input(&mut runtime, 1, "start", vec![]); // A real command retry is still recognized.
+    runtime.tick_once().unwrap();
+    assert_eq!(state(&runtime).simulation_steps, 3);
+}
+
+#[test]
+fn deferred_commands_validate_the_complete_declared_payload_before_admission() {
+    let mut runtime = build_arena_runtime().unwrap();
+    let meta = InputMetadata {
+        source: "test".into(),
+        message_id: 1,
+        schema_version: 1,
+    };
+    for (suffix, count) in [
+        ("inventory", 0),
+        ("chest", 0),
+        ("close", 0),
+        ("use", 1),
+        ("take", 2),
+        ("discard", 2),
+        ("upgrade", 2),
+        ("unequip", 2),
+        ("equip", 3),
+    ] {
+        let mut message = OscMessage::new(format!("/input/arena/{suffix}"));
+        message.args = vec![OscArg::Int(1); count];
+        kitu_demo_game::arena::validate_input(&message, &meta).unwrap();
+        message.args.push(OscArg::Int(1));
+        assert!(
+            kitu_demo_game::arena::validate_input(&message, &meta).is_err(),
+            "{suffix} extra argument"
+        );
+        message.args = vec![OscArg::Float(1.0); count.max(1)];
+        let mut bundle = OscBundle::new();
+        bundle.push(message);
+        assert!(
+            runtime
+                .try_enqueue_input(bundle, Some(meta.clone()))
+                .is_err(),
+            "{suffix} wrong types"
+        );
+    }
+    assert!(
+        kitu_demo_game::arena::validate_input(&OscMessage::new("/input/arena/unknown"), &meta)
+            .is_err()
+    );
+    input(&mut runtime, 1, "start", vec![]);
+    runtime.tick_once().unwrap();
+    assert_eq!(state(&runtime).phase, 1);
+}

--- a/crates/kitu-ecs/README.md
+++ b/crates/kitu-ecs/README.md
@@ -5,6 +5,7 @@ Lightweight ECS world and scheduler powering the Kitu runtime loop.
 ## Responsibilities
 - Track registered component types without locking the runtime into a heavyweight backend.
 - Provide system scheduling hooks that keep ticking deterministic and testable.
+- Own typed application resources with immutable/mutable access scoped to this world.
 - Serve as the glue between runtime orchestration and domain-specific systems.
 
 ## Publish readiness

--- a/crates/kitu-ecs/src/lib.rs
+++ b/crates/kitu-ecs/src/lib.rs
@@ -9,7 +9,10 @@
 //! The runtime (`kitu-runtime`) drives this crate each tick, and transports surface events that
 //! systems can consume. See `doc/crates-overview.md` for the ECS' place in the overall loop.
 
-use std::collections::{HashMap, VecDeque};
+use std::{
+    any::{Any, TypeId},
+    collections::{HashMap, VecDeque},
+};
 
 use kitu_core::{KituError, Result, Tick};
 
@@ -57,6 +60,7 @@ pub struct WorldSnapshot {
 
 /// Minimal world representation for registering components and systems.
 pub struct EcsWorld {
+    resources: HashMap<TypeId, Box<dyn Any + Send + Sync>>,
     components: Vec<String>,
     scheduled: VecDeque<Box<dyn System>>,
     next_world_object_id: u64,
@@ -73,11 +77,37 @@ impl EcsWorld {
     /// Creates an empty ECS world.
     pub fn new() -> Self {
         Self {
+            resources: HashMap::new(),
             components: Vec::new(),
             scheduled: VecDeque::new(),
             next_world_object_id: 1,
             world_objects: Vec::new(),
         }
+    }
+
+    /// Installs or replaces a typed application resource owned by this world.
+    ///
+    /// # Examples
+    /// ```
+    /// use kitu_ecs::EcsWorld;
+    /// let mut world = EcsWorld::new();
+    /// world.insert_resource(12_u32);
+    /// assert_eq!(world.resource::<u32>(), Some(&12));
+    /// *world.resource_mut::<u32>().unwrap() = 13;
+    /// assert_eq!(world.resource::<u32>(), Some(&13));
+    /// ```
+    pub fn insert_resource<R: Any + Send + Sync>(&mut self, resource: R) {
+        self.resources.insert(TypeId::of::<R>(), Box::new(resource));
+    }
+
+    /// Borrows a typed resource without granting mutation access.
+    pub fn resource<R: Any + Send + Sync>(&self) -> Option<&R> {
+        self.resources.get(&TypeId::of::<R>())?.downcast_ref()
+    }
+
+    /// Borrows a typed resource for a runtime-owned update.
+    pub fn resource_mut<R: Any + Send + Sync>(&mut self) -> Option<&mut R> {
+        self.resources.get_mut(&TypeId::of::<R>())?.downcast_mut()
     }
 
     /// Registers a component type by name. The concrete storage will be wired later.

--- a/crates/kitu-runtime/README.md
+++ b/crates/kitu-runtime/README.md
@@ -8,6 +8,7 @@ Tick-based orchestrator that wires Kitu ECS, transports, and future scripting/ti
 - Apply transport input on the next tick (`N` receive -> `N+1` apply).
 - Emit staged runtime output after ECS dispatch and before transport polling.
 - Implement the minimum player move vertical slice (`/input/move` -> `/render/player/transform`).
+- Install persistent application hooks with validated, sequenced input metadata and detached projections.
 - Bridge transports, scripting, and data playback while keeping the loop embeddable.
 
 ## Publish readiness

--- a/crates/kitu-runtime/src/application.rs
+++ b/crates/kitu-runtime/src/application.rs
@@ -1,0 +1,55 @@
+//! Persistent application hooks executed inside the runtime input/output barriers.
+
+use kitu_core::{Result, Tick};
+use kitu_ecs::EcsWorld;
+use kitu_osc_ir::OscBundle;
+
+/// Identity and schema information retained alongside a logical input bundle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InputMetadata {
+    /// Stable producer identity, retained across reconnects to the same runtime.
+    pub source: String,
+    /// Producer-scoped monotonically allocated operation identifier.
+    pub message_id: u64,
+    /// Application contract version, independent of wire encoding.
+    pub schema_version: u32,
+}
+
+/// A logical bundle with optional application envelope metadata.
+#[derive(Debug, Clone)]
+pub struct RuntimeInput {
+    /// Runtime-assigned enqueue order, independent of producer IDs and wire timing.
+    pub sequence: u64,
+    /// Original ordered logical messages.
+    pub bundle: OscBundle,
+    /// Application identity; legacy movement and transport inputs may omit it.
+    pub metadata: Option<InputMetadata>,
+}
+
+/// Immutable committed input context for a single authoritative tick.
+pub struct ApplicationTick<'a> {
+    /// Authoritative source tick, before the runtime increments it.
+    pub tick: Tick,
+    /// Configured fixed timestep in seconds.
+    pub dt: f32,
+    /// Frozen input batch; inputs arriving during this tick belong to a later tick.
+    pub inputs: &'a [RuntimeInput],
+}
+
+/// Application behavior installed before the runtime's first tick.
+///
+/// Keep state in typed [`EcsWorld`] resources and use `snapshot` for detached
+/// projections. Validate fallible input parsing before any system dispatch.
+/// After validation, `tick` commits an infallible rule update: state-dependent
+/// rejections are ordinary outputs, not runtime failures that invite retries.
+/// Implementations must not read wall-clock time or perform host I/O in a tick.
+pub trait RuntimeApplication: Send + Sync + 'static {
+    /// Validates structural input requirements without mutating application state.
+    fn validate_inputs(&self, inputs: &[RuntimeInput]) -> Result<()>;
+
+    /// Updates world-owned state and returns outputs staged for the current barrier.
+    fn tick(&mut self, world: &mut EcsWorld, context: ApplicationTick<'_>) -> Vec<OscBundle>;
+
+    /// Returns detached projection messages without advancing or mutating the world.
+    fn snapshot(&self, world: &EcsWorld) -> Vec<OscBundle>;
+}

--- a/crates/kitu-runtime/src/lib.rs
+++ b/crates/kitu-runtime/src/lib.rs
@@ -25,15 +25,29 @@ pub use kitu_ecs::{WorldObject, WorldSnapshot, WorldTransform};
 use kitu_osc_ir::{OscArg, OscBundle, OscMessage};
 use kitu_transport::{Transport, TransportEvent};
 
+mod application;
+pub use application::{ApplicationTick, InputMetadata, RuntimeApplication, RuntimeInput};
+
 #[derive(Default)]
 struct AuthoritativeInputQueue {
-    committed_batch: VecDeque<OscBundle>,
-    pending_queue: VecDeque<OscBundle>,
+    committed_batch: VecDeque<RuntimeInput>,
+    pending_queue: VecDeque<RuntimeInput>,
+    next_sequence: u64,
 }
 
 impl AuthoritativeInputQueue {
     fn enqueue_pending(&mut self, input: OscBundle) {
-        self.pending_queue.push_back(input);
+        self.enqueue_with_metadata(input, None);
+    }
+
+    fn enqueue_with_metadata(&mut self, bundle: OscBundle, metadata: Option<InputMetadata>) {
+        let sequence = self.next_sequence;
+        self.next_sequence += 1;
+        self.pending_queue.push_back(RuntimeInput {
+            sequence,
+            bundle,
+            metadata,
+        });
     }
 
     fn commit_next_tick_batch(&mut self) {
@@ -42,11 +56,17 @@ impl AuthoritativeInputQueue {
     }
 
     fn drain_committed(&mut self) -> Vec<OscBundle> {
-        self.committed_batch.drain(..).collect()
+        self.committed_batch
+            .drain(..)
+            .map(|input| input.bundle)
+            .collect()
     }
 
     fn committed_snapshot(&self) -> Vec<OscBundle> {
-        self.committed_batch.iter().cloned().collect()
+        self.committed_batch
+            .iter()
+            .map(|input| input.bundle.clone())
+            .collect()
     }
 
     fn clear(&mut self) {
@@ -134,6 +154,7 @@ pub struct Runtime<T: Transport> {
     outputs: OutputBuffer,
     player_transforms: HashMap<String, PlayerTransform>,
     app_actions: AppActionCatalog,
+    application: Option<Box<dyn RuntimeApplication>>,
 }
 
 /// Result of executing an app action through the runtime.
@@ -170,6 +191,7 @@ impl<T: Transport> Runtime<T> {
             outputs: OutputBuffer::default(),
             player_transforms: HashMap::new(),
             app_actions: kitu_general_catalog(),
+            application: None,
         }
     }
 
@@ -211,9 +233,20 @@ impl<T: Transport> Runtime<T> {
     pub fn reset_world_objects(&mut self) {
         self.world.reset_world_objects();
         self.player_transforms.clear();
-        self.inputs.clear();
-        self.committed_input_tick = None;
-        self.outputs.clear();
+        if self.application.is_some() {
+            // Resetting the legacy object sandbox cannot discard an admitted
+            // application operation (in particular a controller-loss pause).
+            self.inputs
+                .pending_queue
+                .retain(|input| input.metadata.is_some());
+            self.inputs
+                .committed_batch
+                .retain(|input| input.metadata.is_some());
+        } else {
+            self.inputs.clear();
+            self.committed_input_tick = None;
+            self.outputs.clear();
+        }
     }
 
     /// Returns the authoritative runtime/ECS world snapshot.
@@ -271,6 +304,76 @@ impl<T: Transport> Runtime<T> {
     /// Enqueues an input bundle for the next tick.
     pub fn enqueue_input(&mut self, input: OscBundle) {
         self.inputs.enqueue_pending(input);
+    }
+
+    /// Queues a logical application input while retaining envelope identity.
+    pub fn enqueue_tagged_input(&mut self, input: OscBundle, metadata: InputMetadata) {
+        self.inputs.enqueue_with_metadata(input, Some(metadata));
+    }
+
+    /// Validates a host envelope before queuing it, returning its runtime-assigned order.
+    ///
+    /// Unlike unchecked legacy enqueue methods, malformed requests cannot discard
+    /// an already-admitted batch. Validation is structural and read-only; command
+    /// eligibility is still decided at the authoritative application tick.
+    ///
+    /// # Examples
+    /// ```
+    /// use kitu_runtime::build_runtime;
+    /// use kitu_transport::LocalChannel;
+    /// use kitu_osc_ir::OscBundle;
+    /// let mut runtime = build_runtime(LocalChannel::connected());
+    /// assert_eq!(runtime.try_enqueue_input(OscBundle::new(), None).unwrap(), 0);
+    /// ```
+    pub fn try_enqueue_input(
+        &mut self,
+        bundle: OscBundle,
+        metadata: Option<InputMetadata>,
+    ) -> Result<u64> {
+        for message in &bundle.messages {
+            if message.address == "/input/move" {
+                parse_move_input(message)?;
+            }
+        }
+        let input = RuntimeInput {
+            sequence: self.inputs.next_sequence,
+            bundle,
+            metadata,
+        };
+        if let Some(application) = &self.application {
+            application.validate_inputs(std::slice::from_ref(&input))?;
+        }
+        let sequence = input.sequence;
+        self.inputs
+            .enqueue_with_metadata(input.bundle, input.metadata);
+        Ok(sequence)
+    }
+
+    /// Installs persistent application behavior before the first authoritative tick.
+    ///
+    /// Returns an error if an application is already installed or execution started.
+    /// Initialize the application's typed world resources before calling this method.
+    pub fn install_application<A: RuntimeApplication>(&mut self, application: A) -> Result<()> {
+        if self.tick.get() != 0 || self.application.is_some() {
+            return Err(KituError::InvalidInput(
+                "application must be installed once before execution",
+            ));
+        }
+        if self.config.tick_rate_hz == 0 || self.config.frame_time().is_zero() {
+            return Err(KituError::InvalidInput(
+                "application requires a positive fixed timestep",
+            ));
+        }
+        self.application = Some(Box::new(application));
+        Ok(())
+    }
+
+    /// Returns the application's detached current projection without ticking.
+    pub fn inspect_application(&self) -> Vec<OscBundle> {
+        self.application
+            .as_ref()
+            .map(|app| app.snapshot(&self.world))
+            .unwrap_or_default()
     }
 
     /// Stages an output bundle that becomes visible after the current tick.
@@ -427,8 +530,30 @@ impl<T: Transport> Runtime<T> {
                 return Err(error);
             }
         };
+        let application_inputs: Vec<_> = self.inputs.committed_batch.iter().cloned().collect();
+        if let Some(application) = self.application.as_ref() {
+            if let Err(error) = application.validate_inputs(&application_inputs) {
+                self.inputs.drain_committed();
+                self.committed_input_tick = None;
+                return Err(error);
+            }
+        }
         self.world.dispatch(self.tick)?;
         self.apply_player_move_slice(parsed_moves)?;
+
+        if let Some(application) = self.application.as_mut() {
+            let outputs = application.tick(
+                &mut self.world,
+                ApplicationTick {
+                    tick: self.tick,
+                    dt: self.config.frame_time().as_secs_f32(),
+                    inputs: &application_inputs,
+                },
+            );
+            for output in outputs {
+                self.outputs.stage(output);
+            }
+        }
 
         self.outputs.emit_staged();
 

--- a/crates/kitu-runtime/tests/application.rs
+++ b/crates/kitu-runtime/tests/application.rs
@@ -1,0 +1,141 @@
+use kitu_core::{KituError, Result};
+use kitu_ecs::EcsWorld;
+use kitu_osc_ir::{OscArg, OscBundle, OscMessage};
+use kitu_runtime::{
+    ApplicationTick, InputMetadata, Runtime, RuntimeApplication, RuntimeConfig, RuntimeInput,
+};
+use kitu_transport::LocalChannel;
+
+struct Counter;
+
+impl RuntimeApplication for Counter {
+    fn validate_inputs(&self, inputs: &[RuntimeInput]) -> Result<()> {
+        if inputs
+            .iter()
+            .flat_map(|i| &i.bundle.messages)
+            .any(|m| m.address == "/bad")
+        {
+            return Err(KituError::InvalidInput("bad application command"));
+        }
+        Ok(())
+    }
+
+    fn tick(&mut self, world: &mut EcsWorld, context: ApplicationTick<'_>) -> Vec<OscBundle> {
+        *world.resource_mut::<u64>().unwrap() += 1;
+        let mut outputs = self.snapshot(world);
+        for input in context.inputs {
+            if let Some(meta) = &input.metadata {
+                let mut message = OscMessage::new("/receipt");
+                message.push_arg(OscArg::Str(meta.source.clone()));
+                message.push_arg(OscArg::Int64(meta.message_id as i64));
+                message.push_arg(OscArg::Int64(context.tick.get() as i64));
+                message.push_arg(OscArg::Float(context.dt));
+                message.push_arg(OscArg::Int64(input.sequence as i64));
+                outputs[0].push(message);
+            }
+        }
+        outputs
+    }
+
+    fn snapshot(&self, world: &EcsWorld) -> Vec<OscBundle> {
+        let mut output = OscBundle::new();
+        let mut state = OscMessage::new("/counter");
+        state.push_arg(OscArg::Int64(*world.resource::<u64>().unwrap() as i64));
+        output.push(state);
+        vec![output]
+    }
+}
+
+fn runtime() -> Runtime<LocalChannel> {
+    let mut runtime = Runtime::new(RuntimeConfig::default_60hz(), LocalChannel::connected());
+    runtime.world_mut().insert_resource(10_u64);
+    runtime.install_application(Counter).unwrap();
+    runtime
+}
+
+#[test]
+fn application_persists_without_inputs_and_preserves_tagged_input_timing() {
+    let mut runtime = runtime();
+    assert_eq!(
+        runtime.inspect_application()[0].messages[0].args,
+        vec![OscArg::Int64(10)]
+    );
+    runtime.enqueue_tagged_input(
+        OscBundle::new(),
+        InputMetadata {
+            source: "client-a".into(),
+            message_id: 7,
+            schema_version: 1,
+        },
+    );
+    assert!(runtime.drain_output_buffer().is_empty());
+    runtime.tick_once().unwrap();
+    let output = runtime.drain_output_buffer();
+    assert_eq!(output[0].messages[0].args, vec![OscArg::Int64(11)]);
+    assert_eq!(
+        output[0].messages[1].args,
+        vec![
+            OscArg::Str("client-a".into()),
+            OscArg::Int64(7),
+            OscArg::Int64(0),
+            OscArg::Float(1.0 / 60.0),
+            OscArg::Int64(0)
+        ]
+    );
+    runtime.tick_once().unwrap();
+    assert_eq!(
+        runtime.drain_output_buffer()[0].messages[0].args,
+        vec![OscArg::Int64(12)]
+    );
+    assert_eq!(runtime.current_tick().get(), 2);
+}
+
+#[test]
+fn malformed_application_batch_cannot_partially_advance_or_poison_following_ticks() {
+    let mut runtime = runtime();
+    let mut input = OscBundle::new();
+    input.push(OscMessage::new("/bad"));
+    runtime.enqueue_input(input);
+    assert!(runtime.tick_once().is_err());
+    assert_eq!(runtime.world_mut().resource::<u64>(), Some(&10));
+    assert_eq!(runtime.current_tick().get(), 0);
+    assert!(runtime.drain_output_buffer().is_empty());
+    runtime.tick_once().unwrap();
+    assert_eq!(runtime.world_mut().resource::<u64>(), Some(&11));
+    assert!(runtime.install_application(Counter).is_err());
+}
+
+#[test]
+fn resources_are_type_and_runtime_local_and_application_installation_is_guarded() {
+    let mut first = runtime();
+    let mut second = runtime();
+    first.world_mut().insert_resource("other type".to_string());
+    first.tick_once().unwrap();
+    assert_eq!(first.world_mut().resource::<u64>(), Some(&11));
+    assert_eq!(second.world_mut().resource::<u64>(), Some(&10));
+    assert!(second.world_mut().resource::<String>().is_none());
+    assert!(second.install_application(Counter).is_err());
+    let mut invalid = Runtime::new(RuntimeConfig { tick_rate_hz: 0 }, LocalChannel::connected());
+    assert!(invalid.install_application(Counter).is_err());
+}
+
+#[test]
+fn host_validation_rejects_bad_inputs_without_discarding_accepted_inputs() {
+    let mut runtime = runtime();
+    assert_eq!(
+        runtime.try_enqueue_input(OscBundle::new(), None).unwrap(),
+        0
+    );
+    let mut bad = OscBundle::new();
+    bad.push(OscMessage::new("/bad"));
+    assert!(runtime.try_enqueue_input(bad, None).is_err());
+    let mut bad_move = OscBundle::new();
+    bad_move.push(OscMessage::new("/input/move"));
+    assert!(runtime.try_enqueue_input(bad_move, None).is_err());
+    assert_eq!(
+        runtime.try_enqueue_input(OscBundle::new(), None).unwrap(),
+        1
+    );
+    runtime.tick_once().unwrap();
+    assert_eq!(runtime.drain_committed_inputs().len(), 2);
+}

--- a/doc/specs/arena-runtime-contract.md
+++ b/doc/specs/arena-runtime-contract.md
@@ -177,3 +177,41 @@ Normal tests only read the checked-in fixtures. Inspect generated differences
 before replacing a fixture. Run the `UnityOnlyArena.Tests` EditMode assembly and
 the existing PlayMode tests; use `tools/verify-arena-reference.py` from the
 repository root to verify pinned source provenance and fixture structure.
+
+## Stage 2 concrete connection
+
+`apps/demo-game` installs the persistent Arena application; the admin host clocks
+it independently at 60 Hz. `KituEndlessArena.unity` is the separate migration
+scene. This slice supports start/menu, movement/aim, pause/resume and host-originated
+disconnect. Inventory, combat and progression are later slices. Structurally
+valid unmigrated commands currently return `not_yet_implemented`.
+
+Connect to `/ws/runtime`. Initial text events include `arenaSession` with `id` and
+`schemaVersion`, followed by `/ui/arena/state`. A controlling client sends:
+
+```json
+{"schemaVersion":1,"sessionId":"<arenaSession.id>","clientId":"<stable-client-id>","messageId":1,"address":"/input/arena/start","args":[]}
+```
+
+`args` is an ordered array of `{ "type": "float", "value": 1.0 }` (or `int`,
+`int64`, `bool`, `str`). Version/session mismatches and malformed envelopes are
+rejected before queue admission. One websocket/client identity owns controls;
+other connected clients can observe. The host reserves producer IDs beginning
+with `host:` and generates disconnect when the owning websocket closes. Losing
+an observer does not pause the game. Restarting the process changes its session
+ID. A reconnect sends a complete projection and requires explicit resume; clients
+must not automatically resend unacknowledged commands or held controls.
+
+State and command output bodies are encoded as one OSC string argument containing
+JSON. State uses the reference field names, including Vector2 `x`/`y`. A command
+outcome also includes producer `source` and original runtime admission `sequence`;
+retries preserve the original applied tick, sequence and outcome. Continuously
+sampled frames use a per-producer high-water ID: stale/duplicate frames are ignored
+and do not grow the discrete-command cache. Message IDs must be monotonically
+allocated across all command kinds; do not reuse a frame ID as a discrete command.
+
+JSON is the Arena network encoding for this stage. The pre-existing legacy KEP
+path remains supported for legacy OSC; versioned Arena MessagePack admission is
+stage 15. Per-entity render/domain events and complete inventory state will be
+added at their migration slices. The current state projection is the rendering
+source for the initial player view, and does not claim full-game parity.

--- a/doc/specs/arena-runtime-contract.md
+++ b/doc/specs/arena-runtime-contract.md
@@ -206,9 +206,15 @@ State and command output bodies are encoded as one OSC string argument containin
 JSON. State uses the reference field names, including Vector2 `x`/`y`. A command
 outcome also includes producer `source` and original runtime admission `sequence`;
 retries preserve the original applied tick, sequence and outcome. Continuously
-sampled frames use a per-producer high-water ID: stale/duplicate frames are ignored
-and do not grow the discrete-command cache. Message IDs must be monotonically
-allocated across all command kinds; do not reuse a frame ID as a discrete command.
+sampled frames share a per-producer high-water ID with discrete commands. Stale
+frames are ignored; a frame reusing a cached command ID returns `id_conflict`.
+A first-seen discrete ID at or below that mark also returns `id_conflict`, so a
+previous frame ID cannot become a consuming operation. Exact cached command
+retries still return the original result. This keeps continuous input memory
+bounded without permitting cross-kind reuse. IDs must be monotonically allocated
+across all kinds; an out-of-order, previously unseen discrete command is rejected.
+Deferred commands still validate their full declared argument shape before queue
+admission; genuinely unknown addresses fail admission.
 
 JSON is the Arena network encoding for this stage. The pre-existing legacy KEP
 path remains supported for legacy OSC; versioned Arena MessagePack admission is

--- a/doc/specs/runtime-execution-contract.md
+++ b/doc/specs/runtime-execution-contract.md
@@ -34,16 +34,20 @@ For tick `N`, execution order is fixed as follows:
 2. **Collect runtime-boundary inputs for tick `N`**
    - Validate and snapshot committed messages that the current runtime owns directly.
    - Current MVP behavior collects `/input/move` before ECS dispatch so invalid movement input fails the tick before state mutation.
+   - A persistent `RuntimeApplication` validates the frozen metadata-bearing batch before any mutation.
 3. **Dispatch ECS systems for tick `N`**
    - Run scheduled ECS systems in deterministic order.
 4. **Apply runtime-owned MVP slice updates**
    - Current MVP behavior applies collected `/input/move` intents after ECS dispatch and stages `/render/player/transform`.
-5. **Emit outputs for tick `N`**
+5. **Update the installed application**
+   - Invoke its persistent tick hook using the fixed timestep and committed inputs.
+   - Application state lives in typed `EcsWorld` resources. State-dependent rejections are outputs, not failed ticks.
+6. **Emit outputs for tick `N`**
    - Move staged outputs into externally visible `output_buffer`.
-6. **Poll transport for next tick input**
+7. **Poll transport for next tick input**
    - Drain `poll_event()` until empty.
    - Any received `TransportEvent::Message` is enqueued into `pending_inputs`.
-7. **Advance tick**
+8. **Advance tick**
    - `tick = tick.next()`.
 
 ## Input timing rule (normative)
@@ -71,3 +75,26 @@ Hosts should poll outputs after `update()`/`tick_once()` returns.
 
 - `doc/architecture.md` defines architecture-level invariants.
 - `doc/detailed-flows.md` uses this tick contract when describing UC-02 and runtime boundaries.
+
+## Persistent applications and host scheduling
+
+`install_application` installs one `RuntimeApplication` before tick zero. Its
+`validate_inputs` hook must be read-only, while `tick` must be infallible after
+validation. The `snapshot` hook returns detached logical OSC projections without
+advancing time. `EcsWorld::{insert_resource, resource, resource_mut}` stores typed,
+world-owned application state independently from the one-shot system scheduler.
+
+`RuntimeInput` preserves `InputMetadata` (producer, message ID, schema) and a
+runtime-assigned monotonically increasing enqueue `sequence`. Hosts should call
+`try_enqueue_input`: it validates structural payloads before admission and returns
+the sequence. This prevents a malformed network packet from discarding other
+accepted inputs. Unchecked enqueue methods remain available for legacy callers;
+the tick still rejects a malformed committed batch atomically before dispatch.
+
+The demo admin host owns a Tokio interval at 60 Hz, independent of websocket and
+HTTP handlers. Those handlers enqueue inputs without invoking `tick_once`. The
+clock drains and broadcasts outputs after each barrier. No-input ticks continue
+running; paused applications still process control input and inspection while
+freezing their own game clocks. Generic legacy app actions retain their existing
+immediate world-object operations; they cannot mutate Arena resources. Runtime
+restart creates a new session and is not a resume-from-disk operation.

--- a/doc/verification/arena-runtime-host/results.json
+++ b/doc/verification/arena-runtime-host/results.json
@@ -1,0 +1,78 @@
+{
+  "stage": 2,
+  "issue": 132,
+  "baselineRevision": "38f2b4be4b7b2b604f1b21dfe9ce407846e0fc43",
+  "unityVersion": "6000.6.0f1",
+  "unity": {
+    "editmode": {
+      "result": "Passed",
+      "total": "46",
+      "passed": "46",
+      "failed": "0",
+      "skipped": "0",
+      "duration": "0.4037874"
+    },
+    "playmode": {
+      "result": "Passed",
+      "total": "13",
+      "passed": "13",
+      "failed": "0",
+      "skipped": "0",
+      "duration": "1.1741911"
+    },
+    "network": {
+      "result": "Passed",
+      "total": "1",
+      "passed": "1",
+      "failed": "0",
+      "skipped": "0",
+      "duration": "0.704192"
+    }
+  },
+  "rust": {
+    "environment": "Dedicated Dev Container using the repository development image and Rust 1.96.0",
+    "fmt": "passed",
+    "clippyAllTargetsAllFeatures": "passed",
+    "testsAndDoctestsPassed": 118,
+    "docAllNoDeps": "passed",
+    "packageLists": [
+      "kitu-ecs",
+      "kitu-runtime"
+    ],
+    "publishDryRun": "Deferred while publish=false per doc/publish-readiness.md; no publication attempted"
+  },
+  "comparison": {
+    "frozenScenario": "stock-eleven-death-retry",
+    "inputTicks": 75,
+    "checkpointTicks": [
+      0,
+      60
+    ],
+    "comparedFields": [
+      "tick",
+      "simulationSteps",
+      "phase",
+      "floor",
+      "overlay",
+      "elapsed",
+      "playerPosition",
+      "aimDirection"
+    ],
+    "floatAbsoluteTolerance": 0.0001
+  },
+  "sceneEvidence": "Actual PlayMode scene/transform and network assertions passed. Batch mode produced no screenshot; this is not visual QA or native-build evidence.",
+  "sourceSha256": {
+    "apps/demo-game/src/arena.rs": "d69965e9a62d8c63922484eac24c62547bdbbf1fc4b7f78273a2b8756a5fa496",
+    "apps/demo-game/src/bin/admin_host.rs": "942feffdeca7bfd38759568d9462d04dc2843c26119c211a4ad6e61a65ce7cd3",
+    "apps/demo-game/tests/arena_lifecycle.rs": "9b024a4874400238e257d82aa5dbc31987d2bb6f6ee1743e502aa7fd05600d21",
+    "crates/kitu-runtime/src/lib.rs": "2b111aec525a3f1960fca1954adaed0fd2b912a68cc3999930f22b89c2c9e7f1",
+    "crates/kitu-runtime/src/application.rs": "5c37e0e600c7f70fe59dfaee644814e2d9a0a28e1483621acd9683618b38958c",
+    "crates/kitu-runtime/tests/application.rs": "948f9cbdece3561087732a4ec0e51e2c065718f64ff5a0c271ed593d40629a2c",
+    "crates/kitu-ecs/src/lib.rs": "e486a3509e6a5672442a8cd131bce652df2ff0a1b44deb0305a53e7d0cf22d17",
+    "kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/ArenaConnection.cs": "a674eb08ba92b1385a69c5c54f8be7371edba88eb5a91b499151b450e9a6208d",
+    "kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/KituArenaClient.cs": "d0ce4f547987083da11e48666762da35cda75c16c66bedd21a1450aa4f09a1b1",
+    "kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/ArenaWorldView.cs": "9bc428dd737518814d250e496219fc2cde77b41971f7d7734b14483c648ada7a",
+    "kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Tests/PlayMode/KituArenaConnectionTests.cs": "b484645aa2d1d22c0f6393c7c4da88bba44b3ca44948f36e9951bd759da24ad6",
+    "kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/KituEndlessArena.unity": "e58a0fd63cedfad0b5a66f352486f328660b104700af54b3fbeaffbb4ccb5877"
+  }
+}

--- a/doc/verification/arena-runtime-host/results.json
+++ b/doc/verification/arena-runtime-host/results.json
@@ -26,14 +26,14 @@
       "passed": "1",
       "failed": "0",
       "skipped": "0",
-      "duration": "0.704192"
+      "duration": "0.6828604"
     }
   },
   "rust": {
     "environment": "Dedicated Dev Container using the repository development image and Rust 1.96.0",
     "fmt": "passed",
     "clippyAllTargetsAllFeatures": "passed",
-    "testsAndDoctestsPassed": 118,
+    "testsAndDoctestsPassed": 120,
     "docAllNoDeps": "passed",
     "packageLists": [
       "kitu-ecs",
@@ -62,9 +62,9 @@
   },
   "sceneEvidence": "Actual PlayMode scene/transform and network assertions passed. Batch mode produced no screenshot; this is not visual QA or native-build evidence.",
   "sourceSha256": {
-    "apps/demo-game/src/arena.rs": "d69965e9a62d8c63922484eac24c62547bdbbf1fc4b7f78273a2b8756a5fa496",
-    "apps/demo-game/src/bin/admin_host.rs": "942feffdeca7bfd38759568d9462d04dc2843c26119c211a4ad6e61a65ce7cd3",
-    "apps/demo-game/tests/arena_lifecycle.rs": "9b024a4874400238e257d82aa5dbc31987d2bb6f6ee1743e502aa7fd05600d21",
+    "apps/demo-game/src/arena.rs": "8c96704dc44189e5c56759ea45da2152e019953995c9e2a04c449f6ef60f2cd3",
+    "apps/demo-game/src/bin/admin_host.rs": "5d0dae52f0a17af911dea4773f15222ca1e35c610bb7b1a3b16a2e7b386ffb18",
+    "apps/demo-game/tests/arena_lifecycle.rs": "a06d0c14da043290a7b2cd920e6924d6cf557e25195d9ddcc37c34bd6e080a25",
     "crates/kitu-runtime/src/lib.rs": "2b111aec525a3f1960fca1954adaed0fd2b912a68cc3999930f22b89c2c9e7f1",
     "crates/kitu-runtime/src/application.rs": "5c37e0e600c7f70fe59dfaee644814e2d9a0a28e1483621acd9683618b38958c",
     "crates/kitu-runtime/tests/application.rs": "948f9cbdece3561087732a4ec0e51e2c065718f64ff5a0c271ed593d40629a2c",
@@ -74,5 +74,9 @@
     "kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/ArenaWorldView.cs": "9bc428dd737518814d250e496219fc2cde77b41971f7d7734b14483c648ada7a",
     "kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Tests/PlayMode/KituArenaConnectionTests.cs": "b484645aa2d1d22c0f6393c7c4da88bba44b3ca44948f36e9951bd759da24ad6",
     "kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/KituEndlessArena.unity": "e58a0fd63cedfad0b5a66f352486f328660b104700af54b3fbeaffbb4ccb5877"
-  }
+  },
+  "reviewFixes": [
+    "Validate payload types for all deferred commands before admission; reject unknown addresses",
+    "Use one producer high-water mark across frames and discrete commands; retain cached retry outcomes"
+  ]
 }

--- a/kitu-integration-runner/unity-demo-game/README.md
+++ b/kitu-integration-runner/unity-demo-game/README.md
@@ -147,6 +147,29 @@ reload policy is a separate behavior change.
 References: [Unity 6.6 upgrade guide](https://docs.unity3d.com/6000.6/Documentation/Manual/UpgradeGuideUnity66.html)
 and [Unity CLI and Pipeline overview](https://unity.com/blog/meet-the-unity-cli).
 
+## Kitu Arena migration scene
+
+Run `cargo run -p kitu-demo-game --bin kitu-demo-game-admin-host` in the Dev
+Container, forwarding port 8787. Open
+`Assets/KituDemoApp/EndlessArena/KituEndlessArena.unity` and enter Play Mode.
+The client inspector `Endpoint` defaults to `ws://127.0.0.1:8787/ws/runtime`.
+Start a run, move with WASD, aim with the mouse and pause/resume with Escape.
+The application is currently the stage-2 movement/lifecycle slice; the complete
+Unity-only comparison scene below remains the default full game until stage 5.
+
+The server owns the 60 Hz game clock. Unity samples device inputs and renders
+received snapshots. Disconnecting the controlling client pauses the game;
+**Connect** synchronizes, and **Resume** explicitly restarts gameplay with fresh
+controls. Focus loss also requests pause. Invalid sessions/contract versions and
+competing controllers are rejected. No server state is recreated locally.
+
+For the real scene/transport test, start an isolated host and run the PlayMode
+`UnityOnlyArena.Tests.KituArenaConnectionTests` test with `KITU_ARENA_WS_URL`
+pointing at its websocket endpoint. The test is explicitly skipped if the variable
+is absent; the normal offline reference suites do not require a running server.
+It checks authoritative movement, paused management ticks and reconnect/resume.
+The shared view is still covered by the original camera and scene regressions.
+
 ## Unity-only endless arena
 
 The [Arena runtime contract](../../doc/specs/arena-runtime-contract.md) defines

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Editor/KituArenaSceneBuilder.cs
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Editor/KituArenaSceneBuilder.cs
@@ -1,0 +1,17 @@
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+
+namespace UnityOnlyArena.Editor
+{
+    public static class KituArenaSceneBuilder
+    {
+        [MenuItem("Kitu/Build Kitu Arena Scene")]
+        public static void Build()
+        {
+            var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            new GameObject("Kitu Arena", typeof(KituArenaClient));
+            EditorSceneManager.SaveScene(scene, "Assets/KituDemoApp/EndlessArena/KituEndlessArena.unity");
+        }
+    }
+}

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Editor/KituArenaSceneBuilder.cs.meta
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Editor/KituArenaSceneBuilder.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ce3ca86b88d774fa2aa41b1edfede3b6

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/KituEndlessArena.unity
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/KituEndlessArena.unity
@@ -1,0 +1,173 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 2
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 2
+    m_PVRDenoiserTypeIndirect: 2
+    m_PVRDenoiserTypeAO: 2
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &676917684
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 676917686}
+  - component: {fileID: 676917685}
+  m_Layer: 0
+  m_Name: Kitu Arena
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &676917685
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 676917684}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d53ab826a12154ecf947b79baef60c25, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: UnityOnlyArena::UnityOnlyArena.KituArenaClient
+  Endpoint: ws://127.0.0.1:8787/ws/runtime
+  ConnectOnStart: 1
+  DeviceInput: 1
+--- !u!4 &676917686
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 676917684}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 676917686}

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/KituEndlessArena.unity.meta
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/KituEndlessArena.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2be5516c0fc194119bed769a5a837db0
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/ArenaConnection.cs
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/ArenaConnection.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace UnityOnlyArena
+{
+    // Transport only: no Unity objects, gameplay clocks or retry of consumed inputs.
+    public sealed class ArenaConnection : IDisposable
+    {
+        private readonly ClientWebSocket socket = new ClientWebSocket();
+        private readonly CancellationTokenSource cancellation = new CancellationTokenSource();
+        private readonly ConcurrentQueue<string> outgoing = new ConcurrentQueue<string>();
+        private readonly ConcurrentQueue<string> incoming = new ConcurrentQueue<string>();
+        private readonly SemaphoreSlim ready = new SemaphoreSlim(0);
+        private volatile bool connected;
+        private volatile string status = "Connecting";
+        public bool Connected => connected;
+        public string Status => status;
+
+        public ArenaConnection(string url) { _ = Run(url); }
+        public bool TryReceive(out string message) => incoming.TryDequeue(out message);
+
+        public bool Send(string message)
+        {
+            if (!connected) return false;
+            if (outgoing.Count >= 256) { status = "Send queue exceeded; reconnect required"; Dispose(); return false; }
+            outgoing.Enqueue(message);
+            ready.Release();
+            return true;
+        }
+
+        private async Task Run(string url)
+        {
+            Task writer = null;
+            try
+            {
+                await socket.ConnectAsync(new Uri(url), cancellation.Token).ConfigureAwait(false);
+                connected = true;
+                status = "Connected";
+                writer = WriteLoop();
+                var buffer = new byte[16384];
+                using (var message = new MemoryStream())
+                {
+                    while (!cancellation.IsCancellationRequested)
+                    {
+                        var part = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellation.Token).ConfigureAwait(false);
+                        if (part.MessageType == WebSocketMessageType.Close) break;
+                        if (part.MessageType != WebSocketMessageType.Text) throw new InvalidDataException("Arena requires JSON text frames");
+                        message.Write(buffer, 0, part.Count);
+                        if (message.Length > 8 * 1024 * 1024) throw new InvalidDataException("Arena projection too large");
+                        if (!part.EndOfMessage) continue;
+                        if (incoming.Count >= 1024) throw new InvalidDataException("Receive queue exceeded; reconnect required");
+                        incoming.Enqueue(Encoding.UTF8.GetString(message.ToArray()));
+                        message.SetLength(0);
+                    }
+                }
+            }
+            catch (Exception error) when (error is WebSocketException || error is OperationCanceledException || error is InvalidDataException || error is UriFormatException)
+            { status = error is OperationCanceledException ? "Disconnected" : error.Message; }
+            finally
+            {
+                connected = false;
+                if (status == "Connected") status = "Disconnected";
+                cancellation.Cancel();
+                socket.Abort();
+                if (writer != null) { try { await writer.ConfigureAwait(false); } catch (Exception) { /* Receive loop already reports connection loss. */ } }
+                socket.Dispose();
+                // These remain usable by a late Send/Dispose on the Unity thread.
+            }
+        }
+
+        private async Task WriteLoop()
+        {
+            try
+            {
+                while (!cancellation.IsCancellationRequested)
+                {
+                    await ready.WaitAsync(cancellation.Token).ConfigureAwait(false);
+                    if (!outgoing.TryDequeue(out string message)) continue;
+                    byte[] bytes = Encoding.UTF8.GetBytes(message);
+                    await socket.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, true, cancellation.Token).ConfigureAwait(false);
+                }
+            }
+            finally { cancellation.Cancel(); socket.Abort(); }
+        }
+
+        public void Dispose()
+        {
+            connected = false;
+            cancellation.Cancel();
+            try { socket.Abort(); } catch (ObjectDisposedException) { }
+        }
+    }
+}

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/ArenaConnection.cs.meta
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/ArenaConnection.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fa8c5a6de5e704ee9b68da67cb7d037f

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/ArenaWorldView.cs
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/ArenaWorldView.cs
@@ -18,7 +18,12 @@ namespace UnityOnlyArena
         private LineRenderer shield;
         public Camera GameCamera { get; private set; }
 
-        public void Initialize(ArenaSimulation model)
+        public void Initialize(ArenaSimulation model) => Initialize(new ReferenceView(model));
+        public void Initialize(ArenaReferenceState state) => Initialize(new ProjectionView(state));
+        public void Sync(ArenaSimulation model) => Sync(new ReferenceView(model));
+        public void Sync(ArenaReferenceState state) => Sync(new ProjectionView(state));
+
+        private void Initialize(IView model)
         {
             baseMaterial = Resources.Load<Material>("ArenaBase");
             stage = new GameObject("Arena presentation").transform;
@@ -55,7 +60,7 @@ namespace UnityOnlyArena
             Sync(model);
         }
 
-        public void Sync(ArenaSimulation model)
+        private void Sync(IView model)
         {
             if (GameCamera == null) return;
             GameCamera.rect = new Rect(0, .19f, 1, .65f);
@@ -72,7 +77,7 @@ namespace UnityOnlyArena
             player.rotation = Quaternion.LookRotation(Point(model.AimDirection, 0));
             chest.gameObject.SetActive(inRun && model.ChestAvailable);
             portal.gameObject.SetActive(inRun && model.PortalAvailable);
-            shield.gameObject.SetActive(inRun && HasShield(model.Inventory));
+            shield.gameObject.SetActive(inRun && model.HasShield);
             shield.transform.position = Point(model.PlayerPosition, .12f);
             SetRing(shield, .85f);
             live.Clear();
@@ -127,11 +132,64 @@ namespace UnityOnlyArena
             foreach (string key in obsolete) { Destroy(objects[key]); objects.Remove(key); }
         }
 
-        private static bool HasShield(ArenaInventory inventory)
+        // Read-only adapters keep rendering shared without running reference rules in the Kitu client.
+        private interface IView
         {
-            for (int i = 2; i < 4; i++)
-                if (inventory.Equipment[i] != null && inventory.Equipment[i].Kind == ItemKind.Shield && inventory.Equipment[i].Shield > 0) return true;
-            return false;
+            ArenaPhase Phase { get; }
+            Vector2 PlayerPosition { get; }
+            Vector2 AimDirection { get; }
+            bool ChestAvailable { get; }
+            bool PortalAvailable { get; }
+            bool HasShield { get; }
+            IEnumerable<ArenaEnemy> Enemies { get; }
+            IEnumerable<ArenaProjectile> Projectiles { get; }
+            IEnumerable<ArenaGrenade> Grenades { get; }
+            IEnumerable<ArenaEffect> Effects { get; }
+        }
+
+        private sealed class ReferenceView : IView
+        {
+            private readonly ArenaSimulation value;
+            public ReferenceView(ArenaSimulation value) { this.value = value; }
+            public ArenaPhase Phase => value.Phase;
+            public Vector2 PlayerPosition => value.PlayerPosition;
+            public Vector2 AimDirection => value.AimDirection;
+            public bool ChestAvailable => value.ChestAvailable;
+            public bool PortalAvailable => value.PortalAvailable;
+            public IEnumerable<ArenaEnemy> Enemies => value.Enemies;
+            public IEnumerable<ArenaProjectile> Projectiles => value.Projectiles;
+            public IEnumerable<ArenaGrenade> Grenades => value.Grenades;
+            public IEnumerable<ArenaEffect> Effects => value.Effects;
+            public bool HasShield {
+                get {
+                    for (int i = 2; i < 4; i++)
+                        if (value.Inventory.Equipment[i] != null && value.Inventory.Equipment[i].Kind == ItemKind.Shield && value.Inventory.Equipment[i].Shield > 0) return true;
+                    return false;
+                }
+            }
+        }
+
+        private sealed class ProjectionView : IView
+        {
+            private readonly ArenaReferenceState value;
+            public ProjectionView(ArenaReferenceState value) { this.value = value; }
+            public ArenaPhase Phase => (ArenaPhase)value.phase;
+            public Vector2 PlayerPosition => value.playerPosition;
+            public Vector2 AimDirection => value.aimDirection;
+            public bool ChestAvailable => value.chestAvailable;
+            public bool PortalAvailable => value.portalAvailable;
+            public IEnumerable<ArenaEnemy> Enemies => value.enemies ?? System.Array.Empty<ArenaEnemy>();
+            public IEnumerable<ArenaProjectile> Projectiles => value.projectiles ?? System.Array.Empty<ArenaProjectile>();
+            public IEnumerable<ArenaGrenade> Grenades => value.grenades ?? System.Array.Empty<ArenaGrenade>();
+            public IEnumerable<ArenaEffect> Effects => value.effects ?? System.Array.Empty<ArenaEffect>();
+            public bool HasShield {
+                get {
+                    if (value.inventory?.equipment == null) return false;
+                    for (int i = 2; i < value.inventory.equipment.Length; i++)
+                        if (value.inventory.equipment[i].kind == (int)ItemKind.Shield && value.inventory.equipment[i].shield > 0) return true;
+                    return false;
+                }
+            }
         }
 
         private GameObject Dynamic(string id, PrimitiveType shape, Color color)

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/KituArenaClient.cs
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/KituArenaClient.cs
@@ -1,0 +1,162 @@
+using System;
+using Newtonsoft.Json.Linq;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace UnityOnlyArena
+{
+    // An input/presentation client. ArenaSimulation is never constructed here.
+    public sealed class KituArenaClient : MonoBehaviour
+    {
+        public string Endpoint = "ws://127.0.0.1:8787/ws/runtime";
+        public bool ConnectOnStart = true;
+        public bool DeviceInput = true;
+        private readonly string clientId = Guid.NewGuid().ToString("N");
+        private long nextMessageId = 1;
+        private ArenaConnection connection;
+        private ArenaWorldView world;
+        private float nextFrame;
+        private bool requireMouseRelease = true;
+        private bool synchronized;
+        public string SessionId { get; private set; }
+        public ArenaReferenceState State { get; private set; }
+        public string Message { get; private set; } = "";
+        public bool Connected => connection != null && connection.Connected && synchronized;
+        public Camera GameCamera => world == null ? null : world.GameCamera;
+
+        private void Awake()
+        {
+            State = new ArenaReferenceState { tick = -1, aimDirection = Vector2.up, overlay = "none" };
+            world = gameObject.AddComponent<ArenaWorldView>();
+            world.Initialize(State);
+        }
+
+        private void Start() { if (ConnectOnStart) Connect(); }
+
+        public void Connect()
+        {
+            connection?.Dispose();
+            SessionId = null;
+            synchronized = false;
+            requireMouseRelease = true;
+            connection = new ArenaConnection(Endpoint);
+        }
+
+        public void Disconnect() { connection?.Dispose(); synchronized = false; }
+
+        public bool Command(string suffix, params int[] values)
+        {
+            var args = new JArray();
+            foreach (int value in values) args.Add(Arg("int", value));
+            requireMouseRelease = true;
+            return Send("/input/arena/" + suffix, args);
+        }
+
+        public bool Frame(Vector2 move, Vector2 aim, bool hasAim = true, bool fireA = false, bool fireB = false)
+        {
+            return Send("/input/arena/frame", new JArray(Arg("float", move.x), Arg("float", move.y),
+                Arg("bool", hasAim), Arg("float", aim.x), Arg("float", aim.y), Arg("bool", fireA), Arg("bool", fireB)));
+        }
+
+        private static JObject Arg(string type, object value) => new JObject { ["type"] = type, ["value"] = JToken.FromObject(value) };
+        private bool Send(string address, JArray args)
+        {
+            if (!Connected) return false;
+            var envelope = new JObject { ["schemaVersion"] = 1, ["sessionId"] = SessionId,
+                ["clientId"] = clientId, ["messageId"] = nextMessageId++, ["address"] = address, ["args"] = args };
+            return connection.Send(envelope.ToString(Newtonsoft.Json.Formatting.None));
+        }
+
+        private void Update()
+        {
+            if (connection == null) return;
+            while (connection.TryReceive(out string json))
+            {
+                try
+                {
+                    var message = JObject.Parse(json);
+                    switch ((string)message["type"])
+                    {
+                        case "arenaSession":
+                            if ((int)message["schemaVersion"] != 1) throw new InvalidOperationException("Incompatible Arena contract");
+                            SessionId = (string)message["id"];
+                            synchronized = false;
+                            break;
+                        case "osc":
+                            if ((string)message["address"] == "/ui/arena/state" && SessionId != null)
+                            {
+                                var state = JsonUtility.FromJson<ArenaReferenceState>((string)message["args"][0]["value"]);
+                                if (state.overlay != State.overlay || state.phase != State.phase) requireMouseRelease = true;
+                                State = state;
+                                synchronized = true;
+                                world.Sync(State);
+                            }
+                            else if ((string)message["address"] == "/ui/arena/command")
+                            {
+                                var outcome = JObject.Parse((string)message["args"][0]["value"]);
+                                Message = (string)outcome["code"];
+                            }
+                            break;
+                        case "error": Message = (string)message["message"]; break;
+                    }
+                }
+                catch (Exception error) { Message = error.Message; Disconnect(); break; }
+            }
+            if (!Connected) { requireMouseRelease = true; return; }
+            if (DeviceInput) ReadInput();
+        }
+
+        private void ReadInput()
+        {
+            var keyboard = Keyboard.current;
+            if (keyboard != null && keyboard.escapeKey.wasPressedThisFrame)
+                Command(State.overlay == "pause" ? "resume" : "pause");
+            var mouse = Mouse.current;
+            if (mouse == null || (!mouse.leftButton.isPressed && !mouse.rightButton.isPressed)) requireMouseRelease = false;
+            // This timer samples devices; only the server owns the game clock.
+            if (Time.unscaledTime < nextFrame) return;
+            nextFrame = Time.unscaledTime + 1f / 60f;
+            var move = Vector2.zero;
+            if (keyboard != null && State.overlay == "none")
+            {
+                float x = (keyboard.dKey.isPressed ? 1 : 0) - (keyboard.aKey.isPressed ? 1 : 0);
+                float y = (keyboard.wKey.isPressed ? 1 : 0) - (keyboard.sKey.isPressed ? 1 : 0);
+                Vector3 right = GameCamera.transform.right, forward = GameCamera.transform.forward;
+                right.y = forward.y = 0;
+                Vector3 direction = right.normalized * x + forward.normalized * y;
+                move = new Vector2(direction.x, direction.z);
+            }
+            Vector2 aim = Vector2.zero;
+            bool hasAim = false;
+            if (mouse != null)
+            {
+                var ray = GameCamera.ScreenPointToRay(mouse.position.ReadValue());
+                if (new Plane(Vector3.up, Vector3.zero).Raycast(ray, out float distance))
+                { var point = ray.GetPoint(distance); aim = new Vector2(point.x, point.z); hasAim = true; }
+            }
+            Frame(move, aim, hasAim, !requireMouseRelease && mouse != null && mouse.leftButton.isPressed,
+                !requireMouseRelease && mouse != null && mouse.rightButton.isPressed);
+        }
+
+        private void OnApplicationFocus(bool focused) { if (!focused) { Command("pause"); requireMouseRelease = true; } }
+        private void OnDestroy() { connection?.Dispose(); }
+
+        private void OnGUI()
+        {
+            GUILayout.BeginArea(new Rect(20, 12, Screen.width - 40, 125));
+            GUILayout.Label("ENDLESS ARENA · Kitu Runtime");
+            GUILayout.Label($"{(Connected ? "Connected" : connection?.Status ?? "Disconnected")}  |  Tick {State.tick}  |  Time {State.elapsed:F2}  |  {State.overlay}  {Message}");
+            GUILayout.BeginHorizontal();
+            if (!Connected) { if (GUILayout.Button("Connect", GUILayout.Width(140))) Connect(); }
+            else
+            {
+                if (State.phase == 0 || State.phase == 5) { if (GUILayout.Button("Start run", GUILayout.Width(140))) Command("start"); }
+                else if (GUILayout.Button(State.overlay == "pause" ? "Resume" : "Pause", GUILayout.Width(140))) Command(State.overlay == "pause" ? "resume" : "pause");
+                if (GUILayout.Button("Main menu", GUILayout.Width(140))) Command("menu");
+            }
+            GUILayout.EndHorizontal();
+            GUILayout.Label("WASD: move · Mouse: aim · Escape: pause/resume");
+            GUILayout.EndArea();
+        }
+    }
+}

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/KituArenaClient.cs.meta
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/KituArenaClient.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d53ab826a12154ecf947b79baef60c25

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/UnityOnlyArena.asmdef
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/UnityOnlyArena.asmdef
@@ -1,6 +1,7 @@
 {
-  "name": "UnityOnlyArena",
-  "references": [
-    "Unity.InputSystem"
-  ]
+    "name": "UnityOnlyArena",
+    "references": [
+        "Unity.InputSystem",
+        "Unity.Newtonsoft.Json"
+    ]
 }

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Tests/PlayMode/KituArenaConnectionTests.cs
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Tests/PlayMode/KituArenaConnectionTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+using UnityEngine.TestTools.Utils;
+
+namespace UnityOnlyArena.Tests
+{
+    public sealed class KituArenaConnectionTests
+    {
+        private GameObject root;
+        [UnityTearDown]
+        public IEnumerator Cleanup() { if (root != null) UnityEngine.Object.Destroy(root); yield return null; }
+
+        [UnityTest, Category("ArenaNetwork")]
+        public IEnumerator RealRuntimeMovesPausesAndResynchronizesWithoutRunningLocalRules()
+        {
+            string endpoint = Environment.GetEnvironmentVariable("KITU_ARENA_WS_URL");
+            if (string.IsNullOrEmpty(endpoint)) Assert.Ignore("Set KITU_ARENA_WS_URL to an isolated running admin host.");
+            // Load the checked-in migration scene, then configure its client before Start.
+            var path = "Assets/KituDemoApp/EndlessArena/KituEndlessArena.unity";
+#if UNITY_EDITOR
+            yield return UnityEditor.SceneManagement.EditorSceneManager.LoadSceneAsyncInPlayMode(path,
+                new LoadSceneParameters(LoadSceneMode.Single));
+#else
+            yield return SceneManager.LoadSceneAsync(path, LoadSceneMode.Single);
+#endif
+            var client = UnityEngine.Object.FindFirstObjectByType<KituArenaClient>();
+            Assert.That(client, Is.Not.Null);
+            root = client.gameObject;
+            client.DeviceInput = false;
+            client.Endpoint = endpoint;
+            client.Connect();
+            yield return Until(() => client.Connected, "initial synchronization");
+            Assert.That(UnityEngine.Object.FindFirstObjectByType<ArenaGame>(), Is.Null);
+            Assert.That(client.Command("menu"), Is.True);
+            yield return Until(() => client.State.phase == 0, "opening");
+            Assert.That(client.Command("start"), Is.True);
+            yield return Until(() => client.State.phase == 1, "preparation");
+            float start = client.State.playerPosition.x;
+            client.Frame(Vector2.right, Vector2.zero);
+            yield return Until(() => client.State.playerPosition.x > start + .3f, "server movement");
+            client.Command("pause");
+            yield return Until(() => client.State.overlay == "pause", "pause");
+            var paused = client.State.playerPosition;
+            float elapsed = client.State.elapsed;
+            long tick = client.State.tick;
+            yield return Until(() => client.State.tick > tick + 8, "management ticks while paused");
+            Assert.That(client.State.elapsed, Is.EqualTo(elapsed));
+            Assert.That(client.State.playerPosition, Is.EqualTo(paused).Using(Vector2ComparerWithEqualsOperator.Instance));
+            string session = client.SessionId;
+            client.Disconnect();
+            yield return new WaitForSecondsRealtime(.15f);
+            client.Connect();
+            yield return Until(() => client.Connected, "reconnection");
+            Assert.That(client.SessionId, Is.EqualTo(session));
+            Assert.That(client.State.overlay, Is.EqualTo("pause"));
+            Assert.That(client.State.elapsed, Is.EqualTo(elapsed));
+            client.Command("resume");
+            yield return Until(() => client.State.elapsed > elapsed + .1f, "explicit resume");
+            Assert.That(client.State.playerPosition, Is.EqualTo(paused).Using(Vector2ComparerWithEqualsOperator.Instance));
+            var player = root.transform.Find("Arena presentation/Player");
+            Assert.That(player, Is.Not.Null);
+            Assert.That(player.position.x, Is.EqualTo(client.State.playerPosition.x).Within(1e-4));
+            yield return null;
+        }
+
+        private static IEnumerator Until(Func<bool> condition, string operation)
+        {
+            float deadline = Time.realtimeSinceStartup + 12f;
+            while (!condition() && Time.realtimeSinceStartup < deadline) yield return null;
+            Assert.That(condition(), Is.True, operation);
+        }
+    }
+}

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Tests/PlayMode/KituArenaConnectionTests.cs.meta
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Tests/PlayMode/KituArenaConnectionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 678e69e69134f4f2ca0b67948fa15714

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Packages/manifest.json
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Packages/manifest.json
@@ -47,6 +47,7 @@
     "com.unity.modules.vehicles": "1.0.0",
     "com.unity.modules.video": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
-    "com.unity.modules.xr": "1.0.0"
+    "com.unity.modules.xr": "1.0.0",
+    "com.unity.nuget.newtonsoft-json": "3.2.2"
   }
 }

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Packages/packages-lock.json
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Packages/packages-lock.json
@@ -106,7 +106,7 @@
     },
     "com.unity.nuget.newtonsoft-json": {
       "version": "3.2.2",
-      "depth": 1,
+      "depth": 0,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"


### PR DESCRIPTION
## Summary

The demo host previously advanced a runtime tick per request. It now runs one independent 60 Hz clock, while input handlers only validate and queue commands. A persistent `RuntimeApplication` hook owns typed ECS resources, receives ordered metadata-bearing inputs, and emits detached projections at the existing output barrier.

The initial Arena application implements start/menu, movement, aim, pause/resume and controller-loss pause. The separate `KituEndlessArena.unity` scene sends versioned commands and renders server state using the shared view. Reconnection synchronizes the existing run and requires explicit resume. The complete Unity-only game and its pinned rule sources remain the comparison baseline until the later migration stages.

Closes #132. Stage 2 of #129, following #131.

## Validation

- Dedicated Dev Container: fmt, Clippy with all targets/features and warnings denied, all 120 Rust tests/doctests, and docs passed.
- Unity 6000.6.0f1: EditMode 46/46 and PlayMode 13/13, including a real websocket connection to an isolated host, movement, paused management ticks and disconnect/reconnect/resume.
- Replayed the first 75 stock-reference input ticks and compared the two frozen C# checkpoints for this slice with the agreed 1e-4 float tolerance.
- Baseline source/fixture integrity script passed. New tests cover invalid admission, deduplication, stale frames, single-controller ownership, legacy movement, and preserving Arena control input across a legacy world reset.
- `cargo package --list --allow-dirty` checked `kitu-ecs` and `kitu-runtime`. They remain internal (`publish=false`); dry-run publication is deferred according to `doc/publish-readiness.md`. No publication was attempted.

Evidence and source hashes: `doc/verification/arena-runtime-host/results.json`. Batch scene assertions are not screenshot or native-build evidence.

## Scope and review notes

Inventory, combat and progression are deliberately subsequent PRs; valid unmigrated Arena operations return `not_yet_implemented`. The full-game default scene has not switched yet. Arena currently uses its versioned JSON envelope; legacy KEP remains available for legacy OSC, with Arena MessagePack planned in stage 15. Generic admin object actions retain their existing object-sandbox behavior and cannot edit Arena resources.

Reviewed admission before mutation, fixed-step independence, disconnect ordering, projection ownership and baseline integrity. No branch-protection bypass or special merge flags are required.

Review follow-up: validated every deferred command shape before admission and shared the producer ID high-water mark across frame/discrete kinds. Both automated review findings now have regressions, and the real Unity connection test was rerun against the updated host.
