### PR TITLE
feat(arena): authoritative inventory, equipment, HP and shields

### DIFF
--- a/apps/demo-game/src/arena.rs
+++ b/apps/demo-game/src/arena.rs
@@ -1,7 +1,7 @@
 //! Authoritative Arena application, incrementally ported against the C# oracle.
 //!
-//! This stage implements lifecycle, movement, aim and pause. Inventory/combat
-//! commands are explicitly rejected until their migration stages are complete.
+//! Lifecycle, movement, aim, pause and inventory use the reference contract.
+//! Combat and progression follow in their respective migration stages.
 
 use std::collections::HashMap;
 
@@ -12,6 +12,9 @@ use kitu_runtime::{ApplicationTick, InputMetadata, RuntimeApplication, RuntimeIn
 use serde::{Deserialize, Serialize};
 
 use crate::DemoRuntime;
+
+pub mod inventory;
+use inventory::Inventory;
 
 /// Stage-independent Arena OSC contract version.
 pub const SCHEMA_VERSION: u32 = 1;
@@ -62,6 +65,12 @@ pub struct ArenaState {
     pub player_position: Vec2,
     /// Last valid normalized aim direction.
     pub aim_direction: Vec2,
+    /// Complete item ownership and health/shield clock projection.
+    pub inventory: Inventory,
+    /// Whether the current safe phase offers a chest.
+    pub chest_available: bool,
+    /// Whether the current phase offers a portal (progression migrates in stage 5).
+    pub portal_available: bool,
 }
 
 impl Default for ArenaState {
@@ -75,6 +84,9 @@ impl Default for ArenaState {
             elapsed: 0.0,
             player_position: Vec2::default(),
             aim_direction: Vec2 { x: 0.0, y: 1.0 },
+            inventory: Inventory::default(),
+            chest_available: false,
+            portal_available: false,
         }
     }
 }
@@ -96,7 +108,25 @@ enum Command {
     Resume,
     Disconnect,
     Frame(Controls),
+    InventoryOpen,
+    ChestOpen,
+    Close,
+    Inventory {
+        operation: InventoryOperation,
+        item_id: i32,
+        index: i32,
+        slot: i32,
+    },
     Unsupported,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum InventoryOperation {
+    Take,
+    Equip,
+    Unequip,
+    Discard,
+    Upgrade,
 }
 
 #[derive(Clone, Serialize)]
@@ -171,15 +201,34 @@ fn parse(message: &OscMessage) -> Result<Command> {
                 "Arena frame expects finite move/aim coordinates and boolean controls",
             ));
         }
-        "/input/arena/inventory" | "/input/arena/chest" | "/input/arena/close" => {
-            Command::Unsupported
-        }
+        "/input/arena/inventory" => Command::InventoryOpen,
+        "/input/arena/chest" => Command::ChestOpen,
+        "/input/arena/close" => Command::Close,
         "/input/arena/take"
         | "/input/arena/discard"
         | "/input/arena/upgrade"
         | "/input/arena/unequip" => {
+            let operation = match message.address.as_str() {
+                "/input/arena/take" => InventoryOperation::Take,
+                "/input/arena/discard" => InventoryOperation::Discard,
+                "/input/arena/upgrade" => InventoryOperation::Upgrade,
+                _ => InventoryOperation::Unequip,
+            };
             return match message.args.as_slice() {
-                [OscArg::Int(_), OscArg::Int(_)] => Ok(Command::Unsupported),
+                [OscArg::Int(item_id), OscArg::Int(target)] => Ok(Command::Inventory {
+                    operation,
+                    item_id: *item_id,
+                    index: if operation == InventoryOperation::Unequip {
+                        0
+                    } else {
+                        *target
+                    },
+                    slot: if operation == InventoryOperation::Unequip {
+                        *target
+                    } else {
+                        0
+                    },
+                }),
                 _ => Err(KituError::InvalidInput(
                     "Arena operation expects two ordered i32 arguments",
                 )),
@@ -187,7 +236,14 @@ fn parse(message: &OscMessage) -> Result<Command> {
         }
         "/input/arena/equip" => {
             return match message.args.as_slice() {
-                [OscArg::Int(_), OscArg::Int(_), OscArg::Int(_)] => Ok(Command::Unsupported),
+                [OscArg::Int(item_id), OscArg::Int(index), OscArg::Int(slot)] => {
+                    Ok(Command::Inventory {
+                        operation: InventoryOperation::Equip,
+                        item_id: *item_id,
+                        index: *index,
+                        slot: *slot,
+                    })
+                }
                 _ => Err(KituError::InvalidInput(
                     "Arena equip expects three ordered i32 arguments",
                 )),
@@ -295,7 +351,28 @@ impl RuntimeApplication for ArenaApplication {
                     session
                         .high_water
                         .insert(meta.source.clone(), meta.message_id);
+                    let inventory_request = match &command {
+                        Command::Inventory {
+                            item_id,
+                            index,
+                            slot,
+                            ..
+                        } => Some((*item_id, *index, *slot)),
+                        _ => None,
+                    };
                     let code = execute(session, command);
+                    if let Some((item_id, index, slot)) = inventory_request.filter(|_| code == "ok")
+                    {
+                        output.push(json_message(
+                            "/game/arena/inventory",
+                            &serde_json::json!({
+                                "tick": tick, "sequence": input.sequence, "source": meta.source,
+                                "messageId": meta.message_id, "operation": message.address,
+                                "itemId": item_id, "index": index, "slot": slot,
+                                "inventory": session.state.inventory,
+                            }),
+                        ));
+                    }
                     let outcome = Outcome {
                         sequence: input.sequence,
                         source: meta.source.clone(),
@@ -332,6 +409,7 @@ impl RuntimeApplication for ArenaApplication {
                     session.state.aim_direction = direction.normalized();
                 }
             }
+            session.state.inventory.advance_time(context.dt);
             session.state.elapsed += context.dt;
             session.state.simulation_steps += 1;
         }
@@ -354,7 +432,12 @@ fn execute(session: &mut ArenaSession, command: Command) -> &'static str {
     match command {
         Command::Start if session.state.phase == 0 || session.state.phase == 5 => {
             let simulation_steps = session.state.simulation_steps;
+            let mut inventory = Inventory::default();
+            inventory.create_chest(0);
             session.state = ArenaState {
+                inventory,
+                chest_available: true,
+                portal_available: true,
                 phase: 1,
                 player_position: Vec2 { x: 0.0, y: -7.0 },
                 simulation_steps,
@@ -363,7 +446,12 @@ fn execute(session: &mut ArenaSession, command: Command) -> &'static str {
         }
         Command::Menu => {
             let simulation_steps = session.state.simulation_steps;
+            let inventory = Inventory {
+                equipment: std::array::from_fn(|_| inventory::Item::default()),
+                ..Inventory::default()
+            };
             session.state = ArenaState {
+                inventory,
                 player_position: Vec2 { x: 0.0, y: -7.0 },
                 simulation_steps,
                 ..ArenaState::default()
@@ -381,11 +469,99 @@ fn execute(session: &mut ArenaSession, command: Command) -> &'static str {
         {
             session.state.overlay = "none".into()
         }
+        Command::InventoryOpen if is_safe(session) && session.state.overlay == "none" => {
+            session.state.overlay = "inventory".into()
+        }
+        Command::ChestOpen if is_safe(session) && session.state.overlay == "none" => {
+            let delta = Vec2 {
+                x: session.state.player_position.x + 3.0,
+                y: session.state.player_position.y,
+            };
+            if !session.state.chest_available || delta.length() > 2.0 {
+                return "out_of_range";
+            }
+            session.state.overlay = "chest".into();
+        }
+        Command::Close
+            if session.state.overlay == "inventory" || session.state.overlay == "chest" =>
+        {
+            session.state.overlay = "none".into()
+        }
+        Command::Inventory {
+            operation,
+            item_id,
+            index,
+            slot,
+        } => return inventory_command(session, operation, item_id, index, slot),
         Command::Unsupported => return "not_yet_implemented",
         _ => return "invalid_state",
     }
     session.controls = Controls::default();
     "ok"
+}
+
+fn is_safe(session: &ArenaSession) -> bool {
+    session.state.phase == 1 || session.state.phase == 4
+}
+
+fn inventory_command(
+    session: &mut ArenaSession,
+    operation: InventoryOperation,
+    item_id: i32,
+    index: i32,
+    slot: i32,
+) -> &'static str {
+    if !is_safe(session)
+        || (session.state.overlay != "inventory" && session.state.overlay != "chest")
+    {
+        return "invalid_state";
+    }
+    let inventory = &mut session.state.inventory;
+    let accepted = match operation {
+        InventoryOperation::Take => {
+            if session.state.overlay != "chest" {
+                return "invalid_state";
+            }
+            if !(0..3).contains(&index) {
+                return "invalid_target";
+            }
+            let Some(chest_index) = inventory
+                .chest
+                .iter()
+                .position(|item| item.id == item_id && item_id > 0)
+            else {
+                return "stale_item";
+            };
+            inventory.take(chest_index as i32, index)
+        }
+        InventoryOperation::Unequip => {
+            if !(0..4).contains(&slot) {
+                return "invalid_target";
+            }
+            if item_id <= 0 || inventory.equipment[slot as usize].id != item_id {
+                return "stale_item";
+            }
+            inventory.unequip(slot)
+        }
+        _ => {
+            if !(0..3).contains(&index) {
+                return "invalid_target";
+            }
+            if item_id <= 0 || inventory.backpack[index as usize].id != item_id {
+                return "stale_item";
+            }
+            match operation {
+                InventoryOperation::Equip => inventory.equip(index, slot),
+                InventoryOperation::Discard => inventory.discard(index),
+                _ => inventory.use_upgrade(index),
+            }
+        }
+    };
+    if accepted {
+        "ok"
+    } else {
+        "rule_rejected"
+    }
 }
 
 fn json_message(address: &str, value: &impl Serialize) -> OscMessage {

--- a/apps/demo-game/src/arena/inventory.rs
+++ b/apps/demo-game/src/arena/inventory.rs
@@ -1,0 +1,282 @@
+//! Arena-owned inventory rules, ported from the pinned C# reference.
+//!
+//! Item structs move between containers; IDs, charge and fractional recovery are
+//! never recreated during a transfer. Network clients only see detached copies.
+
+use serde::{Deserialize, Serialize};
+
+/// One item instance; ID zero is the canonical empty-slot projection.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Item {
+    /// Run-local instance identity.
+    pub id: i32,
+    /// C# ItemKind discriminant: blade, shooter, heavy, medkit, grenade, shield, HP upgrade, attack upgrade.
+    pub kind: i32,
+    /// Unscaled base damage.
+    pub damage: i32,
+    /// Remaining integral shield charge.
+    pub shield: i32,
+    /// Display name.
+    pub name: String,
+    /// Weapon interval in seconds.
+    pub interval: f32,
+    /// Fractional shield recovery retained across transfers.
+    pub shield_fraction: f32,
+}
+
+impl Item {
+    /// Whether the nonempty item fits a weapon slot.
+    pub fn is_weapon(&self) -> bool {
+        self.id > 0 && (0..=2).contains(&self.kind)
+    }
+    /// Whether the nonempty item is consumed by the upgrade action.
+    pub fn is_upgrade(&self) -> bool {
+        self.id > 0 && (self.kind == 6 || self.kind == 7)
+    }
+}
+
+/// Inventory and shared health/shield clocks for one run.
+///
+/// # Examples
+/// ```
+/// use kitu_demo_game::arena::inventory::Inventory;
+/// let mut inventory = Inventory::default();
+/// inventory.create_chest(0);
+/// assert!(inventory.take(0, 0));
+/// assert!(inventory.equip(0, 1));
+/// assert_eq!(inventory.equipment[1].name, "Quick Blade");
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Inventory {
+    /// Current HP; zero prevents all further consumption, transfer or healing.
+    pub health: i32,
+    /// Current HP and shield capacity.
+    pub max_health: i32,
+    /// Last allocated item ID (matching the reference field name).
+    pub next_item_id: i32,
+    /// Number of consumed attack upgrades.
+    pub attack_upgrades: i32,
+    /// Derived attack multiplier.
+    pub attack_multiplier: f32,
+    /// Shared delay before equipped shields may recover.
+    pub shield_delay_remaining: f32,
+    /// Prevents recovery throughout an update that received damage.
+    pub damaged_this_update: bool,
+    /// Three stable backpack positions.
+    pub backpack: [Item; 3],
+    /// Weapon A/B and item A/B, in that order.
+    pub equipment: [Item; 4],
+    /// Ordered available chest items.
+    pub chest: Vec<Item>,
+}
+
+impl Default for Inventory {
+    fn default() -> Self {
+        let mut value = Self {
+            health: 100,
+            max_health: 100,
+            next_item_id: 0,
+            attack_upgrades: 0,
+            attack_multiplier: 1.0,
+            shield_delay_remaining: 0.0,
+            damaged_this_update: false,
+            backpack: std::array::from_fn(|_| Item::default()),
+            equipment: std::array::from_fn(|_| Item::default()),
+            chest: Vec::new(),
+        };
+        value.equipment[0] = value.new_item("Blade", 0, 20, 0.5, 0);
+        value
+    }
+}
+
+impl Inventory {
+    fn new_item(&mut self, name: &str, kind: i32, damage: i32, interval: f32, shield: i32) -> Item {
+        self.next_item_id += 1;
+        Item {
+            id: self.next_item_id,
+            name: name.into(),
+            kind,
+            damage,
+            interval,
+            shield: shield.max(0),
+            shield_fraction: 0.0,
+        }
+    }
+
+    /// Replaces the chest with the reference preparation/repeating boss reward table.
+    pub fn create_chest(&mut self, floor: i32) {
+        self.chest.clear();
+        for (name, kind, initial, boss, interval) in [
+            ("Quick Blade", 0, 20, 24, 0.5),
+            ("Power Blade", 0, 30, 36, 0.8),
+            ("Quick Shooter", 1, 12, 15, 0.25),
+            ("Power Shooter", 1, 20, 24, 0.45),
+            ("Quick Heavy Shooter", 2, 50, 60, 1.0),
+            ("Power Heavy Shooter", 2, 75, 90, 1.5),
+            ("Medkit", 3, 0, 0, 0.0),
+            ("Grenade", 4, 100, 100, 0.0),
+            ("Shield", 5, 0, 0, 0.0),
+            ("Health Upgrade (+10 HP)", 6, 0, 0, 0.0),
+            ("Attack Upgrade (+5%)", 7, 0, 0, 0.0),
+        ] {
+            let item = self.new_item(
+                name,
+                kind,
+                if floor >= 5 { boss } else { initial },
+                interval,
+                if kind == 5 { self.max_health } else { 0 },
+            );
+            self.chest.push(item);
+        }
+    }
+
+    /// Takes or atomically swaps one chest entry into a backpack position.
+    pub fn take(&mut self, chest_index: i32, backpack_index: i32) -> bool {
+        if self.health <= 0
+            || !(0..3).contains(&backpack_index)
+            || chest_index < 0
+            || chest_index as usize >= self.chest.len()
+            || self.chest[chest_index as usize].id == 0
+        {
+            return false;
+        }
+        let bag = backpack_index as usize;
+        let chest = chest_index as usize;
+        if self.backpack[bag].id == 0 {
+            self.backpack[bag] = self.chest.remove(chest);
+        } else {
+            std::mem::swap(&mut self.backpack[bag], &mut self.chest[chest]);
+        }
+        true
+    }
+
+    /// Atomically exchanges compatible backpack/equipment items, even with a full backpack.
+    pub fn equip(&mut self, backpack_index: i32, slot: i32) -> bool {
+        if self.health <= 0 || !(0..3).contains(&backpack_index) || !(0..4).contains(&slot) {
+            return false;
+        }
+        let item = &self.backpack[backpack_index as usize];
+        if item.id == 0 || item.is_upgrade() || item.is_weapon() != (slot < 2) {
+            return false;
+        }
+        std::mem::swap(
+            &mut self.backpack[backpack_index as usize],
+            &mut self.equipment[slot as usize],
+        );
+        true
+    }
+
+    /// Moves equipment into the first free backpack slot; failure preserves all items.
+    pub fn unequip(&mut self, slot: i32) -> bool {
+        if self.health <= 0 || !(0..4).contains(&slot) || self.equipment[slot as usize].id == 0 {
+            return false;
+        }
+        let Some(empty) = self.backpack.iter().position(|item| item.id == 0) else {
+            return false;
+        };
+        self.backpack[empty] = std::mem::take(&mut self.equipment[slot as usize]);
+        true
+    }
+
+    /// Discards exactly one occupied backpack slot.
+    pub fn discard(&mut self, index: i32) -> bool {
+        if self.health <= 0 || !(0..3).contains(&index) || self.backpack[index as usize].id == 0 {
+            return false;
+        }
+        self.backpack[index as usize] = Item::default();
+        true
+    }
+
+    /// Consumes an upgrade once without refilling existing shields or fractions.
+    pub fn use_upgrade(&mut self, index: i32) -> bool {
+        if self.health <= 0
+            || !(0..3).contains(&index)
+            || !self.backpack[index as usize].is_upgrade()
+        {
+            return false;
+        }
+        if self.backpack[index as usize].kind == 6 {
+            self.max_health += 10;
+            self.health = self.max_health.min(self.health + 10);
+        } else {
+            self.attack_upgrades += 1;
+            self.attack_multiplier = 1.0 + self.attack_upgrades as f32 * 0.05;
+        }
+        self.backpack[index as usize] = Item::default();
+        true
+    }
+
+    /// Consumes an eligible item; the caller must validate grenade targeting first.
+    pub fn use_item(&mut self, slot: i32) -> Option<Item> {
+        if self.health <= 0 || !(2..=3).contains(&slot) {
+            return None;
+        }
+        let item = &self.equipment[slot as usize];
+        if item.id == 0 {
+            return None;
+        }
+        match item.kind {
+            3 if self.health < self.max_health => self.health = self.max_health,
+            4 => {}
+            _ => return None,
+        }
+        Some(std::mem::take(&mut self.equipment[slot as usize]))
+    }
+
+    /// Absorbs damage in item A/B order, then HP; even fully shielded damage resets the delay.
+    pub fn apply_damage(&mut self, mut damage: i32) {
+        if damage <= 0 || self.health <= 0 {
+            return;
+        }
+        self.shield_delay_remaining = 3.0;
+        self.damaged_this_update = true;
+        for item in &mut self.equipment[2..4] {
+            if item.id == 0 || item.kind != 5 {
+                continue;
+            }
+            item.shield = self.max_health.min(item.shield);
+            let absorbed = item.shield.min(damage);
+            item.shield -= absorbed;
+            damage -= absorbed;
+        }
+        self.health = 0.max(self.health - damage);
+    }
+
+    /// Refills living HP without changing shields or their shared delay.
+    pub fn heal_fully(&mut self) {
+        if self.health > 0 {
+            self.health = self.max_health;
+        }
+    }
+
+    /// Advances recovery once after all damage in a gameplay update; never while paused.
+    pub fn advance_time(&mut self, dt: f32) {
+        if self.damaged_this_update {
+            self.damaged_this_update = false;
+            return;
+        }
+        if dt <= 0.0 || !dt.is_finite() || self.health <= 0 {
+            return;
+        }
+        let recovery_time = 0.0_f32.max(dt - self.shield_delay_remaining);
+        self.shield_delay_remaining = 0.0_f32.max(self.shield_delay_remaining - dt);
+        if recovery_time <= 0.0 {
+            return;
+        }
+        for item in &mut self.equipment[2..4] {
+            if item.id == 0 || item.kind != 5 {
+                continue;
+            }
+            let recovered = item.shield_fraction + recovery_time * self.max_health as f32 * 0.1;
+            let whole_points = (recovered + 0.00001).floor() as i32;
+            item.shield = self.max_health.min(item.shield + whole_points);
+            item.shield_fraction = if item.shield >= self.max_health {
+                0.0
+            } else {
+                0.0_f32.max(recovered - whole_points as f32)
+            };
+        }
+    }
+}

--- a/apps/demo-game/tests/arena_inventory.rs
+++ b/apps/demo-game/tests/arena_inventory.rs
@@ -1,0 +1,301 @@
+mod support;
+use kitu_demo_game::arena::inventory::{Inventory, Item};
+
+fn ready() -> Inventory {
+    let mut inv = Inventory::default();
+    inv.create_chest(0);
+    inv
+}
+fn take_kind(inv: &mut Inventory, kind: i32, bag: i32) {
+    let index = inv.chest.iter().position(|item| item.kind == kind).unwrap();
+    assert!(inv.take(index as i32, bag));
+}
+fn equip_kind(inv: &mut Inventory, kind: i32, slot: i32) -> i32 {
+    take_kind(inv, kind, 0);
+    assert!(inv.equip(0, slot));
+    inv.equipment[slot as usize].id
+}
+fn items(inv: &Inventory) -> Vec<Item> {
+    let mut items: Vec<_> = inv
+        .backpack
+        .iter()
+        .chain(&inv.equipment)
+        .chain(&inv.chest)
+        .filter(|i| i.id != 0)
+        .cloned()
+        .collect();
+    items.sort_by_key(|item| item.id);
+    items
+}
+
+#[test]
+fn preparation_and_stock_loadout_match_frozen_csharp_inventory_and_results() {
+    assert_eq!(support::replay_reference("preparation", 28), (12, 12));
+    let (checkpoints, outcomes) = support::replay_reference("stock-eleven-death-retry", 185);
+    assert!(checkpoints > 10 && outcomes > 10);
+}
+
+#[test]
+fn chest_tables_repeat_and_swaps_conserve_owned_instances_when_full() {
+    let mut inv = ready();
+    assert_eq!(inv.chest.len(), 11);
+    assert_eq!(inv.chest.iter().filter(|i| i.is_weapon()).count(), 6);
+    assert_eq!(inv.chest.iter().filter(|i| i.is_upgrade()).count(), 2);
+    let original = items(&inv);
+    for index in 0..3 {
+        assert!(inv.take(0, index));
+    }
+    assert!(inv.take(0, 1));
+    assert!(inv.equip(1, 0));
+    assert_eq!(items(&inv), original);
+    inv.create_chest(5);
+    let damage: Vec<_> = inv.chest.iter().map(|i| i.damage).collect();
+    inv.create_chest(100);
+    assert_eq!(
+        inv.chest.iter().map(|i| i.damage).collect::<Vec<_>>(),
+        damage
+    );
+}
+
+#[test]
+fn invalid_transfers_are_atomic_and_unequip_uses_first_empty_slot() {
+    let mut inv = ready();
+    take_kind(&mut inv, 3, 0);
+    take_kind(&mut inv, 6, 1);
+    take_kind(&mut inv, 1, 2);
+    let before = inv.clone();
+    assert!(!inv.equip(0, 0));
+    assert!(!inv.equip(1, 2));
+    assert!(!inv.equip(2, 2));
+    assert!(!inv.equip(-1, 2));
+    assert!(!inv.equip(0, 99));
+    assert!(!inv.unequip(0));
+    assert!(!inv.take(-1, 0));
+    assert!(!inv.take(0, 3));
+    assert!(!inv.use_upgrade(2));
+    assert!(!inv.discard(3));
+    assert_eq!(inv, before);
+    assert!(inv.discard(1));
+    assert!(inv.unequip(0));
+    assert_eq!(inv.backpack[1], before.equipment[0]);
+    assert_eq!(inv.equipment[0].id, 0);
+    assert!(inv.discard(1));
+    assert!(!inv.discard(1));
+}
+
+#[test]
+fn upgrades_consume_once_and_preserve_shield_charge_and_delay() {
+    let mut inv = ready();
+    equip_kind(&mut inv, 5, 2);
+    inv.apply_damage(125);
+    take_kind(&mut inv, 6, 0);
+    assert!(inv.use_upgrade(0));
+    assert!(!inv.use_upgrade(0));
+    assert_eq!(
+        (inv.max_health, inv.health, inv.equipment[2].shield),
+        (110, 85, 0)
+    );
+    take_kind(&mut inv, 7, 0);
+    assert!(inv.use_upgrade(0));
+    assert!(!inv.use_upgrade(0));
+    assert_eq!(inv.attack_multiplier, 1.05);
+    assert_eq!(inv.shield_delay_remaining, 3.0);
+    inv.create_chest(5);
+    assert_eq!(inv.chest.iter().find(|i| i.kind == 5).unwrap().shield, 110);
+}
+
+#[test]
+fn medkits_keep_full_hp_items_and_consumption_never_autofills_equipment() {
+    let mut inv = ready();
+    let medkit = equip_kind(&mut inv, 3, 2);
+    equip_kind(&mut inv, 5, 3);
+    assert!(inv.use_item(2).is_none());
+    assert_eq!(inv.equipment[2].id, medkit);
+    inv.apply_damage(130);
+    assert_eq!(inv.use_item(2).unwrap().id, medkit);
+    assert_eq!(inv.health, 100);
+    assert_eq!(inv.equipment[3].shield, 0);
+    assert_eq!(inv.shield_delay_remaining, 3.0);
+    let grenade = equip_kind(&mut inv, 4, 2);
+    inv.create_chest(5);
+    take_kind(&mut inv, 4, 0);
+    let spare = inv.backpack[0].id;
+    assert_eq!(inv.use_item(2).unwrap().id, grenade);
+    assert_eq!(inv.backpack[0].id, spare);
+    assert_eq!(inv.equipment[2].id, 0);
+    assert!(inv.use_item(2).is_none());
+    equip_kind(&mut inv, 3, 2);
+    inv.create_chest(5);
+    equip_kind(&mut inv, 3, 3);
+    inv.apply_damage(15);
+    assert!(inv.use_item(2).is_some());
+    assert!(inv.use_item(3).is_none());
+}
+
+#[test]
+fn shields_absorb_in_slot_order_and_damage_blocks_the_whole_updates_recovery() {
+    let mut inv = ready();
+    equip_kind(&mut inv, 5, 2);
+    inv.create_chest(5);
+    equip_kind(&mut inv, 5, 3);
+    assert!(inv.use_item(2).is_none());
+    inv.apply_damage(130);
+    assert_eq!(
+        (inv.equipment[2].shield, inv.equipment[3].shield, inv.health),
+        (0, 70, 100)
+    );
+    inv.advance_time(100.0);
+    assert_eq!(inv.equipment[3].shield, 70);
+    assert_eq!(inv.shield_delay_remaining, 3.0);
+    inv.advance_time(2.5);
+    inv.advance_time(0.5);
+    assert_eq!(inv.equipment[3].shield, 70);
+    inv.advance_time(1.0);
+    assert_eq!(inv.equipment[2].shield, 10);
+    assert_eq!(inv.equipment[3].shield, 80);
+    inv.apply_damage(120);
+    assert_eq!(inv.health, 70);
+    inv.heal_fully();
+    assert_eq!(inv.health, 100);
+    assert_eq!((inv.equipment[2].shield, inv.equipment[3].shield), (0, 0));
+}
+
+#[test]
+fn fractional_recovery_survives_transfers_and_only_equipped_items_recover() {
+    let mut inv = ready();
+    let id = equip_kind(&mut inv, 5, 2);
+    inv.apply_damage(50);
+    inv.advance_time(0.0);
+    inv.advance_time(3.05);
+    assert!((inv.equipment[2].shield_fraction - 0.5).abs() <= 1e-5);
+    assert!(inv.unequip(2));
+    inv.advance_time(5.0);
+    assert_eq!(inv.backpack[0].shield, 50);
+    assert!(inv.take(0, 0));
+    inv.advance_time(5.0);
+    assert_eq!(inv.chest[0].id, id);
+    assert_eq!(inv.chest[0].shield, 50);
+    assert!(inv.take(0, 0));
+    assert!(inv.equip(0, 3));
+    inv.advance_time(0.05);
+    assert_eq!(inv.equipment[3].shield, 51);
+    assert!(inv.equipment[3].shield_fraction <= 1e-5);
+    inv.apply_damage(100);
+    inv.advance_time(0.0);
+    inv.advance_time(3.0);
+    for _ in 0..100 {
+        inv.advance_time(0.01);
+    }
+    assert_eq!(inv.equipment[3].shield, 10);
+    take_kind(&mut inv, 6, 0);
+    inv.use_upgrade(0);
+    inv.advance_time(1.0);
+    assert_eq!(inv.equipment[3].shield, 21);
+    inv.advance_time(30.0);
+    assert_eq!(inv.equipment[3].shield, 110);
+}
+
+#[test]
+fn dead_inventory_cannot_revive_consume_transfer_or_regenerate() {
+    let mut inv = ready();
+    equip_kind(&mut inv, 3, 2);
+    take_kind(&mut inv, 6, 0);
+    inv.apply_damage(200);
+    inv.advance_time(0.0);
+    let before = inv.clone();
+    inv.heal_fully();
+    inv.advance_time(100.0);
+    inv.apply_damage(10);
+    assert!(inv.use_item(2).is_none());
+    assert!(!inv.use_upgrade(0));
+    assert!(!inv.take(0, 1));
+    assert!(!inv.equip(0, 3));
+    assert!(!inv.unequip(2));
+    assert!(!inv.discard(0));
+    assert_eq!(inv, before);
+}
+
+#[test]
+fn runtime_upgrades_emit_once_and_rejected_destinations_preserve_ownership() {
+    use kitu_osc_ir::OscArg;
+    let mut runtime = kitu_demo_game::build_arena_runtime().unwrap();
+    support::send(&mut runtime, "commands", 1, "/input/arena/start", vec![]);
+    let length = 58.0_f32.sqrt();
+    support::send(
+        &mut runtime,
+        "frames",
+        1,
+        "/input/arena/frame",
+        vec![
+            OscArg::Float(-3.0 / length),
+            OscArg::Float(7.0 / length),
+            OscArg::Bool(false),
+            OscArg::Float(0.0),
+            OscArg::Float(0.0),
+            OscArg::Bool(false),
+            OscArg::Bool(false),
+        ],
+    );
+    for _ in 0..75 {
+        runtime.tick_once().unwrap();
+        runtime.drain_output_buffer();
+    }
+    support::send(&mut runtime, "commands", 2, "/input/arena/chest", vec![]);
+    runtime.tick_once().unwrap();
+    runtime.drain_output_buffer();
+    assert_eq!(support::projection(&runtime)["overlay"], "chest");
+    support::send(
+        &mut runtime,
+        "commands",
+        3,
+        "/input/arena/take",
+        vec![OscArg::Int(11), OscArg::Int(0)],
+    );
+    for _ in 0..2 {
+        support::send(
+            &mut runtime,
+            "commands",
+            4,
+            "/input/arena/upgrade",
+            vec![OscArg::Int(11), OscArg::Int(0)],
+        );
+    }
+    support::send(
+        &mut runtime,
+        "commands",
+        5,
+        "/input/arena/take",
+        vec![OscArg::Int(2), OscArg::Int(3)],
+    );
+    runtime.tick_once().unwrap();
+    let state = support::projection(&runtime);
+    assert_eq!(state["inventory"]["maxHealth"], 110);
+    assert_eq!(state["inventory"]["backpack"][0]["id"], 0);
+    assert_eq!(state["inventory"]["chest"][0]["id"], 2);
+    let mut events = Vec::new();
+    let mut outcomes = Vec::new();
+    for message in runtime
+        .drain_output_buffer()
+        .into_iter()
+        .flat_map(|b| b.messages)
+    {
+        let OscArg::Str(json) = &message.args[0] else {
+            continue;
+        };
+        let body: serde_json::Value = serde_json::from_str(json).unwrap();
+        if message.address == "/game/arena/inventory" {
+            events.push(body);
+        } else if message.address == "/ui/arena/command" {
+            outcomes.push(body);
+        }
+    }
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0]["messageId"], 3);
+    assert_eq!(events[1]["messageId"], 4);
+    assert_eq!(events[1]["tick"], 76);
+    assert_eq!(events[1]["itemId"], 11);
+    assert_eq!(events[1]["inventory"]["maxHealth"], 110);
+    assert_eq!(outcomes[2]["duplicate"], true);
+    assert_eq!(outcomes[2]["accepted"], true);
+    assert_eq!(outcomes[3]["code"], "invalid_target");
+}

--- a/apps/demo-game/tests/support/mod.rs
+++ b/apps/demo-game/tests/support/mod.rs
@@ -1,0 +1,155 @@
+use kitu_demo_game::DemoRuntime;
+use kitu_osc_ir::{OscArg, OscBundle, OscMessage};
+use kitu_runtime::InputMetadata;
+use serde_json::Value;
+
+pub fn send(runtime: &mut DemoRuntime, source: &str, id: u64, address: &str, args: Vec<OscArg>) {
+    let mut message = OscMessage::new(address);
+    message.args = args;
+    let mut bundle = OscBundle::new();
+    bundle.push(message);
+    runtime
+        .try_enqueue_input(
+            bundle,
+            Some(InputMetadata {
+                source: source.into(),
+                message_id: id,
+                schema_version: 1,
+            }),
+        )
+        .unwrap();
+}
+
+pub fn projection(runtime: &DemoRuntime) -> Value {
+    let bundles = runtime.inspect_application();
+    let OscArg::Str(json) = &bundles[0].messages[0].args[0] else {
+        panic!("JSON projection");
+    };
+    serde_json::from_str(json).unwrap()
+}
+
+pub fn compare(expected: &Value, actual: &Value, path: &str) {
+    match (expected, actual) {
+        (Value::Object(expected), Value::Object(actual)) => {
+            for (key, actual) in actual {
+                compare(
+                    expected
+                        .get(key)
+                        .unwrap_or_else(|| panic!("unknown projection field {path}/{key}")),
+                    actual,
+                    &format!("{path}/{key}"),
+                );
+            }
+        }
+        (Value::Array(expected), Value::Array(actual)) => {
+            assert_eq!(expected.len(), actual.len(), "{path}: membership");
+            for (index, (e, a)) in expected.iter().zip(actual).enumerate() {
+                compare(e, a, &format!("{path}/{index}"));
+            }
+        }
+        (Value::Number(e), Value::Number(a)) if e.as_i64().is_none() || a.as_i64().is_none() => {
+            assert!(
+                (e.as_f64().unwrap() - a.as_f64().unwrap()).abs() <= 1e-4,
+                "{path}: expected {e}, actual {a}"
+            );
+        }
+        _ => assert_eq!(expected, actual, "{path}"),
+    }
+}
+
+pub fn replay_reference(name: &str, limit: usize) -> (usize, usize) {
+    let directory = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../kitu-integration-runner/scenarios/arena/reference")
+        .join(name);
+    let scenario: Value =
+        serde_json::from_str(&std::fs::read_to_string(directory.join("scenario.json")).unwrap())
+            .unwrap();
+    let checkpoints: Vec<Value> = std::fs::read_to_string(directory.join("expected.ndjson"))
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    let outcomes: Vec<Value> = std::fs::read_to_string(directory.join("outcomes.ndjson"))
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    let mut runtime = kitu_demo_game::build_arena_runtime().unwrap();
+    let mut observed = Vec::new();
+    let mut compared = 0;
+    for step in scenario["steps"].as_array().unwrap().iter().take(limit) {
+        let tick = step["tick"].as_u64().unwrap();
+        for command in step["commands"].as_array().unwrap() {
+            let address = command["address"].as_str().unwrap();
+            let fields: &[&str] = match address {
+                "/input/arena/take" | "/input/arena/discard" | "/input/arena/upgrade" => {
+                    &["itemId", "index"]
+                }
+                "/input/arena/equip" => &["itemId", "index", "slot"],
+                "/input/arena/unequip" => &["itemId", "slot"],
+                _ => &[],
+            };
+            let args = fields
+                .iter()
+                .map(|key| OscArg::Int(command[key].as_i64().unwrap() as i32))
+                .collect();
+            send(
+                &mut runtime,
+                "reference:commands",
+                command["id"].as_u64().unwrap(),
+                address,
+                args,
+            );
+        }
+        let f = &step["frame"];
+        // Normalized C# traces do not contain raw frame IDs. Their generated frame
+        // producer is distinct so the preserved recorded command IDs remain intact.
+        send(
+            &mut runtime,
+            "reference:frames",
+            tick + 1,
+            "/input/arena/frame",
+            vec![
+                OscArg::Float(f["Move"]["x"].as_f64().unwrap() as f32),
+                OscArg::Float(f["Move"]["y"].as_f64().unwrap() as f32),
+                OscArg::Bool(f["HasAim"].as_bool().unwrap()),
+                OscArg::Float(f["AimPoint"]["x"].as_f64().unwrap() as f32),
+                OscArg::Float(f["AimPoint"]["y"].as_f64().unwrap() as f32),
+                OscArg::Bool(f["FireA"].as_bool().unwrap()),
+                OscArg::Bool(f["FireB"].as_bool().unwrap()),
+            ],
+        );
+        assert!(
+            !f["UseA"].as_bool().unwrap() && !f["UseB"].as_bool().unwrap(),
+            "consumable trace needs the combat migration"
+        );
+        runtime.tick_once().unwrap();
+        for bundle in runtime.drain_output_buffer() {
+            for message in bundle.messages {
+                if message.address == "/ui/arena/command" {
+                    let OscArg::Str(json) = &message.args[0] else {
+                        panic!("JSON outcome");
+                    };
+                    let mut outcome: Value = serde_json::from_str(json).unwrap();
+                    outcome.as_object_mut().unwrap().remove("source");
+                    outcome.as_object_mut().unwrap().remove("sequence");
+                    observed.push(outcome);
+                }
+            }
+        }
+        if let Some(expected) = checkpoints.iter().find(|value| value["tick"] == tick) {
+            compare(
+                expected,
+                &projection(&runtime),
+                &format!("{name}/tick/{tick}"),
+            );
+            compared += 1;
+        }
+    }
+    let expected: Vec<_> = outcomes
+        .into_iter()
+        .filter(|value| value["tick"].as_u64().unwrap() < limit as u64)
+        .collect();
+    assert_eq!(expected, observed, "{name}: command result/order");
+    (compared, observed.len())
+}

--- a/doc/specs/arena-runtime-contract.md
+++ b/doc/specs/arena-runtime-contract.md
@@ -221,3 +221,37 @@ path remains supported for legacy OSC; versioned Arena MessagePack admission is
 stage 15. Per-entity render/domain events and complete inventory state will be
 added at their migration slices. The current state projection is the rendering
 source for the initial player view, and does not claim full-game parity.
+
+## Stage 3 inventory implementation
+
+The Arena application now owns the complete `inventory` projection: backpack,
+equipment, chest, item IDs, HP/capacity, attack upgrades, shield charge/fractions
+and shared recovery timers. Inventory/chest overlays pause gameplay; start resets
+items and creates the preparation chest, while menu clears ownership. Safe-phase
+commands use expected item IDs and the declared typed payloads. Out-of-range
+backpack destinations for `take` return `invalid_target` before any transfer,
+consistent with other invalid target indices (late review of #131, fixed in #134).
+The pinned C# rule files and both previously frozen traces remain unchanged.
+
+Successful inventory mutations emit `/game/arena/inventory` once, before the
+corresponding command receipt in the same ordered output bundle. Its single JSON
+string contains `tick`, admission `sequence`, producer `source`, `messageId`,
+`operation` (full OSC address), requested `itemId`/`index`/`slot`, and the complete
+post-operation inventory. Rejected commands and duplicate deliveries do not emit
+another inventory event. This preserves the identity of consumed as well as
+transferred items; the full projection also identifies any outgoing swapped item.
+
+The inventory rule API includes medkit/grenade consumption eligibility and shield
+damage/recovery for direct rule comparison. Combat-driven damage and the `use`
+input's attack/target resolution are stage 4. There is no public network command
+that sets HP, invents damage or restores a mutable inventory snapshot. The shared
+shield clock advances exactly once on each unpaused gameplay step; only equipped
+shields recover. Stored fractions survive backpack/chest transfers and upgrades.
+
+The differential test covers every migrated state field, the complete inventory
+object, and every command outcome in `preparation` (28 ticks) and the stock
+loadout/approach before its first floor transition (185 ticks). It replays the
+recorded effective frames, with a separate generated frame producer to preserve
+the original recorded discrete IDs. Floats use 1e-4 absolute tolerance; item IDs,
+HP, shield integers, slots, flags, order and result codes are exact. Full combat
+state and progression parity are later gates, not claimed by this slice.

--- a/doc/verification/arena-inventory/results.json
+++ b/doc/verification/arena-inventory/results.json
@@ -1,0 +1,103 @@
+{
+  "stage": 3,
+  "issue": 134,
+  "baselineRevision": "38f2b4be4b7b2b604f1b21dfe9ce407846e0fc43",
+  "unityVersion": "6000.6.0f1",
+  "unity": {
+    "editmode": {
+      "result": "Passed",
+      "total": "47",
+      "passed": "47",
+      "failed": "0",
+      "skipped": "0",
+      "duration": "0.3776335"
+    },
+    "playmode": {
+      "result": "Passed",
+      "total": "13",
+      "passed": "13",
+      "failed": "0",
+      "skipped": "0",
+      "duration": "2.5527426"
+    }
+  },
+  "rust": {
+    "environment": "Dedicated Dev Container with Rust 1.96.0",
+    "fmt": "passed",
+    "clippyAllTargetsAllFeatures": "passed",
+    "testsAndDoctestsPassed": 130,
+    "docAllNoDeps": "passed",
+    "publication": "Demo app remains internal (publish=false); no package publication attempted"
+  },
+  "comparison": [
+    {
+      "scenario": "preparation",
+      "inputTicks": 28,
+      "checkpointTicks": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        12,
+        25,
+        26,
+        27
+      ],
+      "commandOutcomes": 12
+    },
+    {
+      "scenario": "stock-eleven-death-retry",
+      "inputTicks": 185,
+      "checkpointTicks": [
+        0,
+        60,
+        75,
+        76,
+        77,
+        78,
+        79,
+        80,
+        81,
+        82,
+        83,
+        84,
+        85,
+        86,
+        87,
+        88,
+        89,
+        94,
+        99,
+        105,
+        110,
+        116,
+        120,
+        121,
+        127,
+        132,
+        138,
+        143,
+        180
+      ],
+      "commandOutcomes": 16
+    }
+  ],
+  "floatAbsoluteTolerance": 0.0001,
+  "comparedState": "Every migrated projection field and complete inventory, including item ordering, IDs, charge/fractions, HP and clocks; exact command outcomes. Combat/progression fields are subsequent gates.",
+  "networkEvidence": "Real migration scene: movement/pause/reconnect plus chest access, take/equip, HP upgrade, invalid destination rejection, unequip/chest swap and resumed gameplay. Batch assertions only; no screenshot/native-build claim.",
+  "referenceReviewFix": "PR131 discussion_r3941519066: invalid take destination returns invalid_target. New C# atomicity regression passes; pinned rule sources and frozen fixtures unchanged.",
+  "sourceSha256": {
+    "apps/demo-game/src/arena.rs": "9d4304fd0933844c04fd49739acd2015db1ef1ec4e9e70744813c73a5dcda8fd",
+    "apps/demo-game/src/arena/inventory.rs": "ac3de95ae094cd381bbd220b5e2c46eb28e474e4c1dfa7e5a3033b5cd2545a7d",
+    "apps/demo-game/tests/arena_inventory.rs": "9aad97ffe316a2295e230949fdade6f1239eb96760f6c74db8703fc653e1c32a",
+    "apps/demo-game/tests/support/mod.rs": "505565217fd1fd0b265118d9505f43c1d5d56cbb3771077bb4773a61a8dee01a",
+    "kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/KituArenaClient.cs": "3ba807947389cbc38003a5f64f7dc02d7223300b3225e1e860fb57548314d60a",
+    "kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/ArenaReferenceSession.cs": "5af86a47c612564f55b28e536ccbac2eaf19cd3897e08ee341947d7f0abb2ac4",
+    "kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Tests/Editor/ArenaReferenceTests.cs": "2943fe40b197e8a8351f38ccb16f0e18d9eaaf83a6af45a1d72a5bd8783417bc",
+    "kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Tests/PlayMode/KituArenaConnectionTests.cs": "ee26250176aeb4eae4eed9b1eee455fefd6c23e402403253671c309386803796"
+  }
+}

--- a/kitu-integration-runner/unity-demo-game/README.md
+++ b/kitu-integration-runner/unity-demo-game/README.md
@@ -154,8 +154,15 @@ Container, forwarding port 8787. Open
 `Assets/KituDemoApp/EndlessArena/KituEndlessArena.unity` and enter Play Mode.
 The client inspector `Endpoint` defaults to `ws://127.0.0.1:8787/ws/runtime`.
 Start a run, move with WASD, aim with the mouse and pause/resume with Escape.
-The application is currently the stage-2 movement/lifecycle slice; the complete
-Unity-only comparison scene below remains the default full game until stage 5.
+The application currently supports the movement/lifecycle and inventory slices;
+the complete Unity-only comparison scene below remains the default full game
+until stage 5. Move near the supply chest and press **E**, or open inventory with
+**I**. Select one of three backpack slots to take/swap a chest item, equip or
+unequip, discard, or consume an upgrade. The server validates each operation
+against the displayed item ID and pauses the game while either panel is open.
+HP, attack multiplier and shield charge reflect the authoritative inventory.
+**Escape** or **Close** returns to gameplay. Combat and floor advancement are
+subsequent slices; consumable aiming/attacks do not run yet.
 
 The server owns the 60 Hz game clock. Unity samples device inputs and renders
 received snapshots. Disconnecting the controlling client pauses the game;
@@ -167,7 +174,9 @@ For the real scene/transport test, start an isolated host and run the PlayMode
 `UnityOnlyArena.Tests.KituArenaConnectionTests` test with `KITU_ARENA_WS_URL`
 pointing at its websocket endpoint. The test is explicitly skipped if the variable
 is absent; the normal offline reference suites do not require a running server.
-It checks authoritative movement, paused management ticks and reconnect/resume.
+It checks authoritative movement, paused management ticks and reconnect/resume,
+then takes/equips a shield, consumes an HP upgrade, verifies an atomic rejected
+destination, and swaps the same shield back through the chest.
 The shared view is still covered by the original camera and scene regressions.
 
 ## Unity-only endless arena

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/ArenaReferenceSession.cs
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/ArenaReferenceSession.cs
@@ -162,6 +162,7 @@ namespace UnityOnlyArena
             if (c.address == "/input/arena/take")
             {
                 if (Overlay != "chest") return "invalid_state";
+                if (c.index < 0 || c.index >= inventory.Backpack.Length) return "invalid_target";
                 int chestIndex = inventory.Chest.FindIndex(item => item.Id == c.itemId);
                 if (c.itemId <= 0 || chestIndex < 0) return "stale_item";
                 accepted = inventory.TakeChest(chestIndex, c.index);

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/KituArenaClient.cs
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/KituArenaClient.cs
@@ -18,6 +18,8 @@ namespace UnityOnlyArena
         private float nextFrame;
         private bool requireMouseRelease = true;
         private bool synchronized;
+        private int selectedBackpack;
+        private Vector2 inventoryScroll;
         public string SessionId { get; private set; }
         public ArenaReferenceState State { get; private set; }
         public string Message { get; private set; } = "";
@@ -109,8 +111,13 @@ namespace UnityOnlyArena
         private void ReadInput()
         {
             var keyboard = Keyboard.current;
-            if (keyboard != null && keyboard.escapeKey.wasPressedThisFrame)
-                Command(State.overlay == "pause" ? "resume" : "pause");
+            if (keyboard != null)
+            {
+                if (keyboard.escapeKey.wasPressedThisFrame)
+                    Command(State.overlay == "inventory" || State.overlay == "chest" ? "close" : State.overlay == "pause" ? "resume" : "pause");
+                if (keyboard.iKey.wasPressedThisFrame) Command(State.overlay == "inventory" || State.overlay == "chest" ? "close" : "inventory");
+                if (keyboard.eKey.wasPressedThisFrame) Command("chest");
+            }
             var mouse = Mouse.current;
             if (mouse == null || (!mouse.leftButton.isPressed && !mouse.rightButton.isPressed)) requireMouseRelease = false;
             // This timer samples devices; only the server owns the game clock.
@@ -141,6 +148,68 @@ namespace UnityOnlyArena
         private void OnApplicationFocus(bool focused) { if (!focused) { Command("pause"); requireMouseRelease = true; } }
         private void OnDestroy() { connection?.Dispose(); }
 
+        private static string ItemText(ArenaItemState item)
+        {
+            if (item == null || item.id == 0) return "Empty";
+            string detail = item.kind == (int)ItemKind.Shield ? $" · Shield {item.shield}" :
+                item.kind <= (int)ItemKind.HeavyShooter ? $" · {item.damage} damage / {item.interval:0.##}s" : "";
+            return item.name + detail;
+        }
+
+        private void DrawInventory()
+        {
+            var inventory = State.inventory;
+            var area = new Rect(Screen.width * .12f, 135, Screen.width * .76f, Mathf.Max(100, Screen.height - 150));
+            GUI.Box(area, "");
+            GUILayout.BeginArea(new Rect(area.x + 15, area.y + 10, area.width - 30, area.height - 20));
+            GUILayout.BeginHorizontal();
+            GUILayout.Label(State.overlay == "chest" ? "SUPPLY CHEST · game paused" : "INVENTORY · game paused");
+            if (GUILayout.Button("Close", GUILayout.Width(100))) Command("close");
+            GUILayout.EndHorizontal();
+            inventoryScroll = GUILayout.BeginScrollView(inventoryScroll);
+            GUILayout.Label("Backpack · choose a destination for taking or swapping items");
+            for (int i = 0; i < inventory.backpack.Length; i++)
+            {
+                GUILayout.BeginHorizontal();
+                if (GUILayout.Toggle(selectedBackpack == i, $"{i + 1}. {ItemText(inventory.backpack[i])}", "Button")) selectedBackpack = i;
+                var item = inventory.backpack[i];
+                if (item.id != 0)
+                {
+                    if (item.kind == (int)ItemKind.HealthUpgrade || item.kind == (int)ItemKind.AttackUpgrade)
+                    { if (GUILayout.Button("Use upgrade", GUILayout.Width(110))) Command("upgrade", item.id, i); }
+                    if (GUILayout.Button("Discard", GUILayout.Width(80))) Command("discard", item.id, i);
+                }
+                GUILayout.EndHorizontal();
+            }
+            GUILayout.Space(10);
+            GUILayout.Label("Equipment · swaps preserve the outgoing item in the selected backpack slot");
+            for (int slot = 0; slot < inventory.equipment.Length; slot++)
+            {
+                GUILayout.BeginHorizontal();
+                var item = inventory.equipment[slot];
+                string name = slot < 2 ? "Weapon " + (slot == 0 ? "A" : "B") : "Item " + (slot == 2 ? "A" : "B");
+                GUILayout.Label(name + ": " + ItemText(item));
+                var selected = inventory.backpack[selectedBackpack];
+                if (selected.id != 0 && GUILayout.Button("Equip selected", GUILayout.Width(120))) Command("equip", selected.id, selectedBackpack, slot);
+                if (item.id != 0 && GUILayout.Button("Unequip", GUILayout.Width(85))) Command("unequip", item.id, slot);
+                GUILayout.EndHorizontal();
+            }
+            if (State.overlay == "chest")
+            {
+                GUILayout.Space(10);
+                GUILayout.Label("Chest");
+                foreach (var item in inventory.chest)
+                {
+                    GUILayout.BeginHorizontal(); GUILayout.Label(ItemText(item));
+                    if (GUILayout.Button(inventory.backpack[selectedBackpack].id == 0 ? "Take" : "Swap", GUILayout.Width(100)))
+                        Command("take", item.id, selectedBackpack);
+                    GUILayout.EndHorizontal();
+                }
+            }
+            GUILayout.EndScrollView();
+            GUILayout.EndArea();
+        }
+
         private void OnGUI()
         {
             GUILayout.BeginArea(new Rect(20, 12, Screen.width - 40, 125));
@@ -152,11 +221,18 @@ namespace UnityOnlyArena
             {
                 if (State.phase == 0 || State.phase == 5) { if (GUILayout.Button("Start run", GUILayout.Width(140))) Command("start"); }
                 else if (GUILayout.Button(State.overlay == "pause" ? "Resume" : "Pause", GUILayout.Width(140))) Command(State.overlay == "pause" ? "resume" : "pause");
+                if (State.overlay == "none" && (State.phase == 1 || State.phase == 4))
+                {
+                    if (GUILayout.Button("Inventory (I)", GUILayout.Width(140))) Command("inventory");
+                    if (State.chestAvailable && GUILayout.Button("Open chest (E)", GUILayout.Width(140))) Command("chest");
+                }
                 if (GUILayout.Button("Main menu", GUILayout.Width(140))) Command("menu");
             }
             GUILayout.EndHorizontal();
-            GUILayout.Label("WASD: move · Mouse: aim · Escape: pause/resume");
+            GUILayout.Label("WASD: move · Mouse: aim · I: inventory · E: chest · Escape: close/pause");
+            if (State.inventory != null) GUILayout.Label($"HP {State.inventory.health}/{State.inventory.maxHealth} · Attack ×{State.inventory.attackMultiplier:F2}");
             GUILayout.EndArea();
+            if ((State.overlay == "inventory" || State.overlay == "chest") && State.inventory != null) DrawInventory();
         }
     }
 }

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Tests/Editor/ArenaReferenceTests.cs
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Tests/Editor/ArenaReferenceTests.cs
@@ -88,6 +88,23 @@ namespace UnityOnlyArena.Tests
         }
 
         [Test]
+        public void InvalidChestDestinationsUseTheStableTargetCodeWithoutMovingItems()
+        {
+            var session = new ArenaReferenceSession();
+            session.Tick(default, Command(1, "start"));
+            while (Vector2.Distance(session.Model.PlayerPosition, ArenaSimulation.ChestPosition) > 1.5f)
+                session.Tick(new ArenaInput { Move = (ArenaSimulation.ChestPosition - session.Model.PlayerPosition).normalized });
+            session.Tick(default, Command(2, "chest"));
+            string before = JsonUtility.ToJson(session.Model.Inventory.CaptureReferenceState());
+            int item = session.Model.Inventory.Chest[0].Id;
+            session.Tick(default, Command(3, "take", item, index: 3));
+            Assert.That(session.Outcomes.Single().code, Is.EqualTo("invalid_target"));
+            session.Tick(default, Command(4, "take", item, index: -1));
+            Assert.That(session.Outcomes.Single().code, Is.EqualTo("invalid_target"));
+            Assert.That(JsonUtility.ToJson(session.Model.Inventory.CaptureReferenceState()), Is.EqualTo(before));
+        }
+
+        [Test]
         public void InvalidBatchesAndNonContiguousTicksFailBeforeStateMutation()
         {
             var session = new ArenaReferenceSession("invalid");

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Tests/PlayMode/KituArenaConnectionTests.cs
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Tests/PlayMode/KituArenaConnectionTests.cs
@@ -64,6 +64,42 @@ namespace UnityOnlyArena.Tests
             var player = root.transform.Find("Arena presentation/Player");
             Assert.That(player, Is.Not.Null);
             Assert.That(player.position.x, Is.EqualTo(client.State.playerPosition.x).Within(1e-4));
+            // Interact through the same public commands used by the inventory UI.
+            Assert.That(client.State.inventory.health, Is.EqualTo(100));
+            float deadline = Time.realtimeSinceStartup + 8f;
+            while (Vector2.Distance(client.State.playerPosition, ArenaSimulation.ChestPosition) > 1.3f && Time.realtimeSinceStartup < deadline)
+            {
+                client.Frame((ArenaSimulation.ChestPosition - client.State.playerPosition).normalized, Vector2.zero);
+                yield return null;
+            }
+            client.Frame(Vector2.zero, Vector2.zero);
+            client.Command("chest");
+            yield return Until(() => client.State.overlay == "chest", "open real chest");
+            float chestTime = client.State.elapsed;
+            int shieldId = Array.Find(client.State.inventory.chest, item => item.kind == (int)ItemKind.Shield).id;
+            client.Command("take", shieldId, 0);
+            yield return Until(() => client.State.inventory.backpack[0].id == shieldId, "take shield");
+            client.Command("equip", shieldId, 0, 2);
+            yield return Until(() => client.State.inventory.equipment[2].id == shieldId, "equip shield");
+            int upgradeId = Array.Find(client.State.inventory.chest, item => item.kind == (int)ItemKind.HealthUpgrade).id;
+            client.Command("take", upgradeId, 0);
+            yield return Until(() => client.State.inventory.backpack[0].id == upgradeId, "take upgrade");
+            client.Command("upgrade", upgradeId, 0);
+            yield return Until(() => client.State.inventory.maxHealth == 110, "consume upgrade");
+            Assert.That(client.State.inventory.equipment[2].shield, Is.EqualTo(100));
+            string unchanged = JsonUtility.ToJson(client.State.inventory);
+            int incoming = client.State.inventory.chest[0].id;
+            client.Command("take", incoming, 3);
+            yield return Until(() => client.Message == "invalid_target", "reject invalid destination");
+            Assert.That(JsonUtility.ToJson(client.State.inventory), Is.EqualTo(unchanged));
+            client.Command("unequip", shieldId, 2);
+            yield return Until(() => client.State.inventory.backpack[0].id == shieldId, "unequip");
+            client.Command("take", incoming, 0);
+            yield return Until(() => client.State.inventory.backpack[0].id == incoming, "swap with chest");
+            Assert.That(Array.Find(client.State.inventory.chest, item => item.id == shieldId).shield, Is.EqualTo(100));
+            Assert.That(client.State.elapsed, Is.EqualTo(chestTime));
+            client.Command("close");
+            yield return Until(() => client.State.overlay == "none" && client.State.elapsed > chestTime, "close resumes game");
             yield return null;
         }
 


### PR DESCRIPTION
## Summary

The Kitu Arena run now owns item instances, backpack/chest/equipment transfers, upgrades, HP and shield clocks. Unity's inventory panel displays the detached state and sends guarded commands; exchanges preserve IDs and charge, rejected operations preserve ownership, and opening the panel pauses gameplay. Successful inventory mutations emit one ordered event, including the requested item identity and resulting inventory.

Closes #134. Stage 3 of #129, based on merged #133. Also fixes the late #131 review: an invalid chest destination is now classified as `invalid_target` by both the C# reference adapter and Kitu, with a new atomicity regression. The original rule files and existing frozen fixtures remain unchanged.

## Validation

- Dedicated Dev Container: fmt, all-target/all-feature Clippy with warnings denied, 130 Rust tests/doctests, and docs passed.
- Frozen C# comparison: all 28 preparation ticks / 12 checkpoints / 12 outcomes, and the 185-tick stock preparation prefix / 29 checkpoints / 16 outcomes. Every migrated state field and the complete inventory agree; floats use the agreed absolute 1e-4 tolerance, discrete values and outcomes are exact.
- Rule tests cover full-backpack atomic swaps, item conservation, upgrades, full-HP medkit retention, consumption order, shield slot order, damage priority, delayed/fractional recovery, transfers, and death guards. Runtime tests check one inventory event per accepted mutation and no double consumption on retry.
- Unity 6000.6.0f1: EditMode 47/47, PlayMode 13/13. The real network scene test takes/equips a shield, consumes an HP upgrade, rejects an invalid destination without mutation, unequips/swaps the original shield, and resumes the paused game.
- Baseline integrity verifier passed. Evidence/source hashes: `doc/verification/arena-inventory/results.json`. Batch scene assertions are not screenshot/native-build evidence.

## Scope

This PR ports consumption eligibility and damage/recovery as inventory rules; combat-driven damage, consumable targeting and the `use` input remain stage 4. Floor advancement/default-scene switching remain stage 5. No inbound command sets HP or restores an inventory snapshot. The demo app remains internal (`publish=false`); no package publication was attempted.
