### PR TITLE
feat(arena): complete endless progression and default Kitu client

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Goals:
 
 Implementation status:
 
-- The current repository contains the MVP runtime core, the player-move vertical slice, and early replay/tooling foundations.
+- Endless Arena now runs its complete game rules in the persistent 60 Hz Kitu application; Unity is the default input/presentation client. See the [run instructions](kitu-integration-runner/unity-demo-game/README.md#endless-arena-with-kitu-default), [contract](doc/specs/arena-runtime-contract.md) and [comparison evidence](doc/verification/arena-progression/results.json).
+- The Unity-only reference and frozen inputs remain available. Tanu authoring, TSQ1 replay, live CLI/Admin commands and full native embedding follow in the [staged implementation](https://github.com/Nagitch/kitu-logic-processor/issues/129); they are not implied by full-game server parity.
 - Several data/content and tooling sections below describe target architecture rather than finished production features.
 - For the current implemented/partial/staged breakdown, use [doc/architecture.md](doc/architecture.md#current-implementation-staging).
 - For the rationale and tradeoffs behind accepted cross-cutting choices, use

--- a/apps/demo-game/README.md
+++ b/apps/demo-game/README.md
@@ -58,16 +58,15 @@ cargo test -p kitu-demo-game
 
 The same host also runs the Arena application at 60 Hz independently of messages.
 Open `Assets/KituDemoApp/EndlessArena/KituEndlessArena.unity` in the Unity demo
-project and connect to `ws://localhost:8787/ws/runtime`. This migration scene
-currently plays preparation, inventory/equipment and the first combat floor.
-Full endless progression and the default-scene switch are the next stage. The
+project and connect to `ws://localhost:8787/ws/runtime`. The default scene
+plays the complete endless game, including boss rewards, results and retry. The
 original `EndlessArena.unity` and frozen C# fixtures remain the comparison oracle.
 
 WASD moves, mouse buttons fire the two weapons, Z/X use consumables, E opens a
 nearby chest, I/Tab opens inventory, and Escape closes an overlay or pauses.
 The client only submits input and renders server state. See the
 [Arena contract](../../doc/specs/arena-runtime-contract.md) and
-[stage 4 evidence](../../doc/verification/arena-combat/results.json).
+[full-game evidence](../../doc/verification/arena-progression/results.json).
 
 To include the live migration scene in PlayMode validation, run the host and set
 `KITU_ARENA_WS_URL=ws://localhost:8787/ws/runtime` when launching Unity tests.

--- a/apps/demo-game/src/arena.rs
+++ b/apps/demo-game/src/arena.rs
@@ -1,7 +1,7 @@
 //! Authoritative Arena application, incrementally ported against the C# oracle.
 //!
-//! Lifecycle, movement, inventory and combat use the reference contract.
-//! The first floor is playable; endless progression follows in stage 5.
+//! Lifecycle, movement, inventory, combat and endless progression use the frozen
+//! C# reference contract. Presentation and transport remain separate adapters.
 
 use std::collections::HashMap;
 

--- a/apps/demo-game/src/arena/combat.rs
+++ b/apps/demo-game/src/arena/combat.rs
@@ -48,7 +48,7 @@ impl ArenaState {
         if self.phase == 2 {
             self.transition_remaining -= dt;
             if self.transition_remaining <= 0.00001 {
-                self.enter_first_floor(tick, output);
+                self.enter_next_floor(tick, output);
             }
             return;
         }
@@ -136,6 +136,20 @@ impl ArenaState {
             self.floors_cleared += 1;
             self.phase_to(4, tick, output);
             self.clear_transient(tick, output);
+            if self.floor > 0 && self.floor % 5 == 0 {
+                self.inventory.heal_fully();
+                self.inventory.create_chest(self.floor);
+                emit(
+                    output,
+                    tick,
+                    "/game/arena/reward",
+                    json!({
+                        "floor":self.floor,"health":self.inventory.health,
+                        "itemIds":self.inventory.chest.iter().map(|item| item.id).collect::<Vec<_>>(),
+                        "inventory":self.inventory,
+                    }),
+                );
+            }
             self.portal_armed = (self.player_position - Vec2 { x: 0.0, y: 7.5 }).length() > 1.25;
         }
         if self.portal_available {
@@ -143,13 +157,10 @@ impl ArenaState {
             if !overlaps {
                 self.portal_armed = true;
             } else if self.portal_armed
-                && self.floor == 0
                 && self.inventory.equipment[..2]
                     .iter()
                     .any(|item| item.is_weapon())
             {
-                // Stage 4 opens the first combat floor. Endless progression and
-                // repeating boss rewards are enabled by the following migration.
                 self.transition_remaining = 0.3;
                 self.portal_armed = false;
                 self.inventory.chest.clear();
@@ -178,14 +189,36 @@ impl ArenaState {
         );
     }
 
-    fn enter_first_floor(&mut self, tick: i64, output: &mut OscBundle) {
+    fn enter_next_floor(&mut self, tick: i64, output: &mut OscBundle) {
         self.floor += 1;
         self.player_position = Vec2 { x: 0.0, y: -7.0 };
         self.aim_direction = Vec2 { x: 0.0, y: 1.0 };
         self.weapon_cooldowns = [0.0; 2];
         self.enemies.clear();
-        for x in [-7.5, -4.5, -1.5] {
-            let enemy = self.create_enemy(0, Vec2 { x, y: 6.0 });
+        let boss = self.floor % 5 == 0;
+        let count = if boss { 1 } else { (self.floor + 2).min(12) };
+        let shooters = if self.floor == 1 { 0 } else { count / 3 };
+        let heavy = if self.floor <= 2 { 0 } else { count / 4 };
+        let pursuers = count - shooters - heavy;
+        for i in 0..count {
+            let kind = if boss {
+                3
+            } else if i < pursuers {
+                0
+            } else if i < pursuers + shooters {
+                1
+            } else {
+                2
+            };
+            let position = if boss {
+                Vec2 { x: 0.0, y: 5.5 }
+            } else {
+                Vec2 {
+                    x: -7.5 + (i % 6) as f32 * 3.0,
+                    y: if i < 6 { 6.0 } else { 2.5 },
+                }
+            };
+            let enemy = self.create_enemy(kind, position);
             emit(
                 output,
                 tick,
@@ -767,6 +800,214 @@ mod tests {
         }
         state
     }
+    #[test]
+    fn twenty_one_floors_preserve_rosters_scaling_rewards_and_clear_once() {
+        let mut state = ArenaState {
+            phase: 1,
+            portal_available: true,
+            portal_armed: true,
+            ..ArenaState::default()
+        };
+        state.inventory.create_chest(0);
+        let mut kills = 0;
+        for floor in 1..=21 {
+            state.player_position = Vec2 { x: 0.0, y: 7.5 };
+            step(&mut state, DT, Controls::default(), [false; 2]);
+            assert_eq!(state.phase, 2);
+            assert!(state.inventory.chest.is_empty());
+            let elapsed = state.elapsed;
+            step(
+                &mut state,
+                0.3,
+                Controls {
+                    fire_a: true,
+                    ..Controls::default()
+                },
+                [true; 2],
+            );
+            assert_eq!((state.floor, state.phase), (floor, 3));
+            assert_eq!(state.elapsed, elapsed);
+            assert_eq!(state.weapon_cooldowns, [0.0; 2]);
+            assert!(!state.portal_available && !state.chest_available);
+            let boss = floor % 5 == 0;
+            let count = if boss { 1 } else { (floor + 2).min(12) };
+            assert_eq!(state.enemies.len(), count as usize);
+            if boss {
+                assert_eq!(state.enemies[0].kind, 3);
+                assert_eq!(
+                    state.enemies[0].max_health,
+                    (300.0 * (1.0 + 0.12 * (floor - 1) as f32)).ceil() as i32
+                );
+            } else {
+                assert_eq!(
+                    state.enemies.iter().filter(|e| e.kind == 1).count(),
+                    if floor == 1 { 0 } else { count as usize / 3 }
+                );
+                assert_eq!(
+                    state.enemies.iter().filter(|e| e.kind == 2).count(),
+                    if floor <= 2 { 0 } else { count as usize / 4 }
+                );
+                assert_eq!(
+                    state.enemies[0].max_health,
+                    (40.0 * (1.0 + 0.12 * (floor - 1) as f32)).ceil() as i32
+                );
+                assert_eq!(
+                    state.enemies[0].damage,
+                    (10.0 * (1.0 + 0.08 * (floor - 1) as f32)).floor() as i32
+                );
+                for (i, enemy) in state.enemies.iter().enumerate() {
+                    assert_eq!(
+                        enemy.position,
+                        Vec2 {
+                            x: [-7.5, -4.5, -1.5, 1.5, 4.5, 7.5][i % 6],
+                            y: if i < 6 { 6.0 } else { 2.5 }
+                        }
+                    );
+                }
+            }
+            state.inventory.apply_damage(10);
+            // Same isolated arrangement as the C# 21F rule test: put the roster
+            // in a blade cone, then let normal attack/damage/clear code execute.
+            state.inventory.equipment[0] = item(9000, 0, 10000, 0.5);
+            for enemy in &mut state.enemies {
+                enemy.position = state.player_position + Vec2 { x: 0.0, y: 1.0 };
+                enemy.speed = 0.0;
+                enemy.attack_cooldown = 100.0;
+            }
+            let aim = state.player_position + Vec2 { x: 0.0, y: 1.0 };
+            let output = step(
+                &mut state,
+                DT,
+                Controls {
+                    has_aim: true,
+                    aim,
+                    fire_a: true,
+                    ..Controls::default()
+                },
+                [false; 2],
+            );
+            kills += count;
+            assert_eq!(
+                (
+                    state.phase,
+                    state.floors_cleared,
+                    state.enemies_defeated,
+                    state.bosses_defeated
+                ),
+                (4, floor, kills, floor / 5)
+            );
+            assert_eq!(state.chest_available, boss);
+            assert_eq!(state.inventory.chest.len(), if boss { 11 } else { 0 });
+            assert_eq!(
+                output
+                    .messages
+                    .iter()
+                    .filter(|m| m.address == "/game/arena/reward")
+                    .count(),
+                usize::from(boss)
+            );
+            if boss {
+                assert_eq!(state.inventory.health, 100);
+            }
+            assert!(
+                state.effects.is_empty()
+                    && state.projectiles.is_empty()
+                    && state.grenades.is_empty()
+            );
+            let inventory = state.inventory.clone();
+            let output = step(&mut state, DT, Controls::default(), [false; 2]);
+            assert!(!output
+                .messages
+                .iter()
+                .any(|m| m.address == "/game/arena/reward" || m.address == "/game/arena/phase"));
+            assert_eq!(state.inventory.health, inventory.health);
+            assert_eq!(state.inventory.next_item_id, inventory.next_item_id);
+            assert_eq!(state.inventory.chest, inventory.chest);
+            assert_eq!(state.inventory.equipment, inventory.equipment);
+            assert_eq!(state.inventory.backpack, inventory.backpack);
+        }
+        assert!(!state.result.present);
+    }
+
+    #[test]
+    fn boss_reward_heals_hp_once_and_preserves_charge_and_taken_items() {
+        let mut state = state(5);
+        state.enemies.truncate(1);
+        state.enemies[0].kind = 3;
+        freeze(&mut state.enemies[0], Vec2 { x: 0.0, y: 1.0 }, 20);
+        state.inventory.apply_damage(60);
+        state.inventory.equipment[2] = Item {
+            id: 9000,
+            kind: 5,
+            shield: 12,
+            ..Item::default()
+        };
+        state.inventory.equipment[0] = item(9001, 0, 20, 0.5);
+        step(
+            &mut state,
+            DT,
+            Controls {
+                has_aim: true,
+                aim: Vec2 { x: 0.0, y: 1.0 },
+                fire_a: true,
+                ..Controls::default()
+            },
+            [false; 2],
+        );
+        assert_eq!(
+            (state.inventory.health, state.inventory.equipment[2].shield),
+            (100, 12)
+        );
+        let reward = state.inventory.chest[0].clone();
+        state.inventory.take(0, 0);
+        state.inventory.apply_damage(20);
+        step(&mut state, DT, Controls::default(), [false; 2]);
+        assert_eq!(state.inventory.health, 92);
+        assert_eq!(state.inventory.chest.len(), 10);
+        assert_eq!(state.inventory.backpack[0], reward);
+    }
+
+    #[test]
+    fn portal_under_clear_requires_exit_reentry_and_cannot_skip_a_floor() {
+        let mut state = state(1);
+        state.enemies.clear();
+        state.player_position = Vec2 { x: 0.0, y: 7.5 };
+        step(&mut state, DT, Controls::default(), [false; 2]);
+        assert_eq!(state.phase, 4);
+        step(&mut state, DT, Controls::default(), [false; 2]);
+        assert_eq!(state.phase, 4);
+        step(
+            &mut state,
+            0.4,
+            Controls {
+                movement: Vec2 { x: 0.0, y: -1.0 },
+                ..Controls::default()
+            },
+            [false; 2],
+        );
+        step(
+            &mut state,
+            0.4,
+            Controls {
+                movement: Vec2 { x: 0.0, y: 1.0 },
+                ..Controls::default()
+            },
+            [false; 2],
+        );
+        assert_eq!(state.phase, 2);
+        step(
+            &mut state,
+            0.3,
+            Controls {
+                fire_a: true,
+                ..Controls::default()
+            },
+            [true; 2],
+        );
+        assert_eq!((state.floor, state.phase, state.enemies.len()), (2, 3, 4));
+        assert_eq!(state.player_position, Vec2 { x: 0.0, y: -7.0 });
+    }
+
     fn freeze(enemy: &mut Enemy, position: Vec2, hp: i32) {
         enemy.position = position;
         enemy.health = hp;

--- a/apps/demo-game/tests/arena_progression.rs
+++ b/apps/demo-game/tests/arena_progression.rs
@@ -1,0 +1,75 @@
+mod support;
+
+#[test]
+fn complete_stock_run_matches_csharp_through_eleven_natural_death_and_retry() {
+    use kitu_osc_ir::OscArg;
+    let mut events = Vec::new();
+    assert_eq!(
+        support::replay_reference_observing("stock-eleven-death-retry", usize::MAX, |message| {
+            if message.address.starts_with("/game/arena/") {
+                let OscArg::Str(json) = &message.args[0] else {
+                    panic!("event JSON")
+                };
+                events.push((
+                    message.address.clone(),
+                    serde_json::from_str::<serde_json::Value>(json).unwrap(),
+                ));
+            }
+        }),
+        (550, 53)
+    );
+    let directory = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../kitu-integration-runner/scenarios/arena/reference/stock-eleven-death-retry/expected.ndjson");
+    let checkpoints: Vec<serde_json::Value> = std::fs::read_to_string(directory)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    let rewards: Vec<_> = events
+        .iter()
+        .filter(|(address, _)| address == "/game/arena/reward")
+        .collect();
+    assert_eq!(rewards.len(), 2);
+    for (reward, floor) in rewards.iter().zip([5, 10]) {
+        let expected = checkpoints
+            .iter()
+            .find(|state| state["floor"] == floor && state["phase"] == 4)
+            .unwrap();
+        assert_eq!(reward.1["floor"], floor);
+        assert_eq!(reward.1["tick"], expected["tick"]);
+        support::compare(
+            &expected["inventory"],
+            &reward.1["inventory"],
+            "reward inventory",
+        );
+    }
+    let results: Vec<_> = events
+        .iter()
+        .filter(|(address, _)| address == "/game/arena/result")
+        .collect();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].1["tick"], 5526);
+    let end: Vec<_> = events
+        .iter()
+        .filter(|(_, value)| value["tick"] == 5526)
+        .map(|(address, _)| address.as_str())
+        .collect();
+    assert!(end.ends_with(&[
+        "/game/arena/death",
+        "/game/arena/phase",
+        "/game/arena/result"
+    ]));
+    let retry = events
+        .iter()
+        .filter(|(address, value)| address == "/game/arena/phase" && value["previous"] == 5)
+        .collect::<Vec<_>>();
+    assert_eq!(retry.len(), 1);
+    assert_eq!(
+        (retry[0].1["tick"].as_i64(), retry[0].1["phase"].as_i64()),
+        (Some(5527), Some(1))
+    );
+}
+
+#[test]
+fn preparation_remains_unchanged_after_enabling_endless_progression() {
+    assert_eq!(support::replay_reference("preparation", 28), (12, 12));
+}

--- a/apps/demo-game/tests/support/mod.rs
+++ b/apps/demo-game/tests/support/mod.rs
@@ -63,6 +63,14 @@ pub fn compare(expected: &Value, actual: &Value, path: &str) {
 }
 
 pub fn replay_reference(name: &str, limit: usize) -> (usize, usize) {
+    replay_reference_observing(name, limit, |_| {})
+}
+
+pub fn replay_reference_observing(
+    name: &str,
+    limit: usize,
+    mut observe: impl FnMut(&OscMessage),
+) -> (usize, usize) {
     let directory = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../kitu-integration-runner/scenarios/arena/reference")
         .join(name);
@@ -138,6 +146,7 @@ pub fn replay_reference(name: &str, limit: usize) -> (usize, usize) {
         runtime.tick_once().unwrap();
         for bundle in runtime.drain_output_buffer() {
             for message in bundle.messages {
+                observe(&message);
                 if message.address == "/ui/arena/command" {
                     let OscArg::Str(json) = &message.args[0] else {
                         panic!("JSON outcome");

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -49,6 +49,23 @@ Status terms in this section are used as follows:
 - `partial`: repository support exists, but explicit missing work remains listed below.
 - `staged work`: planned or future work that must not be read as implemented.
 
+### Endless Arena reference application
+
+status: implemented for the server-connected full game (stages 1–5 of #129)
+
+`apps/demo-game` owns all Arena rules in a persistent Runtime application resource.
+The host advances at 60 Hz independently of input requests, and the default Unity
+scene sends versioned OSC-IR inputs and renders full state. Inventory, combat,
+endless progression, boss rewards, results and retry match the preserved C# oracle
+through the recorded 11F/death/retry run; separate rules cover 21F. Unity owns
+camera, device input, presentation and local settings. The generic `/input/move`
+slice remains compatible. See the [Arena contract](specs/arena-runtime-contract.md)
+and [validation evidence](verification/arena-progression/results.json).
+
+Tanu authoring, TSQ1 recording/inspection, live command tooling and the full-game
+FFI/native player path remain the subsequent stages, not implied by the existing
+movement-only FFI or placeholder data adapters described below.
+
 ### P0 — Execution Semantics
 
 status: implemented

--- a/doc/specs/arena-runtime-contract.md
+++ b/doc/specs/arena-runtime-contract.md
@@ -1,9 +1,8 @@
 # Endless Arena runtime contract, version 1
 
-Status: stages 1–3 are merged; stage 4 implements complete combat and the first
-playable Kitu floor. Full endless progression/rewards and the default scene switch
-are stage 5. Delivery is tracked in #129, with frozen reference evidence in #130
-and the Unity-first value investigation in #111.
+Status: stages 1–4 are merged; stage 5 completes the original game's Kitu path
+and makes its Unity scene the default. Delivery is tracked in #129, with frozen
+reference evidence in #130 and the Unity-first value investigation in #111.
 
 ## Authority and baseline
 
@@ -291,3 +290,32 @@ ordering and boss telegraph/recovery. Explicit event-order assertions supplement
 the checkpoint oracle; the baseline does not contain a raw C# domain-event log.
 The PlayMode connection test covers real Input System press gating, grenade
 consumption/pause, projected enemies and a first-floor clear over WebSocket.
+
+## Stage 5 full-game implementation
+
+The default enabled scene is `KituEndlessArena.unity`. `EndlessArena.unity` remains
+checked in as an explicitly selected Unity-only reference. The client displays
+objectives, all equipment/shield values, terminal results and retry, and reuses
+Unity-local volume/fullscreen preferences. Settings can open from the opening
+screen or an already-paused run. Editing/canceling a draft never resumes the run;
+management ticks continue while the authoritative gameplay clock stays paused.
+
+Normal floors contain min(floor+2, 12) enemies, with the reference pursuer/shooter/
+heavy split and ordered spawn positions. Every fifth floor contains one boss.
+After a living boss clear, the existing inventory restores HP (not shield charge)
+and creates the repeating reward chest once. `/game/arena/reward` reports `tick`,
+`order`, `floor`, restored `health`, ordered `itemIds` and the complete resulting
+`inventory`. Continuing in the cleared phase cannot regenerate rewards or heal
+again. Clearing with the player overlapping the portal requires exit/re-entry.
+The next floor retains HP, item identities and shield recovery time, clears
+transient attacks and resets entry position/weapon cooldowns. There is no victory
+endpoint at 10F, 15F or 20F.
+
+The full frozen stock recording (5,528 input ticks) matches all 550 checkpoints
+and 53 command receipts, including 11F entry, natural death at tick 5526 and retry
+at tick 5527. Reward events occur exactly on the C# boss-clear checkpoint ticks;
+there are two rewards and one terminal result. Retry emits one Results→Preparing
+transition. Separate reference-derived rule regressions cover all 21 floor
+rosters, scaling, boss reward one-time behavior and portal re-entry. The full
+Unity scene test additionally plays a live, feedback-driven stock run over the
+network; it is distinct from the deterministic recorded-input oracle.

--- a/doc/verification/arena-progression/results.json
+++ b/doc/verification/arena-progression/results.json
@@ -1,0 +1,130 @@
+{
+  "stage": 5,
+  "issue": 138,
+  "baselineRevision": "38f2b4be4b7b2b604f1b21dfe9ce407846e0fc43",
+  "unityVersion": "6000.6.0f1",
+  "rust": {
+    "environment": "Dedicated Dev Container, Rust 1.96.0",
+    "fmt": "passed",
+    "clippyAllTargetsAllFeatures": "passed",
+    "testsAndDoctestsPassed": 147,
+    "docAllNoDeps": "passed",
+    "publication": "Internal demo app (publish=false); no publication attempted"
+  },
+  "unity": {
+    "editmode": {
+      "result": "Passed",
+      "total": "47",
+      "passed": "47",
+      "failed": "0",
+      "skipped": "0",
+      "duration": "0.3846647"
+    },
+    "playmode": {
+      "result": "Passed",
+      "total": "14",
+      "passed": "14",
+      "failed": "0",
+      "skipped": "0",
+      "duration": "100.4921229"
+    },
+    "inputGateFollowup": {
+      "result": "Passed",
+      "total": "1",
+      "passed": "1",
+      "failed": "0",
+      "skipped": "0",
+      "duration": "7.8707421"
+    }
+  },
+  "comparison": {
+    "scenario": "stock-eleven-death-retry",
+    "inputTicks": 5528,
+    "completeStateCheckpoints": 550,
+    "commandOutcomes": 53,
+    "rewardTicks": [
+      1736,
+      4997
+    ],
+    "resultTick": 5526,
+    "retryTick": 5527,
+    "finalDeathFloor": 11,
+    "enemiesDefeated": 58,
+    "bossesDefeated": 2,
+    "maxHealth": 130,
+    "floatAbsoluteTolerance": 0.0001,
+    "discreteTolerance": 0,
+    "extra": "All object key sets/array order, private timers and IDs included. Two rewards and one result; event ticks tied to frozen C# checkpoints. Preparation remains 28 ticks / 12 checkpoints / 12 receipts."
+  },
+  "rules": "21F roster composition/ordered positions/scaling, no victory endpoint, one-time clear/boss rewards/heal, shield and taken-item preservation, portal exit/re-entry, simultaneous death priority and transition clocks. Isolated setup follows the original C# rule tests; full stock run uses only recorded normal inputs.",
+  "liveScene": {
+    "clears": [
+      {
+        "floor": 1,
+        "runtimeTick": 13700,
+        "health": 110
+      },
+      {
+        "floor": 2,
+        "runtimeTick": 14021,
+        "health": 110
+      },
+      {
+        "floor": 3,
+        "runtimeTick": 14402,
+        "health": 110
+      },
+      {
+        "floor": 4,
+        "runtimeTick": 14752,
+        "health": 110
+      },
+      {
+        "floor": 5,
+        "runtimeTick": 15062,
+        "health": 110
+      },
+      {
+        "floor": 6,
+        "runtimeTick": 15678,
+        "health": 120
+      },
+      {
+        "floor": 7,
+        "runtimeTick": 16277,
+        "health": 120
+      },
+      {
+        "floor": 8,
+        "runtimeTick": 16997,
+        "health": 120
+      },
+      {
+        "floor": 9,
+        "runtimeTick": 17834,
+        "health": 120
+      },
+      {
+        "floor": 10,
+        "runtimeTick": 18326,
+        "health": 120
+      }
+    ],
+    "result": "Reached 11F with max HP130 and two bosses; natural death, frozen results and retry passed through ordinary WebSocket controls, with no ArenaGame instance. Settings drafts preserve paused gameplay while management ticks advance. This feedback-driven scene run is separate from exact recorded-input comparison."
+  },
+  "fixes": [
+    "Keep the original reference scene enabled after the new default scene so baseline scene tests still load it.",
+    "Gate held attack buttons on actual UI/phase transitions; rejected inventory/chest commands during combat do not stop held fire. Targeted Input System test also rechecks required release after a real UI close."
+  ],
+  "limits": "Batch scene assertions; no screenshot or standalone native build claimed. Full-game native embedding is stages 10\u201311.",
+  "sourceSha256": {
+    "apps/demo-game/src/arena.rs": "91ec8e3fbeef96ff2db316add20aeb843face721005ec354591f69125d5f4b49",
+    "apps/demo-game/src/arena/combat.rs": "d4f16af6ed8551de2c25eef7eb85f11c97e4cf13fe4a2e0f8362be777f2941a8",
+    "apps/demo-game/tests/support/mod.rs": "3e4aecc614d1589756d447cc5b0768114e5226447317b56167187312d42c4b06",
+    "apps/demo-game/tests/arena_progression.rs": "f6126ad8eef8be229409a5d6e9221b592bd29dc7740df40478d5644a998dfee1",
+    "kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/KituArenaClient.cs": "5d03209ee52c91d54002d7874f0447c791a19cdaa755b83c1ab2a19575de5e78",
+    "kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Editor/KituArenaSceneBuilder.cs": "f9b2145ad8e1b9c83e47245cf0563ce76ccedf61f5f00da20d8b2315d651184a",
+    "kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Tests/PlayMode/KituArenaConnectionTests.cs": "af44402bc5071bd3733de79abd77977df2035734fbe5d06f0811afe4fee19abe",
+    "kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/ProjectSettings/EditorBuildSettings.asset": "631652d74cda5410a9879a5d3e57974394fa6da1ebb910f83b6169b284591d47"
+  }
+}

--- a/kitu-integration-runner/unity-demo-game/README.md
+++ b/kitu-integration-runner/unity-demo-game/README.md
@@ -147,41 +147,45 @@ reload policy is a separate behavior change.
 References: [Unity 6.6 upgrade guide](https://docs.unity3d.com/6000.6/Documentation/Manual/UpgradeGuideUnity66.html)
 and [Unity CLI and Pipeline overview](https://unity.com/blog/meet-the-unity-cli).
 
-## Kitu Arena migration scene
+## Endless Arena with Kitu (default)
 
 Run `cargo run -p kitu-demo-game --bin kitu-demo-game-admin-host` in the Dev
 Container, forwarding port 8787. Open
 `Assets/KituDemoApp/EndlessArena/KituEndlessArena.unity` and enter Play Mode.
-The client inspector `Endpoint` defaults to `ws://127.0.0.1:8787/ws/runtime`.
-Start a run, move with WASD, aim with the mouse and pause/resume with Escape.
-The application supports lifecycle, inventory and complete first-floor combat;
-the complete Unity-only comparison scene below remains the default full game
-until stage 5. Move near the supply chest and press **E**, or open inventory with
-**I**. Select one of three backpack slots to take/swap a chest item, equip or
-unequip, discard, or consume an upgrade. The server validates each operation
-against the displayed item ID and pauses the game while either panel is open.
-HP, attack multiplier and shield charge reflect the authoritative inventory.
-**Escape** or **Close** returns to gameplay. Mouse buttons fire weapons A/B;
-**Z/X** use equipped consumables. UI changes require a fresh press, and throwing
-a grenade requires a valid ground aim. Enter the portal to fight the first roster;
-endless progression and boss rewards follow in stage 5.
+This is the first enabled build scene. Its inspector `Endpoint` defaults to
+`ws://127.0.0.1:8787/ws/runtime`. The complete game runs in the server: preparation,
+inventory/equipment, combat, endless floors, bosses/rewards, results and retry.
 
-The server owns the 60 Hz game clock. Unity samples device inputs and renders
-received snapshots. Disconnecting the controlling client pauses the game;
-**Connect** synchronizes, and **Resume** explicitly restarts gameplay with fresh
-controls. Focus loss also requests pause. Invalid sessions/contract versions and
-competing controllers are rejected. No server state is recreated locally.
+WASD moves, the mouse aims, mouse buttons fire weapons A/B, Z/X use consumables,
+E opens a nearby supply chest, I/Tab opens inventory and Escape closes/pauses.
+Choose a backpack destination to take/swap, equip/unequip, discard or upgrade.
+Operations use expected item IDs and retain individual shield charge/ownership.
+UI changes require release and a fresh press; grenades need a valid ground aim.
+Enter the portal after clearing a floor, and collect the optional boss reward
+on every fifth floor. Results show the completed run and support retry with R.
+Volume/fullscreen settings reuse the original local preferences. Settings opened
+from pause leave the run paused after Apply or Cancel.
 
-For the real scene/transport test, start an isolated host and run the PlayMode
-`UnityOnlyArena.Tests.KituArenaConnectionTests` test with `KITU_ARENA_WS_URL`
-pointing at its websocket endpoint. The test is explicitly skipped if the variable
-is absent; the normal offline reference suites do not require a running server.
-It checks authoritative movement, paused management ticks and reconnect/resume,
-then takes/equips a shield, consumes an HP upgrade, verifies an atomic rejected
-destination, and swaps the same shield back through the chest. It also checks
-real Input System consumable release/repress, paused grenade flight, projected
-enemies and first-floor clear through the live host.
-The shared view is still covered by the original camera and scene regressions.
+The server owns the 60 Hz game clock, while Unity samples inputs and renders
+complete state projections. Disconnect pauses the game; Connect resynchronizes,
+and Resume explicitly restarts it with fresh controls. Focus loss requests pause.
+Invalid sessions/versions and competing controllers are rejected. The client
+never constructs ArenaSimulation. Legacy `/input/move` keeps its original meaning.
+
+Run PlayMode `UnityOnlyArena.Tests.KituArenaConnectionTests` with
+`KITU_ARENA_WS_URL` pointing at an isolated running host to include real scene
+validation. It checks movement, pause/settings, reconnect, inventory atomicity,
+consumable press gating and first-floor combat, then plays a live stock run to
+11F, natural death and retry. These external-host tests are explicitly skipped
+when that variable is absent; the offline reference suite remains available.
+The Rust frozen-input comparison covers all 5,528 stock ticks, 550 complete state
+checkpoints and 53 receipts. See [evidence](../../doc/verification/arena-progression/results.json).
+
+**Kitu > Prepare Endless Arena (Kitu)** restores the default build entry without
+replacing an existing scene. **Kitu > Build Endless Arena (Kitu, macOS)** builds
+the server-connected scene to `Builds/KituEndlessArena.app`. Native-library
+embedding and a verified standalone build are subsequent stages of #129.
+The original build menu below remains an explicit reference-only choice.
 
 ## Unity-only endless arena
 

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Editor/KituArenaSceneBuilder.cs
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Editor/KituArenaSceneBuilder.cs
@@ -1,4 +1,8 @@
+using System;
+using System.IO;
+using System.Linq;
 using UnityEditor;
+using UnityEditor.Build.Reporting;
 using UnityEditor.SceneManagement;
 using UnityEngine;
 
@@ -6,12 +10,37 @@ namespace UnityOnlyArena.Editor
 {
     public static class KituArenaSceneBuilder
     {
+        public const string ScenePath = "Assets/KituDemoApp/EndlessArena/KituEndlessArena.unity";
+
         [MenuItem("Kitu/Build Kitu Arena Scene")]
         public static void Build()
         {
             var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
             new GameObject("Kitu Arena", typeof(KituArenaClient));
-            EditorSceneManager.SaveScene(scene, "Assets/KituDemoApp/EndlessArena/KituEndlessArena.unity");
+            EditorSceneManager.SaveScene(scene, ScenePath);
+        }
+
+        [MenuItem("Kitu/Prepare Endless Arena (Kitu)")]
+        public static void PrepareDefault()
+        {
+            if (!File.Exists(ScenePath)) Build();
+            var rest = EditorBuildSettings.scenes.Where(s => s.path != ScenePath);
+            EditorBuildSettings.scenes = new[] { new EditorBuildSettingsScene(ScenePath, true) }.Concat(rest).ToArray();
+            AssetDatabase.SaveAssets();
+        }
+
+        [MenuItem("Kitu/Build Endless Arena (Kitu, macOS)")]
+        public static void BuildMac()
+        {
+            PrepareDefault();
+            string destination = Path.GetFullPath(Path.Combine(Application.dataPath, "..", "Builds", "KituEndlessArena.app"));
+            Directory.CreateDirectory(Path.GetDirectoryName(destination));
+            var report = BuildPipeline.BuildPlayer(new BuildPlayerOptions {
+                scenes = new[] { ScenePath }, locationPathName = destination,
+                target = BuildTarget.StandaloneOSX, options = BuildOptions.Development,
+            });
+            if (report.summary.result != BuildResult.Succeeded)
+                throw new Exception("Kitu Arena build failed: " + report.summary.result);
         }
     }
 }

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/KituArenaClient.cs
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Runtime/KituArenaClient.cs
@@ -20,6 +20,9 @@ namespace UnityOnlyArena
         private bool synchronized;
         private int selectedBackpack;
         private Vector2 inventoryScroll;
+        public ArenaSettings Settings { get; private set; }
+        public ArenaSettings DraftSettings { get; private set; }
+        public bool SettingsOpen => DraftSettings != null;
         public string SessionId { get; private set; }
         public ArenaReferenceState State { get; private set; }
         public string Message { get; private set; } = "";
@@ -28,6 +31,8 @@ namespace UnityOnlyArena
 
         private void Awake()
         {
+            Settings = ArenaSettings.Load();
+            Settings.Apply(false);
             State = new ArenaReferenceState { tick = -1, aimDirection = Vector2.up, overlay = "none" };
             world = gameObject.AddComponent<ArenaWorldView>();
             world.Initialize(State);
@@ -48,9 +53,9 @@ namespace UnityOnlyArena
 
         public bool Command(string suffix, params int[] values)
         {
+            if (SettingsOpen) return false;
             var args = new JArray();
             foreach (int value in values) args.Add(Arg("int", value));
-            if (suffix != "use") BlockGameplayButtons();
             return Send("/input/arena/" + suffix, args);
         }
 
@@ -91,6 +96,7 @@ namespace UnityOnlyArena
                                 if (state.overlay != State.overlay ||
                                     (state.phase != State.phase && (state.phase == 0 || state.phase == 5 || State.phase == 0 || State.phase == 5)))
                                     BlockGameplayButtons();
+                                if (SettingsOpen && state.phase != 0 && state.overlay != "pause") DraftSettings = null;
                                 State = state;
                                 synchronized = true;
                                 world.Sync(State);
@@ -118,6 +124,11 @@ namespace UnityOnlyArena
         private void ReadInput()
         {
             var keyboard = Keyboard.current;
+            if (SettingsOpen)
+            {
+                if (keyboard != null && keyboard.escapeKey.wasPressedThisFrame) CancelSettings();
+                return;
+            }
             if (keyboard != null)
             {
                 if (keyboard.escapeKey.wasPressedThisFrame)
@@ -179,7 +190,7 @@ namespace UnityOnlyArena
         private void DrawInventory()
         {
             var inventory = State.inventory;
-            var area = new Rect(Screen.width * .12f, 135, Screen.width * .76f, Mathf.Max(100, Screen.height - 150));
+            var area = new Rect(Screen.width * .12f, 170, Screen.width * .76f, Mathf.Max(100, Screen.height - 185));
             GUI.Box(area, "");
             GUILayout.BeginArea(new Rect(area.x + 15, area.y + 10, area.width - 30, area.height - 20));
             GUILayout.BeginHorizontal();
@@ -230,14 +241,70 @@ namespace UnityOnlyArena
             GUILayout.EndArea();
         }
 
+        public void OpenSettings()
+        {
+            if (State.phase != 0 && State.overlay != "pause") return;
+            DraftSettings = Settings.Copy();
+            BlockGameplayButtons();
+        }
+
+        public void ApplySettings()
+        {
+            if (!SettingsOpen) return;
+            Settings = DraftSettings.Copy();
+            Settings.Apply();
+            DraftSettings = null;
+            BlockGameplayButtons();
+        }
+
+        public void CancelSettings() { DraftSettings = null; BlockGameplayButtons(); }
+        public void ResetSettingsDraft() { if (SettingsOpen) DraftSettings = new ArenaSettings(); }
+
+        private void DrawSettings()
+        {
+            var area = new Rect((Screen.width - 550) / 2f, 175, 550, 335);
+            GUI.Box(area, "");
+            GUILayout.BeginArea(new Rect(area.x + 20, area.y + 15, area.width - 40, area.height - 30));
+            GUILayout.Label("SETTINGS");
+            GUILayout.Space(15);
+            GUILayout.Label($"Master volume: {Mathf.RoundToInt(DraftSettings.Volume * 100)}%");
+            DraftSettings.Volume = GUILayout.HorizontalSlider(DraftSettings.Volume, 0, 1);
+            DraftSettings.Fullscreen = GUILayout.Toggle(DraftSettings.Fullscreen, "Borderless fullscreen (standalone)");
+            GUILayout.Label("Changes are saved only when applied.");
+            GUILayout.Space(15);
+            if (GUILayout.Button("Restore defaults")) ResetSettingsDraft();
+            if (GUILayout.Button("Apply and return")) ApplySettings();
+            if (GUILayout.Button("Cancel")) CancelSettings();
+            GUILayout.EndArea();
+        }
+
+        private void DrawResults()
+        {
+            var result = State.result;
+            if (result == null || !result.present) return;
+            var area = new Rect((Screen.width - 660) / 2f, 175, 660, 370);
+            GUI.Box(area, "");
+            GUILayout.BeginArea(new Rect(area.x + 20, area.y + 15, area.width - 40, area.height - 30));
+            GUILayout.Label("GAME OVER");
+            GUILayout.Label($"Reached {result.floor}F · Cleared {result.floorsCleared} floors");
+            GUILayout.Label($"Defeated {result.enemiesDefeated} enemies, including {result.bossesDefeated} bosses");
+            GUILayout.Label($"Run time {result.elapsed:F2}s · Maximum HP {result.maxHealth} · Attack ×{result.attackMultiplier:F2}");
+            string[] names = { "Weapon A", "Weapon B", "Item A", "Item B" };
+            for (int i = 0; i < result.equipmentNames.Length; i++) GUILayout.Label(names[i] + ": " + result.equipmentNames[i]);
+            GUILayout.Space(15);
+            if (GUILayout.Button("Try again (R)")) Command("start");
+            if (GUILayout.Button("Return to menu")) Command("menu");
+            GUILayout.EndArea();
+        }
+
         private void OnGUI()
         {
-            GUILayout.BeginArea(new Rect(20, 12, Screen.width - 40, 125));
+            GUILayout.BeginArea(new Rect(20, 12, Screen.width - 40, 150));
             GUILayout.Label($"ENDLESS ARENA · {State.floor}F · {(ArenaPhase)State.phase} · Enemies {State.enemies?.Length ?? 0}");
             GUILayout.Label($"{(Connected ? "Connected" : connection?.Status ?? "Disconnected")}  |  Tick {State.tick}  |  Time {State.elapsed:F2}  |  {State.overlay}  {Message}");
             GUILayout.BeginHorizontal();
             if (!Connected) { if (GUILayout.Button("Connect", GUILayout.Width(140))) Connect(); }
-            else
+            else if (!SettingsOpen)
             {
                 if (State.phase == 0 || State.phase == 5) { if (GUILayout.Button("Start run", GUILayout.Width(140))) Command("start"); }
                 else if (GUILayout.Button(State.overlay == "pause" ? "Resume" : "Pause", GUILayout.Width(140))) Command(State.overlay == "pause" ? "resume" : "pause");
@@ -246,12 +313,27 @@ namespace UnityOnlyArena
                     if (GUILayout.Button("Inventory (I)", GUILayout.Width(140))) Command("inventory");
                     if (State.chestAvailable && GUILayout.Button("Open chest (E)", GUILayout.Width(140))) Command("chest");
                 }
+                if ((State.phase == 0 || State.overlay == "pause") && GUILayout.Button("Settings", GUILayout.Width(100))) OpenSettings();
                 if (GUILayout.Button("Main menu", GUILayout.Width(140))) Command("menu");
+                if (State.phase == 0 && GUILayout.Button("Quit", GUILayout.Width(80))) Application.Quit();
             }
             GUILayout.EndHorizontal();
             GUILayout.Label("WASD: move · Mouse: aim/fire A/B · Z/X: items · Tab/I: inventory · E: chest · Escape: close/pause");
             if (State.inventory != null) GUILayout.Label($"HP {State.inventory.health}/{State.inventory.maxHealth} · Attack ×{State.inventory.attackMultiplier:F2}");
+            string objective = State.phase == 1 ? "Prepare at the chest, then enter the portal" :
+                State.phase == 3 ? (State.floor % 5 == 0 ? "Defeat the boss" : "Defeat every enemy") :
+                State.phase == 4 ? (State.chestAvailable ? "Boss defeated · HP restored · Choose a reward, then enter the portal" : "Floor cleared · Enter the portal to continue") : "";
+            GUILayout.Label(objective);
             GUILayout.EndArea();
+            if (SettingsOpen) { DrawSettings(); return; }
+            if (State.phase == 5) DrawResults();
+            if (State.overlay == "none" && State.phase != 0 && State.phase != 5 && State.inventory != null)
+            {
+                GUILayout.BeginArea(new Rect(20, Screen.height - 115, Screen.width - 40, 105));
+                for (int i = 0; i < State.inventory.equipment.Length; i++)
+                    GUILayout.Label((i < 2 ? "Weapon " + (i == 0 ? "A" : "B") : "Item " + (i == 2 ? "A" : "B")) + ": " + ItemText(State.inventory.equipment[i]));
+                GUILayout.EndArea();
+            }
             if ((State.overlay == "inventory" || State.overlay == "chest") && State.inventory != null) DrawInventory();
         }
     }

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Tests/PlayMode/KituArenaConnectionTests.cs
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Tests/PlayMode/KituArenaConnectionTests.cs
@@ -160,6 +160,20 @@ namespace UnityOnlyArena.Tests
             Assert.That(client.State.enemies.Length, Is.EqualTo(3));
             foreach (var enemy in client.State.enemies)
                 Assert.That(root.transform.Find("Arena presentation/enemy-" + enemy.Id), Is.Not.Null);
+            // A rejected inventory/chest request must not release a held weapon.
+            // Gate buttons when an authoritative UI/phase change arrives, not on send.
+            driver.enabled = true; client.DeviceInput = true;
+            var away = client.GameCamera.WorldToScreenPoint(new Vector3(9, 0, -7));
+            yield return DeviceFrame(driver, default, new MouseState { position = away });
+            yield return DeviceFrame(driver, default, new MouseState { position = away, buttons = 1 });
+            yield return Until(() => client.State.weaponCooldowns[0] > .1f, "held fire begins");
+            yield return DeviceFrame(driver, new KeyboardState(Key.Tab, Key.E), new MouseState { position = away, buttons = 1 });
+            yield return DeviceFrame(driver, default, new MouseState { position = away, buttons = 1 });
+            long firingTick = client.State.tick;
+            yield return Until(() => client.State.tick > firingTick + 45, "held fire survives rejected UI requests");
+            Assert.That(client.State.overlay, Is.EqualTo("none"));
+            Assert.That(client.State.weaponCooldowns[0], Is.GreaterThan(0));
+            driver.enabled = false; client.DeviceInput = false;
             deadline = Time.realtimeSinceStartup + 12f;
             while (client.State.phase == 3 && Time.realtimeSinceStartup < deadline)
             {
@@ -175,6 +189,143 @@ namespace UnityOnlyArena.Tests
             Assert.That(client.State.grenades, Is.Empty);
             Assert.That(client.State.effects, Is.Empty);
             yield return null;
+        }
+
+        [UnityTest, Category("ArenaNetwork")]
+        public IEnumerator LiveStockRunReachesElevenDiesAndRetriesWithLocalSettings()
+        {
+            string endpoint = Environment.GetEnvironmentVariable("KITU_ARENA_WS_URL");
+            if (string.IsNullOrEmpty(endpoint)) Assert.Ignore("Set KITU_ARENA_WS_URL to an isolated running admin host.");
+#if UNITY_EDITOR
+            Assert.That(UnityEditor.EditorBuildSettings.scenes.First(s => s.enabled).path,
+                Is.EqualTo("Assets/KituDemoApp/EndlessArena/KituEndlessArena.unity"));
+            yield return UnityEditor.SceneManagement.EditorSceneManager.LoadSceneAsyncInPlayMode(
+                "Assets/KituDemoApp/EndlessArena/KituEndlessArena.unity", new LoadSceneParameters(LoadSceneMode.Single));
+#else
+            yield return SceneManager.LoadSceneAsync("KituEndlessArena", LoadSceneMode.Single);
+#endif
+            var client = UnityEngine.Object.FindFirstObjectByType<KituArenaClient>();
+            root = client.gameObject;
+            client.DeviceInput = false; client.Endpoint = endpoint; client.Connect();
+            yield return Until(() => client.Connected, "stock synchronization");
+            client.Command("menu");
+            yield return Until(() => client.State.phase == 0, "stock opening");
+            client.OpenSettings();
+            Assert.That(client.SettingsOpen, Is.True);
+            float volume = client.Settings.Volume;
+            client.DraftSettings.Volume = .25f;
+            client.CancelSettings();
+            Assert.That(client.Settings.Volume, Is.EqualTo(volume));
+            client.Command("start");
+            yield return Until(() => client.State.phase == 1, "stock start");
+            client.Command("pause");
+            yield return Until(() => client.State.overlay == "pause", "settings pause");
+            float elapsed = client.State.elapsed;
+            long tick = client.State.tick;
+            client.OpenSettings(); client.ResetSettingsDraft();
+            Assert.That(client.SettingsOpen, Is.True);
+            Assert.That(client.Command("resume"), Is.False, "settings cannot resume the game");
+            yield return Until(() => client.State.tick > tick + 8, "settings keep management alive");
+            Assert.That(client.State.elapsed, Is.EqualTo(elapsed));
+            client.CancelSettings();
+            Assert.That(client.State.overlay, Is.EqualTo("pause"));
+            client.Command("resume");
+            yield return Until(() => client.State.overlay == "none", "settings return stays paused until resume");
+            int prepared = -1, clears = 0, usedItem = 0;
+            bool exitPortal = false;
+            float deadline = Time.realtimeSinceStartup + 210f;
+            while (client.State.phase != 5 && Time.realtimeSinceStartup < deadline)
+            {
+                var state = client.State;
+                if (state.floorsCleared != clears)
+                {
+                    clears = state.floorsCleared;
+                    exitPortal = Vector2.Distance(state.playerPosition, ArenaSimulation.PortalPosition) <= ArenaSimulation.PortalRadius;
+                    Debug.Log($"Kitu live stock: cleared {clears}F at runtime tick {state.tick}, HP {state.inventory.health}");
+                }
+                Vector2 move = Vector2.zero, aim = Vector2.zero;
+                bool fire = false;
+                if (state.floor >= 11 && state.phase == 3) { /* Natural death through incoming attacks. */ }
+                else if (state.phase == 1 || state.phase == 4)
+                {
+                    if (exitPortal)
+                    {
+                        move = Vector2.down;
+                        if (Vector2.Distance(state.playerPosition, ArenaSimulation.PortalPosition) > ArenaSimulation.PortalRadius + .25f) exitPortal = false;
+                    }
+                    else if (state.chestAvailable && prepared != state.floor)
+                    {
+                        var toChest = ArenaSimulation.ChestPosition - state.playerPosition;
+                        if (toChest.magnitude > 1.3f) move = toChest.normalized;
+                        else { client.Frame(Vector2.zero, Vector2.zero); yield return StockLoadout(client); prepared = state.floor; }
+                    }
+                    else move = (ArenaSimulation.PortalPosition - state.playerPosition).normalized;
+                }
+                else if (state.phase == 3 && state.enemies.Length > 0)
+                {
+                    float radius = state.playerPosition.magnitude;
+                    Vector2 radial = radius > .01f ? state.playerPosition / radius : Vector2.down;
+                    move = (new Vector2(-radial.y, radial.x) + radial * ((7.7f - radius) * 1.5f)).normalized;
+                    aim = state.enemies.OrderBy(e => (e.Position - state.playerPosition).sqrMagnitude).First().Position;
+                    fire = true;
+                    int item = state.inventory.equipment[3].id;
+                    if (item != 0 && usedItem != item && state.inventory.health <= state.inventory.maxHealth / 2)
+                    { client.Command("use", 3); usedItem = item; }
+                }
+                client.Frame(move, aim, fire, fire, fire);
+                yield return null;
+            }
+            Assert.That(client.State.phase, Is.EqualTo(5), "stock run must naturally reach results");
+            Assert.That(client.State.floor, Is.EqualTo(11), "stock loadout must survive ten floors");
+            Assert.That(client.State.floorsCleared, Is.EqualTo(10));
+            Assert.That(client.State.bossesDefeated, Is.EqualTo(2));
+            Assert.That(client.State.inventory.maxHealth, Is.EqualTo(130));
+            var result = client.State.result;
+            Assert.That(result.present, Is.True);
+            Assert.That(result.equipmentNames.Length, Is.EqualTo(4));
+            Assert.That(result.enemiesDefeated, Is.EqualTo(client.State.enemiesDefeated));
+            string frozen = JsonUtility.ToJson(result);
+            tick = client.State.tick;
+            yield return Until(() => client.State.tick > tick + 8, "results freeze gameplay");
+            Assert.That(JsonUtility.ToJson(client.State.result), Is.EqualTo(frozen));
+            client.Command("start");
+            yield return Until(() => client.State.phase == 1 && client.State.floor == 0, "retry after natural death");
+            Assert.That(client.State.inventory.health, Is.EqualTo(100));
+            Assert.That(client.State.inventory.maxHealth, Is.EqualTo(100));
+            Assert.That(client.State.inventory.chest.Length, Is.EqualTo(11));
+            Assert.That(client.State.result.present, Is.False);
+            Assert.That(JsonUtility.ToJson(result), Is.EqualTo(frozen));
+            Assert.That(UnityEngine.Object.FindFirstObjectByType<ArenaGame>(), Is.Null);
+        }
+
+        private static IEnumerator StockLoadout(KituArenaClient client)
+        {
+            client.Command("chest");
+            yield return Until(() => client.State.overlay == "chest", "stock chest");
+            string[] names = { "Power Shooter", "Quick Shooter", "Shield", "Medkit" };
+            for (int slot = 0; slot < names.Length; slot++)
+            {
+                int bag = Array.FindIndex(client.State.inventory.backpack, item => item.id == 0);
+                Assert.That(bag, Is.GreaterThanOrEqualTo(0));
+                yield return EquipFromChest(client, names[slot], bag, slot);
+                int outgoing = client.State.inventory.backpack[bag].id;
+                if (outgoing != 0)
+                {
+                    client.Command("discard", outgoing, bag);
+                    yield return Until(() => client.State.inventory.backpack[bag].id == 0, "stock discard");
+                }
+            }
+            foreach (var kind in new[] { ItemKind.HealthUpgrade, ItemKind.AttackUpgrade })
+            {
+                int id = Array.Find(client.State.inventory.chest, item => item.kind == (int)kind).id;
+                int bag = Array.FindIndex(client.State.inventory.backpack, item => item.id == 0);
+                client.Command("take", id, bag);
+                yield return Until(() => client.State.inventory.backpack[bag].id == id, "stock upgrade take");
+                client.Command("upgrade", id, bag);
+                yield return Until(() => client.State.inventory.backpack[bag].id == 0, "stock upgrade consume");
+            }
+            client.Command("close");
+            yield return Until(() => client.State.overlay == "none", "stock chest close");
         }
 
         private static IEnumerator EquipFromChest(KituArenaClient client, string name, int bag, int slot)
@@ -205,6 +356,12 @@ namespace UnityOnlyArena.Tests
             driver.MouseState = new MouseState { position = client.GameCamera.WorldToScreenPoint(ArenaWorldView.Point(client.State.playerPosition + Vector2.up * 3f, 0)) };
             client.DeviceInput = true;
             return driver;
+        }
+
+        private static IEnumerator DeviceFrame(ArenaFrontendInputDriver driver, KeyboardState keys, MouseState pointer)
+        {
+            driver.KeyboardState = keys; driver.MouseState = pointer;
+            yield return null; yield return null;
         }
 
         private static IEnumerator Until(Func<bool> condition, string operation)

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/ProjectSettings/EditorBuildSettings.asset
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/ProjectSettings/EditorBuildSettings.asset
@@ -6,6 +6,9 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
+    path: Assets/KituDemoApp/EndlessArena/KituEndlessArena.unity
+    guid: 2be5516c0fc194119bed769a5a837db0
+  - enabled: 1
     path: Assets/KituDemoApp/EndlessArena/EndlessArena.unity
     guid: 8b1c0f14c3af04b288ec80ecd832e17e
   - enabled: 1


### PR DESCRIPTION
## Problem and behavior

The Kitu Arena scene previously stopped after its first floor. It now plays the entire endless game: ordered/scaled floor rosters, a boss every fifth floor, one-time boss healing and reward chests, safe portal re-entry, results and retry. The default Unity build entry is the Kitu client, with the Unity-only scene still enabled for explicit comparison.

Unity displays objectives, equipment/shield values and immutable run results, and reuses local volume/fullscreen settings. Settings entered from pause leave gameplay stopped after cancel/apply. Rejected inventory/chest requests no longer stop a held weapon; release gating follows actual authoritative UI/phase transitions.

## Validation

- Dev Container: fmt, all-target/all-feature Clippy, 147 Rust tests/doctests and documentation passed.
- Full frozen C# stock recording: all 5,528 inputs, 550 complete state checkpoints and 53 command receipts match through 11F, natural death at tick 5526 and retry at 5527. IDs, HP, inventory, hits/deaths and transition ticks are exact; continuous fields use absolute tolerance 1e-4.
- Reward events occur once at reference ticks 1736 and 4997. One terminal result and one retry transition are verified. Separate reference-derived regressions cover 21F rosters/scaling, one-time boss healing/rewards and portal exit/re-entry.
- Unity 6000.6.0f1: 47 EditMode and 14 PlayMode tests passed with the real host enabled. A live scene bot reaches 11F, dies from normal attacks and retries, using public controls and projected state only. A final focused Input System run verifies held fire survives rejected UI requests while real UI close still requires release/repress.
- Preserved the reference scene's build-list availability after an initial setup failure; the complete suite then passed. Pinned source and fixture integrity verified.
- Evidence and source hashes: `doc/verification/arena-progression/results.json`.

Live feedback-driven play is distinct from the exact recorded-input oracle. These are batch scene assertions, not screenshot or native-build claims. Full-game native embedding remains stages 10–11. The application is internal (`publish=false`); no publication attempted.

Closes #138. Stage 5 of #129.
