### PR TITLE
feat(arena): persist and re-execute exact Runtime inputs with TSQ1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,6 +761,7 @@ dependencies = [
  "kitu-osc-ir",
  "kitu-runtime",
  "kitu-transport",
+ "kitu-tsq1",
  "serde",
  "serde_json",
  "sha2",
@@ -816,6 +817,7 @@ dependencies = [
  "kitu-ecs",
  "kitu-osc-ir",
  "kitu-transport",
+ "serde",
 ]
 
 [[package]]
@@ -849,7 +851,13 @@ dependencies = [
 name = "kitu-tsq1"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "kitu-core",
+ "kitu-osc-ir",
+ "serde",
+ "serde_json",
+ "tsq1",
+ "tsq1-osc",
 ]
 
 [[package]]
@@ -941,6 +949,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
+name = "midly"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "207d755f4cb882d20c4da58d707ca9130a0c9bc5061f657a4f299b8e36362b7a"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,6 +1010,27 @@ version = "0.1.0"
 source = "git+https://github.com/Nagitch/openformula-kernel.git?rev=5448dcf6d130e4355da15aeed6c88e56a9a15673#5448dcf6d130e4355da15aeed6c88e56a9a15673"
 dependencies = [
  "libm",
+]
+
+[[package]]
+name = "osc-codec-msgpack"
+version = "0.1.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc6e1d77ba4415e216d9eff921d266b8361f2599bb7557586ab74f0bbee2d44"
+dependencies = [
+ "osc-ir",
+ "rmp-serde",
+ "serde",
+]
+
+[[package]]
+name = "osc-ir"
+version = "0.1.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f6bfb8751d4c5420e75a5104e0100be476dc915a6f4883c5f53c42e20005fb"
+dependencies = [
+ "serde",
+ "serde_bytes",
 ]
 
 [[package]]
@@ -1769,6 +1804,25 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tsq1"
+version = "0.1.0"
+source = "git+https://github.com/Nagitch/tsq1?rev=05707147e83a4fba591a3933d49f056bb6d3540b#05707147e83a4fba591a3933d49f056bb6d3540b"
+dependencies = [
+ "midly",
+ "openformula-kernel",
+]
+
+[[package]]
+name = "tsq1-osc"
+version = "0.1.0"
+source = "git+https://github.com/Nagitch/tsq1?rev=05707147e83a4fba591a3933d49f056bb6d3540b#05707147e83a4fba591a3933d49f056bb6d3540b"
+dependencies = [
+ "osc-codec-msgpack",
+ "osc-ir",
+ "tsq1",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Implementation status:
 
 - Endless Arena now runs its complete game rules in the persistent 60 Hz Kitu application; Unity is the default input/presentation client. See the [run instructions](kitu-integration-runner/unity-demo-game/README.md#endless-arena-with-kitu-default), [contract](doc/specs/arena-runtime-contract.md) and [comparison evidence](doc/verification/arena-progression/results.json).
 - Arena's real [Tanu tables](apps/demo-game/content/arena.tmd) can be edited in VS Code, evaluated and validated in Admin, and applied to the next run. Active runs retain their saved values and hash. See the [authoring workflow](apps/demo-game/README.md#tanu-parameters) and [evidence](doc/verification/arena-tanu/results.json).
-- The Unity-only reference and frozen inputs remain available. TSQ1 replay, live CLI/Shell commands and full native embedding follow in the [staged implementation](https://github.com/Nagitch/kitu-logic-processor/issues/129).
+- The Unity-only reference and frozen inputs remain available. Real [TSQ1 session recording and re-execution](doc/specs/arena-replay.md) preserve exact ticks, ordered inputs and frozen content. Admin playback controls, live CLI/Shell commands and full native embedding follow in the [staged implementation](https://github.com/Nagitch/kitu-logic-processor/issues/129).
 - Several data/content and tooling sections below describe target architecture rather than finished production features.
 - For the current implemented/partial/staged breakdown, use [doc/architecture.md](doc/architecture.md#current-implementation-staging).
 - For the rationale and tradeoffs behind accepted cross-cutting choices, use

--- a/apps/demo-game/Cargo.toml
+++ b/apps/demo-game/Cargo.toml
@@ -21,6 +21,7 @@ kitu-runtime = { path = "../../crates/kitu-runtime" }
 kitu-core = { path = "../../crates/kitu-core" }
 kitu-ecs = { path = "../../crates/kitu-ecs" }
 kitu-data-tmd = { path = "../../crates/kitu-data-tmd" }
+kitu-tsq1 = { path = "../../crates/kitu-tsq1" }
 sha2 = "0.11"
 hex = "0.4"
 kitu-transport = { path = "../../crates/kitu-transport" }
@@ -30,3 +31,7 @@ tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.7", features = ["cors"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[build-dependencies]
+sha2 = "0.11"
+hex = "0.4"

--- a/apps/demo-game/README.md
+++ b/apps/demo-game/README.md
@@ -105,7 +105,7 @@ Each start emits `/game/arena/run` with the complete evaluated configuration and
 hash. The host writes an atomic JSON manifest under
 `apps/demo-game/.arena/runs/<runtime-session>/<run>.json`; use
 `KITU_ARENA_RUN_DIRECTORY` to choose the directory. Admin reports save failures.
-Keep these manifests with future recordings; input recording/playback is stage 7.
+TSQ1 recordings also retain these full evaluated run configurations; see the recording workflow below.
 
 HTTP interfaces use the same host as Unity:
 
@@ -134,3 +134,29 @@ development; it is not the live Runtime CLI planned in stage 9. The macOS PlayMo
 test `LiveTanuConfigurationIsProjectedInNewRuns` accepts
 `KITU_ARENA_EXPECTED_STARTER_DAMAGE` (default 20) to verify a value applied through
 Admin. See [stage 6 evidence](../../doc/verification/arena-tanu/results.json).
+
+
+## TSQ1 recordings
+
+The host records from its first Runtime tick, including pauses and retries. Save
+and verify a live session through the actual binary TSQ1 APIs:
+
+```sh
+curl -X POST http://127.0.0.1:8787/arena/recording/save
+# Use the returned SHA-256 id:
+curl -X POST http://127.0.0.1:8787/arena/recordings/ID/verify
+curl http://127.0.0.1:8787/arena/recording/export -o arena.tsq
+curl -X POST --data-binary @arena.tsq http://127.0.0.1:8787/arena/recordings/import
+```
+
+Verification runs a separate instance of the same Runtime, restoring saved
+initial values and replaying normal input admission/ticks. It compares every
+state and ordered output, then returns the final state; the live game continues.
+Changing the current Tanu document does not change the saved configuration.
+`GET /arena/recording` exposes limits and recording failures. Initial limits are
+one hour of management ticks and 64 MiB per encoded file; start a new host session
+for a fresh recording. Invalid/incompatible files return a diagnostic.
+
+See the [full file/version/endpoint contract](../../doc/specs/arena-replay.md).
+Admin playback/seek controls follow in stage 8; these endpoints already save,
+load and re-execute real TSQ1. No standalone live CLI is implied by the curl examples.

--- a/apps/demo-game/build.rs
+++ b/apps/demo-game/build.rs
@@ -1,0 +1,69 @@
+use sha2::{Digest, Sha256};
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+fn files(path: &Path, out: &mut Vec<PathBuf>) {
+    if path.is_dir() {
+        println!("cargo:rerun-if-changed={}", path.display());
+        for entry in fs::read_dir(path).unwrap() {
+            files(&entry.unwrap().path(), out);
+        }
+    } else if path.extension().is_some_and(|ext| ext == "rs") {
+        out.push(path.to_path_buf());
+    }
+}
+fn main() {
+    let root = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("../..");
+    let mut paths = vec![
+        root.join("Cargo.lock"),
+        root.join("apps/demo-game/Cargo.toml"),
+        root.join("apps/demo-game/content/arena-default.json"),
+        root.join("apps/demo-game/src/arena.rs"),
+    ];
+    files(&root.join("apps/demo-game/src/arena"), &mut paths);
+    for name in [
+        "kitu-runtime",
+        "kitu-core",
+        "kitu-ecs",
+        "kitu-osc-ir",
+        "kitu-transport",
+    ] {
+        files(&root.join("crates").join(name).join("src"), &mut paths);
+    }
+    paths.sort();
+    let mut hash = Sha256::new();
+    let compiler = std::process::Command::new(env::var("RUSTC").unwrap())
+        .arg("--version")
+        .output()
+        .expect("read Rust compiler version");
+    assert!(compiler.status.success());
+    hash.update(compiler.stdout);
+    for key in ["OPT_LEVEL", "DEBUG", "CARGO_ENCODED_RUSTFLAGS"] {
+        println!("cargo:rerun-if-env-changed={key}");
+        hash.update(key.as_bytes());
+        hash.update(env::var(key).unwrap_or_default().as_bytes());
+    }
+    for path in paths {
+        println!("cargo:rerun-if-changed={}", path.display());
+        hash.update(
+            path.strip_prefix(&root)
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .as_bytes(),
+        );
+        hash.update([0]);
+        hash.update(fs::read(path).unwrap());
+        hash.update([0]);
+    }
+    println!(
+        "cargo:rustc-env=ARENA_EXECUTION_HASH={}",
+        hex::encode(hash.finalize())
+    );
+    println!(
+        "cargo:rustc-env=ARENA_EXECUTION_TARGET={}",
+        env::var("TARGET").unwrap()
+    );
+}

--- a/apps/demo-game/src/arena.rs
+++ b/apps/demo-game/src/arena.rs
@@ -174,6 +174,18 @@ struct ArenaApplication;
 pub fn install(runtime: &mut DemoRuntime) -> Result<()> {
     let content = config::ContentVersion::from_tmd(include_bytes!("../content/arena.tmd"))
         .map_err(|_| KituError::InvalidInput("invalid bundled Arena TMD"))?;
+    install_with_content(runtime, content)
+}
+
+/// Installs an unstarted Arena using detached, previously evaluated content.
+/// Replay uses this boundary so the current authoring file is never consulted.
+pub fn install_with_content(
+    runtime: &mut DemoRuntime,
+    content: config::ContentVersion,
+) -> Result<()> {
+    content
+        .validate()
+        .map_err(|_| KituError::InvalidInput("invalid initial Arena content"))?;
     runtime.install_application(ArenaApplication)?;
     runtime.world_mut().insert_resource(ArenaSession {
         pending_content: Some(Arc::new(content)),

--- a/apps/demo-game/src/bin/admin_host.rs
+++ b/apps/demo-game/src/bin/admin_host.rs
@@ -33,6 +33,8 @@ const KEP_ROUTE_SERVER_EVENT: &str = "/server/event";
 
 #[path = "admin_host/content.rs"]
 mod content;
+#[path = "admin_host/recording.rs"]
+mod recording;
 
 #[derive(Clone)]
 struct AppState {
@@ -43,6 +45,8 @@ struct AppState {
 
 struct GameState {
     runtime: DemoRuntime,
+    recorder: kitu_demo_game::replay::Recorder,
+    recording_error: Option<String>,
     next_log_id: u64,
     logs: Vec<DebugLogEntry>,
     runtime_id: String,
@@ -52,8 +56,12 @@ struct GameState {
 
 impl GameState {
     fn new() -> Result<Self> {
+        let runtime = build_arena_runtime()?;
+        let recorder = kitu_demo_game::replay::Recorder::new(&runtime)?;
         Ok(Self {
-            runtime: build_arena_runtime()?,
+            runtime,
+            recorder,
+            recording_error: None,
             next_log_id: 1,
             logs: Vec::new(),
             runtime_id: format!(
@@ -256,6 +264,16 @@ async fn main() -> Result<()> {
         .route("/arena/content", get(content::inspect))
         .route("/arena/content/validate", post(content::validate))
         .route("/arena/content/stage", post(content::stage))
+        .route("/arena/recording", get(recording::status))
+        .route("/arena/recording/export", get(recording::export))
+        .route("/arena/recording/save", post(recording::save))
+        .route("/arena/recordings", get(recording::list))
+        .route("/arena/recordings/import", post(recording::import))
+        .route("/arena/recordings/{id}", get(recording::download))
+        .route("/arena/recordings/{id}/verify", post(recording::verify))
+        .layer(axum::extract::DefaultBodyLimit::max(
+            kitu_tsq1::recording::MAX_BYTES,
+        ))
         .route("/app-actions", get(app_action_catalog))
         .route("/app-actions/{id}", get(app_action_definition))
         .route("/app-actions/{id}/run", post(run_app_action))
@@ -709,8 +727,17 @@ fn advance_runtime_tick(state: &AppState) -> Result<Vec<ServerEvent>> {
         .lock()
         .map_err(|_| anyhow::anyhow!("state lock poisoned"))?;
     guard.runtime.tick_once().context("tick Kitu runtime")?;
+    let outputs = guard.runtime.drain_output_buffer();
+    if guard.recording_error.is_none() {
+        let GameState {
+            runtime, recorder, ..
+        } = &mut *guard;
+        if let Err(error) = recorder.capture(runtime, &outputs) {
+            guard.recording_error = Some(format!("{error:#}"));
+        }
+    }
     let mut events = Vec::new();
-    for bundle in guard.runtime.drain_output_buffer() {
+    for bundle in outputs {
         for message in bundle.messages {
             events.push(ServerEvent::Osc {
                 address: message.address,
@@ -965,7 +992,7 @@ impl IntoResponse for ApiError {
     fn into_response(self) -> axum::response::Response {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "error": self.0.to_string() })),
+            Json(serde_json::json!({ "error": format!("{:#}", self.0) })),
         )
             .into_response()
     }

--- a/apps/demo-game/src/bin/admin_host/recording.rs
+++ b/apps/demo-game/src/bin/admin_host/recording.rs
@@ -1,0 +1,183 @@
+//! Detached TSQ1 export, atomic local persistence and bounded replay verification.
+use super::*;
+use axum::{body::Bytes, http::header};
+use kitu_demo_game::replay::{Recorder, Session};
+use sha2::{Digest, Sha256};
+use std::{
+    path::PathBuf,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+pub(super) async fn status(
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let game = state.inner.lock().map_err(|_| ApiError::state_poisoned())?;
+    Ok(Json(
+        serde_json::json!({"runtimeId":game.runtime_id,"ticks":game.recorder.ticks(),"liveTick":game.runtime.current_tick().get(),"error":game.recording_error,"maxTicks":kitu_demo_game::replay::MAX_TICKS}),
+    ))
+}
+fn detached(state: &AppState) -> Result<Recorder> {
+    let game = state
+        .inner
+        .lock()
+        .map_err(|_| anyhow::anyhow!("state lock poisoned"))?;
+    // An incomplete recorder must not be presented as a complete live session.
+    anyhow::ensure!(
+        game.recording_error.is_none(),
+        "recording incomplete: {}",
+        game.recording_error.as_deref().unwrap_or_default()
+    );
+    Ok(game.recorder.clone())
+}
+async fn encoded(state: &AppState) -> Result<Vec<u8>> {
+    let recorder = detached(state)?;
+    tokio::task::spawn_blocking(move || recorder.encode()).await?
+}
+fn binary(bytes: Vec<u8>) -> impl IntoResponse {
+    (
+        [
+            (header::CONTENT_TYPE, "application/octet-stream"),
+            (
+                header::CONTENT_DISPOSITION,
+                "attachment; filename=arena.tsq",
+            ),
+        ],
+        bytes,
+    )
+}
+pub(super) async fn export(State(state): State<AppState>) -> Result<impl IntoResponse, ApiError> {
+    Ok(binary(encoded(&state).await?))
+}
+pub(super) async fn save(
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let bytes = encoded(&state).await?;
+    Ok(Json(persist(&directory(), &bytes).await?))
+}
+pub(super) fn directory() -> PathBuf {
+    env::var_os("KITU_ARENA_RECORDING_DIRECTORY")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| "apps/demo-game/.arena/recordings".into())
+}
+fn path(id: &str) -> Result<PathBuf> {
+    anyhow::ensure!(
+        id.len() == 64 && id.bytes().all(|c| c.is_ascii_hexdigit()),
+        "invalid recording id"
+    );
+    Ok(directory().join(format!("{id}.tsq")))
+}
+async fn persist(dir: &std::path::Path, bytes: &[u8]) -> Result<serde_json::Value> {
+    let id = hex::encode(Sha256::digest(bytes));
+    tokio::fs::create_dir_all(dir).await?;
+    static NEXT: AtomicU64 = AtomicU64::new(0);
+    let temporary = dir.join(format!(
+        ".{id}-{}-{}.tmp",
+        std::process::id(),
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    ));
+    tokio::fs::write(&temporary, bytes).await?;
+    let destination = dir.join(format!("{id}.tsq"));
+    if let Err(error) = tokio::fs::rename(&temporary, &destination).await {
+        let _ = tokio::fs::remove_file(&temporary).await;
+        return Err(error.into());
+    }
+    Ok(serde_json::json!({"id":id,"bytes":bytes.len(),"path":destination}))
+}
+pub(super) async fn list() -> Result<Json<serde_json::Value>, ApiError> {
+    let mut entries = Vec::new();
+    let mut files = match tokio::fs::read_dir(directory()).await {
+        Ok(files) => files,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(Json(serde_json::json!([])))
+        }
+        Err(e) => return Err(anyhow::Error::from(e).into()),
+    };
+    while let Some(file) = files.next_entry().await.map_err(anyhow::Error::from)? {
+        let name = file.file_name().to_string_lossy().to_string();
+        if let Some(id) = name.strip_suffix(".tsq") {
+            if path(id).is_ok() {
+                entries.push(serde_json::json!({"id":id,"bytes":file.metadata().await.map_err(anyhow::Error::from)?.len()}));
+            }
+        }
+    }
+    entries.sort_by(|a, b| a["id"].as_str().cmp(&b["id"].as_str()));
+    Ok(Json(serde_json::Value::Array(entries)))
+}
+async fn read(id: &str) -> Result<Vec<u8>> {
+    use tokio::io::AsyncReadExt;
+    let mut bytes = Vec::new();
+    tokio::fs::File::open(path(id)?)
+        .await?
+        .take(kitu_tsq1::recording::MAX_BYTES as u64 + 1)
+        .read_to_end(&mut bytes)
+        .await?;
+    anyhow::ensure!(
+        bytes.len() <= kitu_tsq1::recording::MAX_BYTES,
+        "recording exceeds size limit"
+    );
+    Ok(bytes)
+}
+pub(super) async fn download(Path(id): Path<String>) -> Result<impl IntoResponse, ApiError> {
+    Ok(binary(read(&id).await?))
+}
+pub(super) async fn import(bytes: Bytes) -> Result<Json<serde_json::Value>, ApiError> {
+    let bytes = bytes.to_vec();
+    let bytes = tokio::task::spawn_blocking(move || {
+        Session::decode(&bytes)?;
+        Ok::<_, anyhow::Error>(bytes)
+    })
+    .await
+    .map_err(anyhow::Error::from)??;
+    Ok(Json(persist(&directory(), &bytes).await?))
+}
+pub(super) async fn verify(
+    Path(id): Path<String>,
+) -> Result<Json<kitu_demo_game::replay::Verification>, ApiError> {
+    let bytes = read(&id).await?;
+    // CPU work is detached from the live simulation; only one verification at a time.
+    static VERIFY: tokio::sync::Semaphore = tokio::sync::Semaphore::const_new(1);
+    let _permit = VERIFY.acquire().await.map_err(anyhow::Error::from)?;
+    let result = tokio::task::spawn_blocking(move || Session::decode(&bytes)?.verify())
+        .await
+        .map_err(anyhow::Error::from)??;
+    Ok(Json(result))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[tokio::test]
+    async fn live_host_saves_loads_and_verifies_the_same_tick_queue() {
+        let state = super::super::tests::test_state();
+        {
+            let mut game = state.inner.lock().unwrap();
+            let mut bundle = kitu_osc_ir::OscBundle::new();
+            bundle.push(OscMessage::new("/input/arena/start"));
+            game.runtime
+                .try_enqueue_input(
+                    bundle,
+                    Some(InputMetadata {
+                        source: "recording-test".into(),
+                        message_id: 1,
+                        schema_version: 1,
+                    }),
+                )
+                .unwrap();
+        }
+        for _ in 0..10 {
+            advance_runtime_tick(&state).unwrap();
+        }
+        let bytes = encoded(&state).await.unwrap();
+        let dir = std::env::temp_dir().join(format!("kitu-tsq1-{}", std::process::id()));
+        let saved = persist(&dir, &bytes).await.unwrap();
+        let loaded = tokio::fs::read(saved["path"].as_str().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(loaded, bytes);
+        let report = Session::decode(&loaded).unwrap().verify().unwrap();
+        assert_eq!((report.ticks, report.inputs, report.runs), (10, 1, 1));
+        assert_eq!(state.inner.lock().unwrap().runtime.current_tick().get(), 10);
+        tokio::fs::remove_dir_all(dir).await.unwrap();
+        assert!(path("../secrets").is_err());
+    }
+}

--- a/apps/demo-game/src/bin/admin_host/recording.rs
+++ b/apps/demo-game/src/bin/admin_host/recording.rs
@@ -147,6 +147,34 @@ pub(super) async fn verify(
 mod tests {
     use super::*;
     #[tokio::test]
+    async fn unencodable_committed_input_reports_recording_failure_while_game_ticks_continue() {
+        let state = super::super::tests::test_state();
+        {
+            let mut game = state.inner.lock().unwrap();
+            let mut message = OscMessage::new("/test/ignored");
+            message.args.push(OscArg::Float(f32::NAN));
+            game.runtime
+                .try_enqueue_input(
+                    kitu_osc_ir::OscBundle {
+                        messages: vec![message],
+                    },
+                    None,
+                )
+                .unwrap();
+        }
+        advance_runtime_tick(&state).unwrap();
+        advance_runtime_tick(&state).unwrap();
+        let Json(status) = status(State(state.clone())).await.unwrap();
+        assert_eq!(status["liveTick"], 2);
+        assert_eq!(status["ticks"], 0);
+        assert!(status["error"]
+            .as_str()
+            .unwrap()
+            .contains("non-finite OSC float"));
+        assert!(encoded(&state).await.is_err());
+    }
+
+    #[tokio::test]
     async fn live_host_saves_loads_and_verifies_the_same_tick_queue() {
         let state = super::super::tests::test_state();
         {

--- a/apps/demo-game/src/lib.rs
+++ b/apps/demo-game/src/lib.rs
@@ -8,6 +8,7 @@ use kitu_runtime::{build_runtime, Runtime};
 use kitu_transport::LocalChannel;
 
 pub mod arena;
+pub mod replay;
 
 /// Stable app identifier used in project-scoped app actions.
 pub const APP_ID: &str = "demo-game";

--- a/apps/demo-game/src/replay.rs
+++ b/apps/demo-game/src/replay.rs
@@ -1,0 +1,359 @@
+//! Arena session recording and deterministic re-execution through the live Runtime.
+//!
+//! Sessions begin at Runtime tick zero, including opening/menu/management ticks.
+//! Replays restore the saved initial content and enqueue every committed bundle;
+//! they never inject snapshots or bypass application validation and update order.
+
+use crate::{
+    arena::{self, config::ContentVersion},
+    build_demo_runtime, DemoRuntime,
+};
+use anyhow::{ensure, Context, Result};
+use kitu_osc_ir::OscBundle;
+use kitu_runtime::InputMetadata;
+use kitu_tsq1::recording::{bundle_bytes, Recording, TimedBundle};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+/// Maximum session duration accepted by the initial in-memory recorder (one hour).
+pub const MAX_TICKS: u64 = 216_000;
+const RECORDING_VERSION: u32 = 1;
+
+/// Build identity required to replay rules with the same execution semantics.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ExecutionVersion {
+    /// Application package version.
+    pub package: String,
+    /// SHA-256 of rule/runtime sources and the locked dependency graph.
+    pub source_hash: String,
+    /// Compilation target; cross-target equivalence is validated separately.
+    pub target: String,
+}
+impl ExecutionVersion {
+    /// Identity of the currently compiled application.
+    pub fn current() -> Self {
+        Self {
+            package: env!("CARGO_PKG_VERSION").into(),
+            source_hash: env!("ARENA_EXECUTION_HASH").into(),
+            target: env!("ARENA_EXECUTION_TARGET").into(),
+        }
+    }
+}
+
+/// Exact hashes of detached application state and ordered outputs after one tick.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TickProof {
+    /// Canonical logical application projection hash.
+    pub state: String,
+    /// All ordered output bundles, including receipts and domain events.
+    pub output: String,
+}
+
+/// Complete metadata needed to reconstruct and validate a session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Manifest {
+    /// Arena recording schema, distinct from OSC and TSQ1 versions.
+    pub version: u32,
+    /// Stable application identifier.
+    pub app: String,
+    /// Compiled rules and Runtime identity.
+    pub execution: ExecutionVersion,
+    /// OSC application contract version.
+    pub contract_version: u32,
+    /// Fixed Runtime ticks per second.
+    pub tick_rate: u32,
+    /// Evaluated content present before the very first input/tick.
+    pub initial_content: ContentVersion,
+    /// Projection before execution; protects initial-condition compatibility.
+    pub initial_state: String,
+    /// Total completed management ticks, including pauses and empty input ticks.
+    pub ticks: u64,
+    /// One state/output proof per completed tick, in tick order.
+    pub proofs: Vec<TickProof>,
+    /// Detached run-start events containing each run's full frozen configuration.
+    pub runs: Vec<Value>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct InputIdentity {
+    sequence: u64,
+    identity: Option<InputMetadata>,
+}
+
+/// Recorder attached at creation of a live Runtime.
+#[derive(Clone)]
+pub struct Recorder {
+    manifest: Manifest,
+    inputs: Vec<TimedBundle>,
+}
+impl Recorder {
+    /// Captures initial conditions without advancing or changing the Runtime.
+    ///
+    /// # Examples
+    /// ```
+    /// let mut runtime = kitu_demo_game::build_arena_runtime().unwrap();
+    /// let mut recorder = kitu_demo_game::replay::Recorder::new(&runtime).unwrap();
+    /// runtime.tick_once().unwrap();
+    /// let outputs = runtime.drain_output_buffer();
+    /// recorder.capture(&runtime, &outputs).unwrap();
+    /// let session = kitu_demo_game::replay::Session::decode(&recorder.encode().unwrap()).unwrap();
+    /// assert_eq!(session.verify().unwrap().ticks, 1);
+    /// ```
+    pub fn new(runtime: &DemoRuntime) -> Result<Self> {
+        ensure!(
+            runtime.current_tick().get() == 0,
+            "recording must begin at Runtime creation"
+        );
+        let initial = arena::inspect_content(runtime).context("Arena is not installed")?;
+        ensure!(
+            initial.run == 0 && initial.active.is_none(),
+            "recording requires initial Arena state"
+        );
+        Ok(Self {
+            manifest: Manifest {
+                version: RECORDING_VERSION,
+                app: "endless-arena".into(),
+                execution: ExecutionVersion::current(),
+                contract_version: arena::SCHEMA_VERSION,
+                tick_rate: runtime.config().tick_rate_hz,
+                initial_content: initial.pending,
+                initial_state: hash_bundles(&runtime.inspect_application())?,
+                ticks: 0,
+                proofs: Vec::new(),
+                runs: Vec::new(),
+            },
+            inputs: Vec::new(),
+        })
+    }
+    /// Records one successfully completed tick, before committed inputs are drained.
+    /// Missing ticks, excessive sessions or invalid OSC fail without partial capture.
+    pub fn capture(&mut self, runtime: &DemoRuntime, outputs: &[OscBundle]) -> Result<()> {
+        ensure!(
+            runtime.current_tick().get() == self.manifest.ticks + 1,
+            "recording missed a tick"
+        );
+        ensure!(
+            self.manifest.ticks < MAX_TICKS,
+            "recording reached one-hour limit; save and start a new session"
+        );
+        let batch = runtime.committed_input_records();
+        ensure!(
+            self.inputs.len() + batch.len() <= kitu_tsq1::recording::MAX_ENTRIES,
+            "recording input limit reached"
+        );
+        let entries = batch
+            .into_iter()
+            .enumerate()
+            .map(|(order, input)| {
+                Ok(TimedBundle {
+                    tick: self.manifest.ticks,
+                    order: u32::try_from(order)?,
+                    metadata: serde_json::to_value(InputIdentity {
+                        sequence: input.sequence,
+                        identity: input.metadata,
+                    })?,
+                    bundle: input.bundle,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let proof = proof(runtime, outputs)?;
+        let mut runs = Vec::new();
+        for message in outputs.iter().flat_map(|bundle| &bundle.messages) {
+            if message.address == "/game/arena/run" {
+                let [kitu_osc_ir::OscArg::Str(json)] = message.args.as_slice() else {
+                    anyhow::bail!("invalid run manifest output")
+                };
+                runs.push(serde_json::from_str(json)?);
+            }
+        }
+        self.inputs.extend(entries);
+        self.manifest.proofs.push(proof);
+        self.manifest.runs.extend(runs);
+        self.manifest.ticks += 1;
+        Ok(())
+    }
+    /// Encodes a detached point-in-time TSQ1 session, suitable for atomic disk saves.
+    pub fn encode(&self) -> Result<Vec<u8>> {
+        Recording {
+            manifest: serde_json::to_value(&self.manifest)?,
+            entries: self.inputs.clone(),
+        }
+        .encode()
+    }
+    /// Completed tick count available in this recorder.
+    pub fn ticks(&self) -> u64 {
+        self.manifest.ticks
+    }
+}
+
+/// Validated, immutable TSQ1 session loaded for replay.
+#[derive(Clone)]
+pub struct Session {
+    manifest: Manifest,
+    inputs: Vec<TimedBundle>,
+}
+
+/// Result of a complete deterministic re-execution.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Verification {
+    /// Completed ticks compared to saved state/output proofs.
+    pub ticks: u64,
+    /// Number of replayed bundles, including retransmissions.
+    pub inputs: usize,
+    /// Number of complete saved run-start manifests compared.
+    pub runs: usize,
+    /// Final authoritative application projection.
+    pub state: Value,
+}
+impl Session {
+    /// Loads real TSQ1, rejecting incompatible execution/contract versions and bounds.
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        let document = Recording::decode(bytes)?;
+        let manifest: Manifest = serde_json::from_value(document.manifest)?;
+        ensure!(
+            manifest.version == RECORDING_VERSION && manifest.app == "endless-arena",
+            "incompatible Arena recording version"
+        );
+        ensure!(
+            manifest.execution == ExecutionVersion::current(),
+            "incompatible Arena execution version"
+        );
+        ensure!(
+            manifest.contract_version == arena::SCHEMA_VERSION && manifest.tick_rate == 60,
+            "incompatible Arena contract or tick rate"
+        );
+        ensure!(
+            manifest.ticks <= MAX_TICKS && manifest.proofs.len() as u64 == manifest.ticks,
+            "invalid recording tick count"
+        );
+        manifest.initial_content.validate()?;
+        ensure!(
+            valid_hash(&manifest.initial_state)
+                && manifest
+                    .proofs
+                    .iter()
+                    .all(|p| valid_hash(&p.state) && valid_hash(&p.output)),
+            "invalid state/output proof"
+        );
+        for (sequence, entry) in document.entries.iter().enumerate() {
+            ensure!(
+                entry.tick < manifest.ticks,
+                "input lies outside the recording"
+            );
+            let identity: InputIdentity = serde_json::from_value(entry.metadata.clone())?;
+            ensure!(
+                identity.sequence == sequence as u64,
+                "recorded queue order is not contiguous"
+            );
+        }
+        Ok(Self {
+            manifest,
+            inputs: document.entries,
+        })
+    }
+    /// Returns saved metadata, including all detached run configurations.
+    pub fn manifest(&self) -> &Manifest {
+        &self.manifest
+    }
+    /// Creates a fresh Runtime with saved initial conditions and no authoring I/O.
+    pub fn runtime(&self) -> Result<DemoRuntime> {
+        let mut runtime = build_demo_runtime()?;
+        arena::install_with_content(&mut runtime, self.manifest.initial_content.clone())?;
+        ensure!(
+            hash_bundles(&runtime.inspect_application())? == self.manifest.initial_state,
+            "incompatible initial Arena state"
+        );
+        Ok(runtime)
+    }
+    /// Applies one recorded tick through the ordinary admission queue and tick loop.
+    /// State and ordered outputs must match before the resulting projection is usable.
+    /// The caller supplies a Runtime created by [`Self::runtime`], advanced in order.
+    pub fn tick(&self, runtime: &mut DemoRuntime) -> Result<Vec<OscBundle>> {
+        let tick = runtime.current_tick().get();
+        ensure!(
+            tick < self.manifest.ticks,
+            "replay reached end of recording"
+        );
+        let first = self.inputs.partition_point(|entry| entry.tick < tick);
+        for entry in self.inputs[first..]
+            .iter()
+            .take_while(|entry| entry.tick == tick)
+        {
+            let identity: InputIdentity = serde_json::from_value(entry.metadata.clone())?;
+            let sequence = runtime
+                .try_enqueue_input(entry.bundle.clone(), identity.identity)
+                .with_context(|| {
+                    format!(
+                        "replay input rejected at tick {tick}, order {}",
+                        entry.order
+                    )
+                })?;
+            ensure!(
+                sequence == identity.sequence,
+                "replay queue sequence diverged at tick {tick}"
+            );
+        }
+        runtime.tick_once()?;
+        let outputs = runtime.drain_output_buffer();
+        let actual = proof(runtime, &outputs)?;
+        let expected = &self.manifest.proofs[tick as usize];
+        ensure!(
+            actual.state == expected.state,
+            "replay state diverged at tick {tick}"
+        );
+        ensure!(
+            actual.output == expected.output,
+            "replay output/event order diverged at tick {tick}"
+        );
+        Ok(outputs)
+    }
+    /// Re-executes every tick and compares every state/output and frozen run manifest.
+    pub fn verify(&self) -> Result<Verification> {
+        let mut runtime = self.runtime()?;
+        let mut recorder = Recorder::new(&runtime)?;
+        while runtime.current_tick().get() < self.manifest.ticks {
+            let outputs = self.tick(&mut runtime)?;
+            recorder.capture(&runtime, &outputs)?;
+        }
+        ensure!(
+            recorder.manifest.runs == self.manifest.runs,
+            "saved run manifests diverged"
+        );
+        let projection = runtime.inspect_application();
+        let kitu_osc_ir::OscArg::Str(json) = &projection[0].messages[0].args[0] else {
+            unreachable!()
+        };
+        Ok(Verification {
+            ticks: self.manifest.ticks,
+            inputs: self.inputs.len(),
+            runs: self.manifest.runs.len(),
+            state: serde_json::from_str(json)?,
+        })
+    }
+}
+
+fn valid_hash(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|b| b.is_ascii_hexdigit())
+}
+fn proof(runtime: &DemoRuntime, outputs: &[OscBundle]) -> Result<TickProof> {
+    Ok(TickProof {
+        state: hash_bundles(&runtime.inspect_application())?,
+        output: hash_bundles(outputs)?,
+    })
+}
+fn hash_bundles(bundles: &[OscBundle]) -> Result<String> {
+    let mut hash = Sha256::new();
+    hash.update((bundles.len() as u64).to_le_bytes());
+    for bundle in bundles {
+        let bytes = bundle_bytes(bundle)?;
+        hash.update((bytes.len() as u64).to_le_bytes());
+        hash.update(bytes);
+    }
+    Ok(hex::encode(hash.finalize()))
+}

--- a/apps/demo-game/src/replay.rs
+++ b/apps/demo-game/src/replay.rs
@@ -90,6 +90,7 @@ struct InputIdentity {
 pub struct Recorder {
     manifest: Manifest,
     inputs: Vec<TimedBundle>,
+    encoded_size_bound: usize,
 }
 impl Recorder {
     /// Captures initial conditions without advancing or changing the Runtime.
@@ -114,7 +115,7 @@ impl Recorder {
             initial.run == 0 && initial.active.is_none(),
             "recording requires initial Arena state"
         );
-        Ok(Self {
+        let mut recorder = Self {
             manifest: Manifest {
                 version: RECORDING_VERSION,
                 app: "endless-arena".into(),
@@ -128,7 +129,11 @@ impl Recorder {
                 runs: Vec::new(),
             },
             inputs: Vec::new(),
-        })
+            encoded_size_bound: 0,
+        };
+        // Reserve growth from the initial one-digit tick count to any u64.
+        recorder.encoded_size_bound = recorder.encode()?.len() + 20;
+        Ok(recorder)
     }
     /// Records one successfully completed tick, before committed inputs are drained.
     /// Missing ticks, excessive sessions or invalid OSC fail without partial capture.
@@ -139,7 +144,7 @@ impl Recorder {
         );
         ensure!(
             self.manifest.ticks < MAX_TICKS,
-            "recording reached one-hour limit; save and start a new session"
+            "recording reached one-hour limit; start a new session"
         );
         let batch = runtime.committed_input_records();
         ensure!(
@@ -171,6 +176,32 @@ impl Recorder {
                 runs.push(serde_json::from_str(json)?);
             }
         }
+        let mut size = self.encoded_size_bound;
+        for (offset, entry) in entries.iter().enumerate() {
+            let identity: InputIdentity = serde_json::from_value(entry.metadata.clone())?;
+            ensure!(
+                identity.sequence == (self.inputs.len() + offset) as u64,
+                "recording queue sequence was skipped"
+            );
+            size = size
+                .checked_add(entry.encoded_size_bound()?)
+                .context("recording size overflow")?;
+        }
+        // These values are already JSON-owned or strings, so serde_json's value
+        // conversion does not change their representation in the TSQ1 manifest.
+        size = size
+            .checked_add(serde_json::to_vec(&proof)?.len() + 1)
+            .context("recording size overflow")?;
+        for run in &runs {
+            size = size
+                .checked_add(serde_json::to_vec(run)?.len() + 1)
+                .context("recording size overflow")?;
+        }
+        ensure!(
+            size <= kitu_tsq1::recording::MAX_BYTES,
+            "recording reached encoded-size limit; start a new session"
+        );
+        self.encoded_size_bound = size;
         self.inputs.extend(entries);
         self.manifest.proofs.push(proof);
         self.manifest.runs.extend(runs);
@@ -356,4 +387,62 @@ fn hash_bundles(bundles: &[OscBundle]) -> Result<String> {
         hash.update(bytes);
     }
     Ok(hex::encode(hash.finalize()))
+}
+
+#[cfg(test)]
+mod recording_bounds_tests {
+    use super::*;
+    use kitu_osc_ir::{OscArg, OscMessage};
+
+    fn pending(runtime: &mut DemoRuntime, argument: OscArg) {
+        let mut message = OscMessage::new("/test/unhandled");
+        message.args.push(argument);
+        runtime
+            .try_enqueue_input(
+                OscBundle {
+                    messages: vec![message],
+                },
+                None,
+            )
+            .unwrap();
+        runtime.tick_once().unwrap();
+    }
+
+    #[test]
+    fn capture_rejects_unencodable_osc_without_poisoning_the_saved_prefix() {
+        let mut runtime = crate::build_arena_runtime().unwrap();
+        let mut recorder = Recorder::new(&runtime).unwrap();
+        let prefix = recorder.encode().unwrap();
+        pending(&mut runtime, OscArg::Float(f32::NAN));
+        let outputs = runtime.drain_output_buffer();
+        assert!(recorder
+            .capture(&runtime, &outputs)
+            .unwrap_err()
+            .to_string()
+            .contains("non-finite OSC float"));
+        assert_eq!(recorder.encode().unwrap(), prefix);
+        assert_eq!(recorder.ticks(), 0);
+    }
+
+    #[test]
+    fn capture_checks_cumulative_encoded_bound_before_appending() {
+        let mut runtime = crate::build_arena_runtime().unwrap();
+        let mut recorder = Recorder::new(&runtime).unwrap();
+        pending(&mut runtime, OscArg::Str("small".into()));
+        let outputs = runtime.drain_output_buffer();
+        recorder.capture(&runtime, &outputs).unwrap();
+        assert!(recorder.encode().unwrap().len() <= recorder.encoded_size_bound);
+        let prefix = recorder.encode().unwrap();
+        // Model an almost-full recorder without allocating 64 MiB in every test.
+        recorder.encoded_size_bound = kitu_tsq1::recording::MAX_BYTES - 1;
+        pending(&mut runtime, OscArg::Str("next valid finite input".into()));
+        let outputs = runtime.drain_output_buffer();
+        assert!(recorder
+            .capture(&runtime, &outputs)
+            .unwrap_err()
+            .to_string()
+            .contains("encoded-size limit"));
+        assert_eq!(recorder.encode().unwrap(), prefix);
+        assert_eq!(recorder.ticks(), 1);
+    }
 }

--- a/apps/demo-game/tests/arena_replay.rs
+++ b/apps/demo-game/tests/arena_replay.rs
@@ -1,0 +1,155 @@
+#[allow(dead_code)] // Shared oracle helpers are used by different integration binaries.
+mod support;
+use kitu_demo_game::{
+    arena::{
+        self,
+        config::{ArenaConfig, ContentVersion},
+    },
+    build_arena_runtime,
+    replay::{Recorder, Session},
+};
+use kitu_osc_ir::OscArg;
+use kitu_tsq1::recording::Recording;
+use serde_json::{json, Value};
+
+#[test]
+fn real_tsq1_replays_every_stock_tick_state_and_event_through_eleven_death_retry() {
+    let initial = build_arena_runtime().unwrap();
+    let mut recorder = Recorder::new(&initial).unwrap();
+    let (checkpoints, outcomes) = support::replay_reference_observing_ticks(
+        "stock-eleven-death-retry",
+        5528,
+        |_| {},
+        |runtime, outputs| recorder.capture(runtime, outputs).unwrap(),
+    );
+    assert_eq!((checkpoints, outcomes), (550, 53));
+    let bytes = recorder.encode().unwrap();
+    assert_eq!(&bytes[..4], b"TSQ1");
+    let session = Session::decode(&bytes).unwrap();
+    let verified = session.verify().unwrap();
+    assert_eq!((verified.ticks, verified.runs), (5528, 2));
+    assert_eq!(verified.state["phase"], 1);
+    assert_eq!(verified.state["inventory"]["maxHealth"], 100);
+    assert_eq!(session.manifest().proofs.len(), 5528);
+    if let Some(dir) = std::env::var_os("KITU_REPLAY_EVIDENCE_DIR") {
+        std::fs::create_dir_all(&dir).unwrap();
+        let dir = std::path::Path::new(&dir);
+        std::fs::write(dir.join("stock-eleven-death-retry.tsq"), bytes).unwrap();
+        std::fs::write(
+            dir.join("stock-verification.json"),
+            serde_json::to_vec_pretty(&verified).unwrap(),
+        )
+        .unwrap();
+    }
+}
+
+#[test]
+fn saved_content_management_ticks_and_duplicates_survive_later_tanu_edits() {
+    let mut runtime = build_arena_runtime().unwrap();
+    let mut recorder = Recorder::new(&runtime).unwrap();
+    let mut edited = ArenaConfig::default();
+    edited.items[0].damage = 37;
+    let saved = ContentVersion::from_tmd(&edited.to_tmd().unwrap()).unwrap();
+    arena::stage_content(&mut runtime, saved.clone(), 1).unwrap();
+    support::send(&mut runtime, "unity", 1, "/input/arena/start", vec![]);
+    support::send(&mut runtime, "unity", 1, "/input/arena/start", vec![]);
+    for tick in 0..15 {
+        match tick {
+            2 => support::send(&mut runtime, "unity", 2, "/input/arena/pause", vec![]),
+            5 => support::send(&mut runtime, "unity", 3, "/input/arena/resume", vec![]),
+            7 => {
+                edited.items[0].damage = 99;
+                arena::stage_content(
+                    &mut runtime,
+                    ContentVersion::from_tmd(&edited.to_tmd().unwrap()).unwrap(),
+                    2,
+                )
+                .unwrap();
+            }
+            8 => {
+                support::send(&mut runtime, "unity", 4, "/input/arena/menu", vec![]);
+                support::send(&mut runtime, "unity", 5, "/input/arena/start", vec![]);
+            }
+            10 => support::send(
+                &mut runtime,
+                "unity",
+                6,
+                "/input/arena/use",
+                vec![OscArg::Int(2)],
+            ),
+            _ => {}
+        }
+        runtime.tick_once().unwrap();
+        let outputs = runtime.drain_output_buffer();
+        recorder.capture(&runtime, &outputs).unwrap();
+    }
+    let bytes = recorder.encode().unwrap();
+    let session = Session::decode(&bytes).unwrap();
+    assert_eq!(session.manifest().runs[0]["content"]["hash"], saved.hash);
+    assert_eq!(
+        session.manifest().runs[0]["content"]["values"]["items"][0]["damage"],
+        37
+    );
+    assert_eq!(
+        session.manifest().runs[1]["content"]["values"]["items"][0]["damage"],
+        99
+    );
+    let expected = support::projection(&runtime);
+    assert_eq!(session.verify().unwrap().state, expected);
+    // Reconstruct from the old detached initial values even if current authoring differs.
+    assert_eq!(
+        arena::inspect_content(&session.runtime().unwrap())
+            .unwrap()
+            .pending,
+        session.manifest().initial_content
+    );
+    let entries = Recording::decode(&bytes).unwrap().entries;
+    assert_eq!(entries[1].tick, entries[2].tick);
+    assert_eq!(
+        entries[1].metadata["identity"]["messageId"],
+        entries[2].metadata["identity"]["messageId"]
+    );
+    assert_ne!(entries[1].order, entries[2].order);
+}
+
+#[test]
+fn incompatible_tampered_and_truncated_sessions_are_rejected_with_tick_diagnostics() {
+    let mut runtime = build_arena_runtime().unwrap();
+    let mut recorder = Recorder::new(&runtime).unwrap();
+    support::send(&mut runtime, "unity", 1, "/input/arena/start", vec![]);
+    runtime.tick_once().unwrap();
+    let outputs = runtime.drain_output_buffer();
+    recorder.capture(&runtime, &outputs).unwrap();
+    let bytes = recorder.encode().unwrap();
+    let original = Recording::decode(&bytes).unwrap();
+    for key in ["version", "contractVersion", "tickRate", "ticks"] {
+        let mut doc = original.clone();
+        doc.manifest[key] = json!(999999999);
+        assert!(Session::decode(&doc.encode().unwrap()).is_err(), "{key}");
+    }
+    let mut doc = original.clone();
+    doc.manifest["execution"]["sourceHash"] = json!("old");
+    assert!(Session::decode(&doc.encode().unwrap()).is_err());
+    let mut doc = original.clone();
+    doc.entries[0].metadata["sequence"] = json!(1);
+    assert!(Session::decode(&doc.encode().unwrap()).is_err());
+    let mut doc = original.clone();
+    doc.manifest["proofs"][0]["output"] = json!("0".repeat(64));
+    let session = Session::decode(&doc.encode().unwrap()).unwrap();
+    assert!(session
+        .verify()
+        .unwrap_err()
+        .to_string()
+        .contains("event order diverged at tick 0"));
+    let mut doc = original;
+    doc.manifest["runs"] = Value::Array(vec![]);
+    assert!(Session::decode(&doc.encode().unwrap())
+        .unwrap()
+        .verify()
+        .is_err());
+    assert!(Session::decode(&bytes[..bytes.len() - 1]).is_err());
+    assert!(Recorder::new(&runtime).is_err());
+    runtime.tick_once().unwrap();
+    runtime.tick_once().unwrap();
+    assert!(recorder.capture(&runtime, &[]).is_err());
+}

--- a/apps/demo-game/tests/support/mod.rs
+++ b/apps/demo-game/tests/support/mod.rs
@@ -69,7 +69,16 @@ pub fn replay_reference(name: &str, limit: usize) -> (usize, usize) {
 pub fn replay_reference_observing(
     name: &str,
     limit: usize,
+    observe: impl FnMut(&OscMessage),
+) -> (usize, usize) {
+    replay_reference_observing_ticks(name, limit, observe, |_, _| {})
+}
+
+pub fn replay_reference_observing_ticks(
+    name: &str,
+    limit: usize,
     mut observe: impl FnMut(&OscMessage),
+    mut on_tick: impl FnMut(&DemoRuntime, &[OscBundle]),
 ) -> (usize, usize) {
     let directory = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../kitu-integration-runner/scenarios/arena/reference")
@@ -144,7 +153,9 @@ pub fn replay_reference_observing(
             }
         }
         runtime.tick_once().unwrap();
-        for bundle in runtime.drain_output_buffer() {
+        let outputs = runtime.drain_output_buffer();
+        on_tick(&runtime, &outputs);
+        for bundle in outputs {
             for message in bundle.messages {
                 observe(&message);
                 if message.address == "/ui/arena/command" {

--- a/crates/kitu-runtime/Cargo.toml
+++ b/crates/kitu-runtime/Cargo.toml
@@ -17,3 +17,4 @@ kitu-ecs = { path = "../kitu-ecs" }
 kitu-transport = { path = "../kitu-transport" }
 kitu-osc-ir = { path = "../kitu-osc-ir" }
 kitu-app-actions = { path = "../kitu-app-actions" }
+serde = { version = "1", features = ["derive"] }

--- a/crates/kitu-runtime/src/application.rs
+++ b/crates/kitu-runtime/src/application.rs
@@ -5,7 +5,8 @@ use kitu_ecs::EcsWorld;
 use kitu_osc_ir::OscBundle;
 
 /// Identity and schema information retained alongside a logical input bundle.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct InputMetadata {
     /// Stable producer identity, retained across reconnects to the same runtime.
     pub source: String,

--- a/crates/kitu-runtime/src/lib.rs
+++ b/crates/kitu-runtime/src/lib.rs
@@ -413,6 +413,23 @@ impl<T: Transport> Runtime<T> {
         drained
     }
 
+    /// Returns the last committed batch with its application identities and queue order.
+    ///
+    /// Inspect immediately after a successful tick and before draining committed
+    /// inputs. Pending inputs are excluded; inspection never consumes the batch.
+    ///
+    /// # Examples
+    /// ```
+    /// let mut runtime = kitu_runtime::build_runtime(kitu_transport::LocalChannel::connected());
+    /// runtime.enqueue_input(kitu_osc_ir::OscBundle::new());
+    /// runtime.tick_once().unwrap();
+    /// assert_eq!(runtime.committed_input_records()[0].sequence, 0);
+    /// assert_eq!(runtime.committed_input_records().len(), 1);
+    /// ```
+    pub fn committed_input_records(&self) -> Vec<RuntimeInput> {
+        self.inputs.committed_batch.iter().cloned().collect()
+    }
+
     fn enqueue_player_move(&mut self, entity_id: &str, x: f32, z: f32) {
         let mut message = OscMessage::new("/input/move");
         message.push_arg(OscArg::Str(entity_id.to_string()));

--- a/crates/kitu-tsq1/Cargo.toml
+++ b/crates/kitu-tsq1/Cargo.toml
@@ -13,3 +13,9 @@ include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 kitu-core = { path = "../kitu-core" }
+kitu-osc-ir = { path = "../kitu-osc-ir" }
+anyhow = { workspace = true }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tsq1 = { git = "https://github.com/Nagitch/tsq1", rev = "05707147e83a4fba591a3933d49f056bb6d3540b" }
+tsq1-osc = { git = "https://github.com/Nagitch/tsq1", rev = "05707147e83a4fba591a3933d49f056bb6d3540b" }

--- a/crates/kitu-tsq1/README.md
+++ b/crates/kitu-tsq1/README.md
@@ -1,6 +1,14 @@
 # kitu-tsq1
 
-TSQ1 timeline AST and playback helpers for Kitu presentation flows.
+Real TSQ1 binary recordings, typed OSC-IR conversion and legacy timeline helpers.
+
+`recording::Recording` uses the pinned public TSQ1/OSC APIs, with explicit tick/order
+envelopes and application-owned manifests. i32/i64 widths, finite f32 values,
+argument/message ordering and immediate bundles round trip losslessly. Unsupported
+bundle semantics are rejected. See `doc/specs/arena-replay.md` in the repository.
+
+The old `Timeline::parse` emit/wait text helper remains a compatibility API; it is
+not the binary TSQ1 format and is not used by Arena recording.
 
 ## Responsibilities
 - Model TSQ1 timelines and events in a deterministic, testable form.

--- a/crates/kitu-tsq1/src/lib.rs
+++ b/crates/kitu-tsq1/src/lib.rs
@@ -1,7 +1,7 @@
-//! TSQ1 timeline parser and scheduler skeleton.
+//! TSQ1 binary recordings and legacy text timeline helpers.
 //!
 //! # Responsibilities
-//! - Parse TSQ1 text into a structured AST for deterministic playback.
+//! - Encode real TSQ1 documents with exact ticks and lossless typed OSC bundles.
 //! - Provide scheduling helpers that emit OSC/IR events for the runtime loop.
 //! - Keep the timeline model self-contained so tooling and runtime share the same semantics.
 //!
@@ -12,6 +12,8 @@
 use std::collections::VecDeque;
 
 use kitu_core::{KituError, Result, Tick};
+
+pub mod recording;
 
 /// A single timeline step.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/kitu-tsq1/src/recording.rs
+++ b/crates/kitu-tsq1/src/recording.rs
@@ -1,0 +1,362 @@
+//! Real TSQ1 recordings with explicit application ticks and typed OSC bundles.
+//!
+//! A track pairs a custom envelope with an OSC MessagePack event. Musical time
+//! is a display axis (60 PPQ, one second per quarter); explicit ticks and order
+//! are authoritative. Application manifests and per-input metadata stay opaque.
+
+use anyhow::{bail, ensure, Context, Result};
+use kitu_osc_ir::{OscArg, OscBundle, OscMessage};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tsq1::{Event, EventKind, Sequence, TempoEntry, TimeDomain, Track, UnknownChunk};
+use tsq1_osc::osc_ir::{IrBundle, IrBundleElement, IrValue};
+
+/// Largest accepted binary recording, before any decoding or allocation.
+pub const MAX_BYTES: usize = 64 * 1024 * 1024;
+/// Upper bound on logical bundles in one recording.
+pub const MAX_ENTRIES: usize = 1_000_000;
+const FORMAT: u32 = 1;
+const ENVELOPE: u8 = 0x4b;
+
+/// One committed bundle, retaining its exact tick and position within that tick.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TimedBundle {
+    /// Zero-based application tick; never reconstructed from elapsed time.
+    pub tick: u64,
+    /// Zero-based contiguous order among bundles in this tick.
+    pub order: u32,
+    /// Application-owned identity and queue metadata.
+    pub metadata: Value,
+    /// Original ordered messages and typed arguments.
+    pub bundle: OscBundle,
+}
+
+/// Portable binary session with application-owned version/initial-state metadata.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Recording {
+    /// Application manifest, interpreted and validated by the application.
+    pub manifest: Value,
+    /// Ordered committed inputs, including intentional retransmissions.
+    pub entries: Vec<TimedBundle>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Header {
+    format: u32,
+    manifest: Value,
+}
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Envelope {
+    tick: u64,
+    order: u32,
+    metadata: Value,
+}
+
+impl Recording {
+    /// Encodes using the pinned TSQ1 public API, validating order before writing.
+    ///
+    /// # Examples
+    /// ```
+    /// use kitu_tsq1::recording::Recording;
+    /// let document = Recording { manifest: serde_json::json!({"app":"example"}), entries: vec![] };
+    /// let bytes = document.encode().unwrap();
+    /// assert_eq!(&bytes[..4], b"TSQ1");
+    /// assert_eq!(Recording::decode(&bytes).unwrap(), document);
+    /// ```
+    pub fn encode(&self) -> Result<Vec<u8>> {
+        ensure!(self.entries.len() <= MAX_ENTRIES, "too many input bundles");
+        let mut sequence = Sequence::new(60);
+        sequence.tempo_map.push(TempoEntry {
+            tick: 0,
+            microseconds_per_quarter: 1_000_000,
+        });
+        sequence.unknown_chunks.push(UnknownChunk {
+            id: *b"KITU",
+            data: serde_json::to_vec(&Header {
+                format: FORMAT,
+                manifest: self.manifest.clone(),
+            })?,
+        });
+        let mut track = Track::default();
+        let mut previous = None;
+        for entry in &self.entries {
+            validate_order(previous, entry.tick, entry.order)?;
+            let delta = entry.tick - previous.map_or(0, |(tick, _)| tick);
+            track.events.push(Event {
+                delta,
+                domain: TimeDomain::Musical,
+                kind: EventKind::Custom {
+                    type_id: ENVELOPE,
+                    data: serde_json::to_vec(&Envelope {
+                        tick: entry.tick,
+                        order: entry.order,
+                        metadata: entry.metadata.clone(),
+                    })?,
+                },
+            });
+            track.events.push(tsq1_osc::event_from_ir(
+                TimeDomain::Musical,
+                0,
+                &bundle_to_ir(&entry.bundle)?,
+            )?);
+            previous = Some((entry.tick, entry.order));
+        }
+        sequence.tracks.push(track);
+        let bytes = sequence.encode()?;
+        ensure!(bytes.len() <= MAX_BYTES, "recording exceeds size limit");
+        Ok(bytes)
+    }
+
+    /// Decodes and validates the Kitu envelope without coercing OSC types.
+    /// Unsupported chunks/tracks/time axes are rejected rather than discarded.
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        ensure!(bytes.len() <= MAX_BYTES, "recording exceeds size limit");
+        let sequence = Sequence::decode(bytes).context("decode TSQ1")?;
+        ensure!(
+            sequence.tracks.len() == 1
+                && sequence.ppq == 60
+                && sequence.absolute_unit == tsq1::AbsoluteUnit::Microseconds
+                && sequence.flags == Sequence::new(60).flags
+                && sequence.tempo_map
+                    == vec![TempoEntry {
+                        tick: 0,
+                        microseconds_per_quarter: 1_000_000
+                    }]
+                && sequence.sync_anchors.is_empty()
+                && sequence.markers.is_empty()
+                && sequence.smpte_timing.is_none(),
+            "unsupported recording time axis or tracks"
+        );
+        ensure!(
+            sequence.unknown_chunks.len() == 1 && sequence.unknown_chunks[0].id == *b"KITU",
+            "missing or unsupported recording manifest"
+        );
+        let header: Header = serde_json::from_slice(&sequence.unknown_chunks[0].data)?;
+        ensure!(header.format == FORMAT, "incompatible recording format");
+        let events = &sequence.tracks[0].events;
+        ensure!(
+            events.len() % 2 == 0 && events.len() / 2 <= MAX_ENTRIES,
+            "unpaired or excessive recording events"
+        );
+        let mut previous = None;
+        let mut entries = Vec::with_capacity(events.len() / 2);
+        for pair in events.chunks_exact(2) {
+            let EventKind::Custom {
+                type_id: ENVELOPE,
+                data,
+            } = &pair[0].kind
+            else {
+                bail!("expected input envelope")
+            };
+            let envelope: Envelope = serde_json::from_slice(data)?;
+            validate_order(previous, envelope.tick, envelope.order)?;
+            let delta = envelope.tick - previous.map_or(0, |(tick, _)| tick);
+            ensure!(
+                pair[0].domain == TimeDomain::Musical
+                    && pair[0].delta == delta
+                    && pair[1].domain == TimeDomain::Musical
+                    && pair[1].delta == 0,
+                "tick and TSQ1 time axis disagree"
+            );
+            entries.push(TimedBundle {
+                tick: envelope.tick,
+                order: envelope.order,
+                metadata: envelope.metadata,
+                bundle: bundle_from_ir(&tsq1_osc::event_to_ir(&pair[1])?)?,
+            });
+            previous = Some((envelope.tick, envelope.order));
+        }
+        Ok(Self {
+            manifest: header.manifest,
+            entries,
+        })
+    }
+}
+
+fn validate_order(previous: Option<(u64, u32)>, tick: u64, order: u32) -> Result<()> {
+    match previous {
+        None => ensure!(order == 0, "first tick order must be zero"),
+        Some((last_tick, last_order)) => {
+            ensure!(tick >= last_tick, "input ticks decreased");
+            let expected = if tick == last_tick {
+                last_order.checked_add(1).context("input order overflow")?
+            } else {
+                0
+            };
+            ensure!(order == expected, "input order is not contiguous");
+        }
+    }
+    Ok(())
+}
+
+/// Converts Kitu's immediate, flat bundle into OSC-IR without flattening messages.
+/// Each message is `[address, type-tags, arguments]`; tags distinguish i32/i64.
+/// Non-finite floats cannot enter the Runtime and are rejected at this boundary.
+pub fn bundle_to_ir(bundle: &OscBundle) -> Result<IrValue> {
+    let mut result = IrBundle::immediate();
+    for message in &bundle.messages {
+        let mut tags = String::new();
+        let mut args = Vec::new();
+        for arg in &message.args {
+            let (tag, value) = match arg {
+                OscArg::Int(v) => ('i', IrValue::Integer(i64::from(*v))),
+                OscArg::Int64(v) => ('h', IrValue::Integer(*v)),
+                OscArg::Float(v) => {
+                    ensure!(v.is_finite(), "non-finite OSC float");
+                    ('f', IrValue::Float(f64::from(*v)))
+                }
+                OscArg::Str(v) => ('s', IrValue::from(v.clone())),
+                OscArg::Bool(v) => ('b', IrValue::Bool(*v)),
+            };
+            tags.push(tag);
+            args.push(value);
+        }
+        result.add_message(IrValue::Array(vec![
+            IrValue::from(message.address.clone()),
+            IrValue::from(tags),
+            IrValue::Array(args),
+        ]));
+    }
+    Ok(IrValue::Bundle(result))
+}
+
+/// Restores exact Kitu widths and message order. Nested or scheduled bundles and
+/// unsupported argument types are errors; they are never silently flattened.
+pub fn bundle_from_ir(value: &IrValue) -> Result<OscBundle> {
+    let IrValue::Bundle(bundle) = value else {
+        bail!("expected OSC bundle")
+    };
+    ensure!(
+        bundle.is_immediate(),
+        "scheduled bundle cannot be a Runtime input"
+    );
+    let mut result = OscBundle::new();
+    for element in &bundle.elements {
+        let IrBundleElement::Message(IrValue::Array(fields)) = element else {
+            bail!("expected flat OSC message")
+        };
+        let [IrValue::String(address), IrValue::String(tags), IrValue::Array(args)] =
+            fields.as_slice()
+        else {
+            bail!("invalid typed OSC message")
+        };
+        ensure!(tags.len() == args.len(), "OSC type/argument count mismatch");
+        let mut message = OscMessage::new(address.to_string());
+        for (tag, value) in tags.bytes().zip(args) {
+            message.args.push(match (tag, value) {
+                (b'i', IrValue::Integer(v)) => {
+                    OscArg::Int(i32::try_from(*v).context("i32 overflow")?)
+                }
+                (b'h', IrValue::Integer(v)) => OscArg::Int64(*v),
+                (b'f', IrValue::Float(v)) => {
+                    ensure!(
+                        v.is_finite() && f64::from(*v as f32).to_bits() == v.to_bits(),
+                        "OSC float is not lossless f32"
+                    );
+                    OscArg::Float(*v as f32)
+                }
+                (b's', IrValue::String(v)) => OscArg::Str(v.to_string()),
+                (b'b', IrValue::Bool(v)) => OscArg::Bool(*v),
+                _ => bail!("OSC type/value mismatch"),
+            });
+        }
+        result.push(message);
+    }
+    Ok(result)
+}
+
+/// Canonical MessagePack bytes for hashing ordered logical output bundles.
+pub fn bundle_bytes(bundle: &OscBundle) -> Result<Vec<u8>> {
+    let event = tsq1_osc::event_from_ir(TimeDomain::Musical, 0, &bundle_to_ir(bundle)?)?;
+    let EventKind::Osc(osc) = event.kind else {
+        unreachable!()
+    };
+    Ok(osc.data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn binary_roundtrip_preserves_width_order_bundles_and_large_ticks() {
+        let bundle = OscBundle {
+            messages: vec![
+                OscMessage {
+                    address: "/input/test".into(),
+                    args: vec![
+                        OscArg::Int(7),
+                        OscArg::Int64(7),
+                        OscArg::Int64(i64::MAX),
+                        OscArg::Int64(i64::MIN),
+                        OscArg::Float(-0.0),
+                        OscArg::Float(0.1),
+                        OscArg::Str("日本語\n\0".into()),
+                        OscArg::Bool(false),
+                        OscArg::Bool(true),
+                    ],
+                },
+                OscMessage::new("/second"),
+            ],
+        };
+        let tick = 9_007_199_254_740_993;
+        let doc = Recording {
+            manifest: serde_json::json!({"contract":1}),
+            entries: vec![
+                TimedBundle {
+                    tick,
+                    order: 0,
+                    metadata: serde_json::json!({"id":u64::MAX}),
+                    bundle: bundle.clone(),
+                },
+                TimedBundle {
+                    tick,
+                    order: 1,
+                    metadata: Value::Null,
+                    bundle: OscBundle::new(),
+                },
+            ],
+        };
+        let bytes = doc.encode().unwrap();
+        assert_eq!(&bytes[..4], b"TSQ1");
+        let restored = Recording::decode(&bytes).unwrap();
+        assert_eq!(restored, doc);
+        assert_eq!(
+            bundle_bytes(&restored.entries[0].bundle).unwrap(),
+            bundle_bytes(&bundle).unwrap()
+        );
+        let OscArg::Float(zero) = restored.entries[0].bundle.messages[0].args[4] else {
+            panic!()
+        };
+        assert_eq!(zero.to_bits(), (-0.0f32).to_bits());
+    }
+    #[test]
+    fn rejects_reordered_inputs_lossy_types_and_unsupported_bundles() {
+        let mut doc = Recording {
+            manifest: Value::Null,
+            entries: vec![TimedBundle {
+                tick: 3,
+                order: 1,
+                metadata: Value::Null,
+                bundle: OscBundle::new(),
+            }],
+        };
+        assert!(doc.encode().is_err());
+        doc.entries[0].order = 0;
+        let mut sequence = Sequence::decode(&doc.encode().unwrap()).unwrap();
+        sequence.tracks[0].events[0].delta = 4;
+        assert!(Recording::decode(&sequence.encode().unwrap()).is_err());
+        let mut bundle = IrBundle::immediate();
+        bundle.add_bundle(IrBundle::immediate());
+        assert!(bundle_from_ir(&IrValue::Bundle(bundle)).is_err());
+        assert!(Recording::decode(b"emit:fake").is_err());
+        let bundle = OscBundle {
+            messages: vec![OscMessage {
+                address: "/bad".into(),
+                args: vec![OscArg::Float(f32::NAN)],
+            }],
+        };
+        assert!(bundle_to_ir(&bundle).is_err());
+    }
+}

--- a/crates/kitu-tsq1/src/recording.rs
+++ b/crates/kitu-tsq1/src/recording.rs
@@ -54,6 +54,35 @@ struct Envelope {
     metadata: Value,
 }
 
+impl TimedBundle {
+    /// Validates OSC encoding and returns a conservative wire-size bound for this
+    /// envelope/event pair. The bound includes maximum-width TSQ1 framing, so it
+    /// remains valid for any preceding tick without serializing the whole track.
+    ///
+    /// # Examples
+    /// ```
+    /// use kitu_tsq1::recording::TimedBundle;
+    /// let input = TimedBundle { tick: 0, order: 0, metadata: serde_json::Value::Null,
+    ///     bundle: kitu_osc_ir::OscBundle::new() };
+    /// assert!(input.encoded_size_bound().unwrap() > 0);
+    /// ```
+    pub fn encoded_size_bound(&self) -> Result<usize> {
+        let envelope = serde_json::to_vec(&Envelope {
+            tick: self.tick,
+            order: self.order,
+            metadata: self.metadata.clone(),
+        })?;
+        let payload = bundle_bytes(&self.bundle)?;
+        // Two event deltas and lengths are at most ten-byte VLQs each; the
+        // remaining domain/kind/vendor/OSC-format discriminants fit in 24 bytes.
+        envelope
+            .len()
+            .checked_add(payload.len())
+            .and_then(|size| size.checked_add(64))
+            .context("encoded input size overflow")
+    }
+}
+
 impl Recording {
     /// Encodes using the pinned TSQ1 public API, validating order before writing.
     ///
@@ -319,6 +348,19 @@ mod tests {
             ],
         };
         let bytes = doc.encode().unwrap();
+        let empty_size = Recording {
+            manifest: doc.manifest.clone(),
+            entries: vec![],
+        }
+        .encode()
+        .unwrap()
+        .len();
+        let bound: usize = doc
+            .entries
+            .iter()
+            .map(|entry| entry.encoded_size_bound().unwrap())
+            .sum();
+        assert!(bytes.len() <= empty_size + bound);
         assert_eq!(&bytes[..4], b"TSQ1");
         let restored = Recording::decode(&bytes).unwrap();
         assert_eq!(restored, doc);

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -68,7 +68,10 @@ and shows active/pending hashes. Runs retain and save their evaluated configurat
 invalid edits preserve the last valid version. See the
 [authoring workflow](../apps/demo-game/README.md#tanu-parameters).
 
-TSQ1 recording/inspection, live command tooling and the full-game FFI/native player
+Real TSQ1 recording and deterministic re-execution now preserve exact input ticks,
+identities and frozen content through the normal Runtime queue (stage 7; see
+[the replay contract](specs/arena-replay.md)). Admin playback controls, live command
+tooling and the full-game FFI/native player
 path remain subsequent stages, not implied by the movement-only FFI or the other
 placeholder data adapters described below.
 

--- a/doc/specs/arena-replay.md
+++ b/doc/specs/arena-replay.md
@@ -57,7 +57,8 @@ C# reference comparison continues to allow absolute float error `1e-4` while
 requiring exact discrete state, hits/deaths and event ticks/order.
 
 The first recorder is bounded to 216,000 management ticks (one hour), 1,000,000
-input bundles and 64 MiB encoded files. Reaching a recorder bound reports an
+input bundles and 64 MiB encoded files. Capture validates every OSC bundle and maintains a checked, conservative cumulative
+encoded-size bound before appending a tick. Reaching a recorder bound reports an
 incomplete-recording diagnostic without stopping live gameplay. Start a new host
 session for a fresh recording. This is an explicit initial implementation limit,
 not a claim of arbitrary-duration streaming or crash recovery.

--- a/doc/specs/arena-replay.md
+++ b/doc/specs/arena-replay.md
@@ -1,0 +1,108 @@
+# Arena TSQ1 recording contract
+
+Stage 7 of [the roadmap](https://github.com/Nagitch/kitu-logic-processor/issues/129)
+uses the public `tsq1` and `tsq1-osc` APIs at workspace revision
+`05707147e83a4fba591a3933d49f056bb6d3540b`. No TSQ1 format fork is involved.
+
+## File and exact input ordering
+
+The binary `.tsq` starts with `TSQ1`. A single track stores pairs:
+
+1. Custom event type `0x4b`: JSON `{tick, order, metadata}`. Arena metadata contains
+   the Runtime queue `sequence` and optional `{source, messageId, schemaVersion}`.
+2. OSC MessagePack event: one immediate OSC-IR bundle. Every contained message is
+   `[address, typeTags, arguments]`; tags `i`, `h`, `f`, `s`, `b` preserve i32, i64,
+   f32, string and boolean identity. Argument/message ordering and empty bundles
+   survive the public codec round trip. Unsupported/nested/scheduled bundles and
+   non-finite or lossy f32 values are rejected, never flattened or coerced.
+
+Exact `tick` and contiguous per-tick `order` determine application scheduling.
+The 60 PPQ / 1,000,000 microseconds per quarter musical axis is a display mapping;
+its deltas must agree with explicit ticks. No elapsed-time conversion or rounding
+is used to reconstruct input ticks. Retransmissions remain in the input stream so
+normal Runtime identity handling reproduces the original duplicate receipts.
+
+The `KITU` extension chunk contains envelope format 1 and the Arena manifest.
+Unknown tracks/chunks/axes are rejected by this application profile even though
+TSQ1 itself supports them. The legacy `emit:`/`wait:` text helper remains available
+for compatibility, but it is not a TSQ1 document and Arena does not use it.
+
+## Session and version model
+
+A recording starts at Runtime creation, before tick 0. It includes menu, pause,
+empty-input and management ticks, all successful starts, next-run configuration
+staging and retries. Starting recording halfway through a session is rejected;
+there is no incomplete snapshot masquerading as an initial state.
+
+The manifest stores:
+
+- Arena recording/OSC contract versions, application ID and 60 Hz rate.
+- Package version, execution hash and compilation target. The hash covers Arena
+  rules, Runtime/ECS/core/OSC/transport sources, reference initial defaults, the
+  locked dependency graph, compiler version and compilation flags. Unsupported
+  builds fail compatibility checks. Keeping an old runtime binary is required
+  when execution semantics change; a package version alone is insufficient.
+- Full evaluated initial Tanu configuration, its semantic/source hashes and the
+  evaluator revision. Every later staged configuration is retained in input data.
+- Initial projection hash, completed tick count, a state and ordered-output hash
+  for every tick, and each full run-start manifest with frozen evaluated values.
+
+Replay builds the ordinary application with the detached initial content, feeds
+its normal validated input queue, calls the same `tick_once`, and compares every
+state/output before continuing. It never consults the current `.tmd` and never
+sets HP, actors or clocks from recorded output. Altering the authoring file does
+not affect old recordings. Divergence includes its exact tick in the diagnostic.
+Hashes demand exact reproducibility within a compatible build; the independent
+C# reference comparison continues to allow absolute float error `1e-4` while
+requiring exact discrete state, hits/deaths and event ticks/order.
+
+The first recorder is bounded to 216,000 management ticks (one hour), 1,000,000
+input bundles and 64 MiB encoded files. Reaching a recorder bound reports an
+incomplete-recording diagnostic without stopping live gameplay. Start a new host
+session for a fresh recording. This is an explicit initial implementation limit,
+not a claim of arbitrary-duration streaming or crash recovery.
+
+## Host integration
+
+All live ticks are captured before committed inputs are drained. Snapshot cloning
+holds the state lock briefly; TSQ1 encoding, file I/O and replay verification run
+outside the simulation lock. Recording files use SHA-256 content IDs and atomic
+local rename. `KITU_ARENA_RECORDING_DIRECTORY` overrides the default
+`apps/demo-game/.arena/recordings` directory.
+
+| Endpoint | Result |
+| --- | --- |
+| `GET /arena/recording` | Recorded/live ticks, session ID, limits and diagnostics |
+| `GET /arena/recording/export` | Download a complete detached `.tsq` |
+| `POST /arena/recording/save` | Persist the current recording; return ID/path/size |
+| `GET /arena/recordings` | List saved content IDs and sizes |
+| `POST /arena/recordings/import` | Validate and save a binary TSQ1 request body |
+| `GET /arena/recordings/{id}` | Download the saved binary |
+| `POST /arena/recordings/{id}/verify` | Re-execute in a separate Runtime and return verified state |
+
+File identifiers are restricted to SHA-256 hex strings. Import validates format,
+versions, initial content and bounds; verify additionally executes all ticks and
+checks proofs. Invalid files cannot mutate the live run. CPU verification is
+serialized. These are local development endpoints under the existing host's
+loopback default; production remote operation is outside the approved scope.
+
+Admin playback, stop, step, seek and Unity replay projection are stage 8. Live
+CLI commands are stage 9. Stage 7 supplies the real recorder, persistence and
+re-execution core they will use.
+
+## Reproduce the stock artifact
+
+Inside the Kitu Dev Container:
+
+```sh
+KITU_REPLAY_EVIDENCE_DIR=/workspaces/kitu-logic-processor/.tmp/arena-tsq1 \
+  cargo test -p kitu-demo-game --test arena_replay \
+  real_tsq1_replays_every_stock_tick_state_and_event_through_eleven_death_retry -- --exact
+```
+
+The generated stock `.tsq` and verification JSON cover 5,528 ticks, 550 C#
+checkpoints and 53 command outcomes, then compare every Rust state and ordered
+output on replay. [Stage 7 evidence](../verification/arena-tsq1/results.json)
+also records real macOS Unity input capture, HTTP save/download/import/verification,
+and bounds. Generated recordings remain local; the test regenerates them for the
+current execution version.

--- a/doc/verification/arena-tsq1/live-verification.json
+++ b/doc/verification/arena-tsq1/live-verification.json
@@ -1,0 +1,125 @@
+{
+  "ticks": 10122,
+  "inputs": 30144,
+  "runs": 5,
+  "state": {
+    "aimDirection": {
+      "x": -0.4997235,
+      "y": 0.866185
+    },
+    "bossesDefeated": 0,
+    "chestAvailable": false,
+    "effects": [],
+    "elapsed": 6.7166996,
+    "enemies": [],
+    "enemiesDefeated": 3,
+    "floor": 1,
+    "floorsCleared": 1,
+    "grenades": [],
+    "inventory": {
+      "attackMultiplier": 1.0,
+      "attackUpgrades": 0,
+      "backpack": [
+        {
+          "damage": 20,
+          "id": 1,
+          "interval": 0.5,
+          "kind": 0,
+          "name": "Blade",
+          "shield": 0,
+          "shieldFraction": 0.0
+        },
+        {
+          "damage": 0,
+          "id": 0,
+          "interval": 0.0,
+          "kind": 0,
+          "name": "",
+          "shield": 0,
+          "shieldFraction": 0.0
+        },
+        {
+          "damage": 0,
+          "id": 0,
+          "interval": 0.0,
+          "kind": 0,
+          "name": "",
+          "shield": 0,
+          "shieldFraction": 0.0
+        }
+      ],
+      "chest": [],
+      "damagedThisUpdate": false,
+      "equipment": [
+        {
+          "damage": 20,
+          "id": 5,
+          "interval": 0.45,
+          "kind": 1,
+          "name": "Power Shooter",
+          "shield": 0,
+          "shieldFraction": 0.0
+        },
+        {
+          "damage": 12,
+          "id": 4,
+          "interval": 0.25,
+          "kind": 1,
+          "name": "Quick Shooter",
+          "shield": 0,
+          "shieldFraction": 0.0
+        },
+        {
+          "damage": 0,
+          "id": 10,
+          "interval": 0.0,
+          "kind": 5,
+          "name": "Shield",
+          "shield": 110,
+          "shieldFraction": 0.0
+        },
+        {
+          "damage": 0,
+          "id": 0,
+          "interval": 0.0,
+          "kind": 0,
+          "name": "",
+          "shield": 0,
+          "shieldFraction": 0.0
+        }
+      ],
+      "health": 110,
+      "maxHealth": 110,
+      "nextItemId": 12,
+      "shieldDelayRemaining": 0.0
+    },
+    "nextEntityId": 34,
+    "overlay": "pause",
+    "phase": 4,
+    "playerPosition": {
+      "x": 0.0,
+      "y": -7.0
+    },
+    "portalArmed": true,
+    "portalAvailable": true,
+    "projectiles": [],
+    "result": {
+      "attackMultiplier": 0.0,
+      "bossesDefeated": 0,
+      "elapsed": 0.0,
+      "enemiesDefeated": 0,
+      "equipmentNames": [],
+      "floor": 0,
+      "floorsCleared": 0,
+      "maxHealth": 0,
+      "present": false
+    },
+    "simulationSteps": 5914,
+    "tick": 10121,
+    "transitionRemaining": -3.7252903e-09,
+    "weaponCooldowns": [
+      0.11666651,
+      0.050000012
+    ]
+  }
+}

--- a/doc/verification/arena-tsq1/results.json
+++ b/doc/verification/arena-tsq1/results.json
@@ -5,10 +5,10 @@
   "tsq1Revision": "05707147e83a4fba591a3933d49f056bb6d3540b",
   "sourceSha256": {
     "apps/demo-game/build.rs": "25ad0ab65ae4ccff6abc6eb0ab884c615a940b77f88c555f02c0fc73612788e6",
-    "apps/demo-game/src/replay.rs": "a94c92dfead1724ac71a702e8487a9f525b8a626c9a52583687e0e77adce685c",
-    "apps/demo-game/src/bin/admin_host/recording.rs": "fc6065a6d0791759be138015bd6be98b294f692abed9c93a5ce100bbd9d79ea6",
+    "apps/demo-game/src/replay.rs": "daef8a968a314f0a6b1547885a2c2e7cd5faff215a842904961b0b67399887fd",
+    "apps/demo-game/src/bin/admin_host/recording.rs": "e2aad1b3308ae7d7888dc2af3620310b8caefc71cd9dcdcaeb044c8fc1b3aeae",
     "apps/demo-game/src/bin/admin_host.rs": "a70158138e901c9aca6ad4334013e277ec99b3990a577bb60217aae06a6c7b63",
-    "crates/kitu-tsq1/src/recording.rs": "5b3a57f9e91b3ceeec9d300b0ef0506150a295aa6797b1b2235a2943a2bfc0f4",
+    "crates/kitu-tsq1/src/recording.rs": "df18f34fad057cea3db0826337f0cd34c6f8edd1841c45e80c4509502734782b",
     "crates/kitu-runtime/src/lib.rs": "b91c815eacd65cc85fce65062bb35886941315a312ced13aa32506b11b92e01c",
     "crates/kitu-runtime/src/application.rs": "bb68dc96960c9cac272a61950c16e8cfb449f1856d63385acf5f1cda960cf382",
     "Cargo.lock": "195e87ac7008ecabeee51ed9617580dbf471a644362cd0da2a8011944d60b00f"
@@ -33,7 +33,8 @@
       "skipped": "0",
       "duration": "101.4366727"
     },
-    "frozenReference": "Original rule/fixture hashes unchanged; 550 stock checkpoints and 53 outcomes through 11F, natural death and retry; zero mismatches"
+    "frozenReference": "Original rule/fixture hashes unchanged; 550 stock checkpoints and 53 outcomes through 11F, natural death and retry; zero mismatches",
+    "reviewFix": "Each captured bundle now validates OSC encoding; checked cumulative conservative wire-size bounds reject overflow before appending. Skipped queue sequences are rejected. Added 2 recorder tests, 1 host status/continued-ticking test and 1 size-bound doctest; affected suites, workspace Clippy and rustdoc passed. The existing real Unity file again verified all 10122 ticks, 30144 inputs and 5 runs through the updated HTTP host."
   },
   "recordings": {
     "stock": {

--- a/doc/verification/arena-tsq1/results.json
+++ b/doc/verification/arena-tsq1/results.json
@@ -1,0 +1,76 @@
+{
+  "stage": 7,
+  "issue": 142,
+  "baseRevision": "96bd46c7ba9c65cae596ee6d633068031afa0454",
+  "tsq1Revision": "05707147e83a4fba591a3933d49f056bb6d3540b",
+  "sourceSha256": {
+    "apps/demo-game/build.rs": "25ad0ab65ae4ccff6abc6eb0ab884c615a940b77f88c555f02c0fc73612788e6",
+    "apps/demo-game/src/replay.rs": "a94c92dfead1724ac71a702e8487a9f525b8a626c9a52583687e0e77adce685c",
+    "apps/demo-game/src/bin/admin_host/recording.rs": "fc6065a6d0791759be138015bd6be98b294f692abed9c93a5ce100bbd9d79ea6",
+    "apps/demo-game/src/bin/admin_host.rs": "a70158138e901c9aca6ad4334013e277ec99b3990a577bb60217aae06a6c7b63",
+    "crates/kitu-tsq1/src/recording.rs": "5b3a57f9e91b3ceeec9d300b0ef0506150a295aa6797b1b2235a2943a2bfc0f4",
+    "crates/kitu-runtime/src/lib.rs": "b91c815eacd65cc85fce65062bb35886941315a312ced13aa32506b11b92e01c",
+    "crates/kitu-runtime/src/application.rs": "bb68dc96960c9cac272a61950c16e8cfb449f1856d63385acf5f1cda960cf382",
+    "Cargo.lock": "195e87ac7008ecabeee51ed9617580dbf471a644362cd0da2a8011944d60b00f"
+  },
+  "validation": {
+    "rustTestsAndDoctests": 165,
+    "devContainer": "Rust 1.96.0; workspace all-feature tests, fmt, all-target/all-feature Clippy, rustdoc warnings denied, changed internal package lists passed",
+    "tsq1PublicApi": "Pinned tsq1-osc tests: 2 passed in Dev Container; no TSQ1 source changes",
+    "unityEditMode": {
+      "result": "Passed",
+      "total": "47",
+      "passed": "47",
+      "failed": "0",
+      "skipped": "0",
+      "duration": "0.4062743"
+    },
+    "unityPlayMode": {
+      "result": "Passed",
+      "total": "15",
+      "passed": "15",
+      "failed": "0",
+      "skipped": "0",
+      "duration": "101.4366727"
+    },
+    "frozenReference": "Original rule/fixture hashes unchanged; 550 stock checkpoints and 53 outcomes through 11F, natural death and retry; zero mismatches"
+  },
+  "recordings": {
+    "stock": {
+      "bytes": 2666070,
+      "id": "da420d2d7df0dc0ce3f4e4528c87071b0a2655d79dffbe5df525f0ff77d56434",
+      "path": "apps/demo-game/.arena/recordings/da420d2d7df0dc0ce3f4e4528c87071b0a2655d79dffbe5df525f0ff77d56434.tsq",
+      "ticks": 5528,
+      "inputs": 5581,
+      "runs": 2,
+      "httpImportDownload": "byte-identical round trip",
+      "httpVerify": "all state/output proofs and run manifests matched"
+    },
+    "unityLive": {
+      "bytes": 11921082,
+      "id": "4a078634957826d914b6858aca6699054db27461e2bab719f00563a9d120d1f3",
+      "path": "apps/demo-game/.arena/recordings/4a078634957826d914b6858aca6699054db27461e2bab719f00563a9d120d1f3.tsq",
+      "ticks": 10122,
+      "inputs": 30144,
+      "runs": 5,
+      "httpVerify": "all state/output proofs and run manifests matched; 11.388 seconds, separate Runtime"
+    }
+  },
+  "regressions": [
+    "i32/i64 widths, finite f32 including negative zero, boolean/string values, argument/message order, empty bundles and ticks above JavaScript safe integer range round trip through public TSQ1 OSC codecs.",
+    "Reordered inputs, invalid data/version/initial conditions, corrupted proofs and altered run manifests are rejected with diagnostics.",
+    "Duplicate IDs, paused management ticks and Tanu changes to 37 then 99 reproduce saved run configurations through the ordinary input queue.",
+    "The first uncapped batchmode stock driver exceeded the 64 MiB recording limit. The production device input path already limits frames to 60 Hz. The test driver now waits for each projected Runtime tick; full PlayMode and real recording save/replay pass. No reference or game-rule changes were made."
+  ],
+  "limits": [
+    "The initial in-memory recorder is bounded to 216000 ticks, 1000000 inputs and 64 MiB encoded data. Bounds are independent; this is not an unlimited streaming recorder.",
+    "Execution compatibility is conservative: compiler/flags, rule/runtime source, lockfile and target changes require matching old builds. Data edits replay with their detached saved values.",
+    "Admin playback controls/Unity replay projection are stage 8; live CLI is stage 9. Binary artifacts remain in the ignored local recording directory and are reproducible using the documented test command.",
+    "Parent workspace publication awaits restored GitHub integration write access; Kitu stage PRs remain writable."
+  ],
+  "execution": {
+    "package": "0.1.0",
+    "sourceHash": "e410f19439c2eb7d683a7eb53bafb4257ca19f1ea5ef486050b66c03ac6ea090",
+    "target": "aarch64-unknown-linux-gnu"
+  }
+}

--- a/doc/verification/arena-tsq1/stock-verification.json
+++ b/doc/verification/arena-tsq1/stock-verification.json
@@ -1,0 +1,225 @@
+{
+  "ticks": 5528,
+  "inputs": 5581,
+  "runs": 2,
+  "state": {
+    "aimDirection": {
+      "x": 0.0,
+      "y": 1.0
+    },
+    "bossesDefeated": 0,
+    "chestAvailable": true,
+    "effects": [],
+    "elapsed": 0.016666668,
+    "enemies": [],
+    "enemiesDefeated": 0,
+    "floor": 0,
+    "floorsCleared": 0,
+    "grenades": [],
+    "inventory": {
+      "attackMultiplier": 1.0,
+      "attackUpgrades": 0,
+      "backpack": [
+        {
+          "damage": 0,
+          "id": 0,
+          "interval": 0.0,
+          "kind": 0,
+          "name": "",
+          "shield": 0,
+          "shieldFraction": 0.0
+        },
+        {
+          "damage": 0,
+          "id": 0,
+          "interval": 0.0,
+          "kind": 0,
+          "name": "",
+          "shield": 0,
+          "shieldFraction": 0.0
+        },
+        {
+          "damage": 0,
+          "id": 0,
+          "interval": 0.0,
+          "kind": 0,
+          "name": "",
+          "shield": 0,
+          "shieldFraction": 0.0
+        }
+      ],
+      "chest": [
+        {
+          "damage": 20,
+          "id": 2,
+          "interval": 0.5,
+          "kind": 0,
+          "name": "Quick Blade",
+          "shield": 0,
+          "shieldFraction": 0.0
+        },
+        {
+          "damage": 30,
+          "id": 3,
+          "interval": 0.8,
+          "kind": 0,
+          "name": "Power Blade",
+          "shield": 0,
+          "shieldFraction": 0.0
+        },
+        {
+          "damage": 12,
+          "id": 4,
+          "interval": 0.25,
+          "kind": 1,
+          "name": "Quick Shooter",
+          "shield": 0,
+          "shieldFraction": 0.0
+        },
+        {
+          "damage": 20,
+          "id": 5,
+          "interval": 0.45,
+          "kind": 1,
+          "name": "Power Shooter",
+          "shield": 0,
+          "shieldFraction": 0.0
+        },
+        {
+          "damage": 50,
+          "id": 6,
+          "interval": 1.0,
+          "kind": 2,
+          "name": "Quick Heavy Shooter",
+          "shield": 0,
+          "shieldFraction": 0.0
+        },
+        {
+          "damage": 75,
+          "id": 7,
+          "interval": 1.5,
+          "kind": 2,
+          "name": "Power Heavy Shooter",
+          "shield": 0,
+          "shieldFraction": 0.0
+        },
+        {
+          "damage": 0,
+          "id": 8,
+          "interval": 0.0,
+          "kind": 3,
+          "name": "Medkit",
+          "shield": 0,
+          "shieldFraction": 0.0
+        },
+        {
+          "damage": 100,
+          "id": 9,
+          "interval": 0.0,
+          "kind": 4,
+          "name": "Grenade",
+          "shield": 0,
+          "shieldFraction": 0.0
+        },
+        {
+          "damage": 0,
+          "id": 10,
+          "interval": 0.0,
+          "kind": 5,
+          "name": "Shield",
+          "shield": 100,
+          "shieldFraction": 0.0
+        },
+        {
+          "damage": 0,
+          "id": 11,
+          "interval": 0.0,
+          "kind": 6,
+          "name": "Health Upgrade (+10 HP)",
+          "shield": 0,
+          "shieldFraction": 0.0
+        },
+        {
+          "damage": 0,
+          "id": 12,
+          "interval": 0.0,
+          "kind": 7,
+          "name": "Attack Upgrade (+5%)",
+          "shield": 0,
+          "shieldFraction": 0.0
+        }
+      ],
+      "damagedThisUpdate": false,
+      "equipment": [
+        {
+          "damage": 20,
+          "id": 1,
+          "interval": 0.5,
+          "kind": 0,
+          "name": "Blade",
+          "shield": 0,
+          "shieldFraction": 0.0
+        },
+        {
+          "damage": 0,
+          "id": 0,
+          "interval": 0.0,
+          "kind": 0,
+          "name": "",
+          "shield": 0,
+          "shieldFraction": 0.0
+        },
+        {
+          "damage": 0,
+          "id": 0,
+          "interval": 0.0,
+          "kind": 0,
+          "name": "",
+          "shield": 0,
+          "shieldFraction": 0.0
+        },
+        {
+          "damage": 0,
+          "id": 0,
+          "interval": 0.0,
+          "kind": 0,
+          "name": "",
+          "shield": 0,
+          "shieldFraction": 0.0
+        }
+      ],
+      "health": 100,
+      "maxHealth": 100,
+      "nextItemId": 12,
+      "shieldDelayRemaining": 0.0
+    },
+    "nextEntityId": 1,
+    "overlay": "none",
+    "phase": 1,
+    "playerPosition": {
+      "x": 0.0,
+      "y": -7.0
+    },
+    "portalArmed": true,
+    "portalAvailable": true,
+    "projectiles": [],
+    "result": {
+      "attackMultiplier": 0.0,
+      "bossesDefeated": 0,
+      "elapsed": 0.0,
+      "enemiesDefeated": 0,
+      "equipmentNames": [],
+      "floor": 0,
+      "floorsCleared": 0,
+      "maxHealth": 0,
+      "present": false
+    },
+    "simulationSteps": 5480,
+    "tick": 5527,
+    "transitionRemaining": -3.7252903e-09,
+    "weaponCooldowns": [
+      0.0,
+      0.0
+    ]
+  }
+}

--- a/doc/verification/arena-tsq1/unity-editmode.xml
+++ b/doc/verification/arena-tsq1/unity-editmode.xml
@@ -1,0 +1,325 @@
+<?xml version="1.0" encoding="utf-8"?>
+<test-run id="2" testcasecount="47" result="Passed" total="47" passed="47" failed="0" inconclusive="0" skipped="0" asserts="0" engine-version="3.5.0.0" clr-version="4.0.30319.42000" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:40Z" duration="0.4062743">
+  <test-suite type="TestSuite" id="1000" name="kitu-unity-demo-game" fullname="kitu-unity-demo-game" runstate="Runnable" testcasecount="47" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:40Z" duration="0.406274" total="47" passed="47" failed="0" inconclusive="0" skipped="0" asserts="0">
+    <properties>
+      <property name="platform" value="EditMode" />
+    </properties>
+    <test-suite type="Assembly" id="1064" name="UnityOnlyArena.Tests.dll" fullname="/Users/mujina/.codex/worktrees/e19c/kitu-workspace/kitu-logic-processor/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Library/ScriptAssemblies/UnityOnlyArena.Tests.dll" runstate="Runnable" testcasecount="47" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:40Z" duration="0.401474" total="47" passed="47" failed="0" inconclusive="0" skipped="0" asserts="0">
+      <properties>
+        <property name="_PID" value="88665" />
+        <property name="_APPDOMAIN" value="Unity Child Domain" />
+        <property name="platform" value="EditMode" />
+        <property name="EditorOnly" value="True" />
+      </properties>
+      <test-suite type="TestFixture" id="1011" name="ArenaInventoryTests" fullname="ArenaInventoryTests" classname="ArenaInventoryTests" runstate="Runnable" testcasecount="15" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.031029" total="15" passed="15" failed="0" inconclusive="0" skipped="0" asserts="0">
+        <properties />
+        <test-case id="1013" name="ChestHasSixDistinctWeaponCandidatesAndFiveItemUpgradeCandidates" fullname="ArenaInventoryTests.ChestHasSixDistinctWeaponCandidatesAndFiveItemUpgradeCandidates" methodname="ChestHasSixDistinctWeaponCandidatesAndFiveItemUpgradeCandidates" classname="ArenaInventoryTests" runstate="Runnable" seed="11475273" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.010640" asserts="0">
+          <properties>
+            <property name="retryIteration" value="0" />
+            <property name="repeatIteration" value="0" />
+          </properties>
+        </test-case>
+        <test-case id="1021" name="DamageUpdateCannotRegenerateAndRecoveryStartsAfterThreeSeconds" fullname="ArenaInventoryTests.DamageUpdateCannotRegenerateAndRecoveryStartsAfterThreeSeconds" methodname="DamageUpdateCannotRegenerateAndRecoveryStartsAfterThreeSeconds" classname="ArenaInventoryTests" runstate="Runnable" seed="2112446060" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.001285" asserts="0">
+          <properties>
+            <property name="retryIteration" value="0" />
+            <property name="repeatIteration" value="0" />
+          </properties>
+        </test-case>
+        <test-case id="1024" name="DamageWithoutAShieldStillStartsSharedDelayAndChangingEquipmentKeepsIt" fullname="ArenaInventoryTests.DamageWithoutAShieldStillStartsSharedDelayAndChangingEquipmentKeepsIt" methodname="DamageWithoutAShieldStillStartsSharedDelayAndChangingEquipmentKeepsIt" classname="ArenaInventoryTests" runstate="Runnable" seed="224046719" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.000716" asserts="0">
+          <properties>
+            <property name="retryIteration" value="0" />
+            <property name="repeatIteration" value="0" />
+          </properties>
+        </test-case>
+        <test-case id="1026" name="DeathPreventsRevivalConsumptionAndFurtherInventoryChanges" fullname="ArenaInventoryTests.DeathPreventsRevivalConsumptionAndFurtherInventoryChanges" methodname="DeathPreventsRevivalConsumptionAndFurtherInventoryChanges" classname="ArenaInventoryTests" runstate="Runnable" seed="2009625340" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.001390" asserts="0">
+          <properties>
+            <property name="retryIteration" value="0" />
+            <property name="repeatIteration" value="0" />
+          </properties>
+        </test-case>
+        <test-case id="1022" name="FractionalRecoveryAccumulatesAcrossSmallUpdatesAndUsesNewCapacity" fullname="ArenaInventoryTests.FractionalRecoveryAccumulatesAcrossSmallUpdatesAndUsesNewCapacity" methodname="FractionalRecoveryAccumulatesAcrossSmallUpdatesAndUsesNewCapacity" classname="ArenaInventoryTests" runstate="Runnable" seed="2121985023" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.000330" asserts="0">
+          <properties>
+            <property name="retryIteration" value="0" />
+            <property name="repeatIteration" value="0" />
+          </properties>
+        </test-case>
+        <test-case id="1017" name="FullHealthMedkitIsKeptAndUsedMedkitOnlyRefillsHp" fullname="ArenaInventoryTests.FullHealthMedkitIsKeptAndUsedMedkitOnlyRefillsHp" methodname="FullHealthMedkitIsKeptAndUsedMedkitOnlyRefillsHp" classname="ArenaInventoryTests" runstate="Runnable" seed="1714210330" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.000407" asserts="0">
+          <properties>
+            <property name="retryIteration" value="0" />
+            <property name="repeatIteration" value="0" />
+          </properties>
+        </test-case>
+        <test-case id="1019" name="GrenadeIsConsumedImmediatelyAndBackpackDoesNotAutoRefillEquipment" fullname="ArenaInventoryTests.GrenadeIsConsumedImmediatelyAndBackpackDoesNotAutoRefillEquipment" methodname="GrenadeIsConsumedImmediatelyAndBackpackDoesNotAutoRefillEquipment" classname="ArenaInventoryTests" runstate="Runnable" seed="921548480" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.000324" asserts="0">
+          <properties>
+            <property name="retryIteration" value="0" />
+            <property name="repeatIteration" value="0" />
+          </properties>
+        </test-case>
+        <test-case id="1025" name="HealingDoesNotTouchShieldOrDelayAndNonPositiveDamageDoesNothing" fullname="ArenaInventoryTests.HealingDoesNotTouchShieldOrDelayAndNonPositiveDamageDoesNothing" methodname="HealingDoesNotTouchShieldOrDelayAndNonPositiveDamageDoesNothing" classname="ArenaInventoryTests" runstate="Runnable" seed="2031438551" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.000254" asserts="0">
+          <properties>
+            <property name="retryIteration" value="0" />
+            <property name="repeatIteration" value="0" />
+          </properties>
+        </test-case>
+        <test-case id="1015" name="InvalidOperationsAreAtomicAndUnequipNeedsAnEmptyBackpackSlot" fullname="ArenaInventoryTests.InvalidOperationsAreAtomicAndUnequipNeedsAnEmptyBackpackSlot" methodname="InvalidOperationsAreAtomicAndUnequipNeedsAnEmptyBackpackSlot" classname="ArenaInventoryTests" runstate="Runnable" seed="210752257" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.000614" asserts="0">
+          <properties>
+            <property name="retryIteration" value="0" />
+            <property name="repeatIteration" value="0" />
+          </properties>
+        </test-case>
+        <test-case id="1012" name="ResetRemovesAllRunStateAndRestoresOnlyTheStarterBlade" fullname="ArenaInventoryTests.ResetRemovesAllRunStateAndRestoresOnlyTheStarterBlade" methodname="ResetRemovesAllRunStateAndRestoresOnlyTheStarterBlade" classname="ArenaInventoryTests" runstate="Runnable" seed="1440339386" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.001756" asserts="0">
+          <properties>
+            <property name="retryIteration" value="0" />
+            <property name="repeatIteration" value="0" />
+          </properties>
+        </test-case>
+        <test-case id="1023" name="ShieldChargeAndFractionSurviveSwapsButOnlyEquipmentRegenerates" fullname="ArenaInventoryTests.ShieldChargeAndFractionSurviveSwapsButOnlyEquipmentRegenerates" methodname="ShieldChargeAndFractionSurviveSwapsButOnlyEquipmentRegenerates" classname="ArenaInventoryTests" runstate="Runnable" seed="374329072" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.000449" asserts="0">
+          <properties>
+            <property name="retryIteration" value="0" />
+            <property name="repeatIteration" value="0" />
+          </properties>
+        </test-case>
+        <test-case id="1020" name="ShieldsAbsorbInSlotOrderAndRemainEquippedWhenEmpty" fullname="ArenaInventoryTests.ShieldsAbsorbInSlotOrderAndRemainEquippedWhenEmpty" methodname="ShieldsAbsorbInSlotOrderAndRemainEquippedWhenEmpty" classname="ArenaInventoryTests" runstate="Runnable" seed="1526798575" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.000211" asserts="0">
+          <properties>
+            <property name="retryIteration" value="0" />
+            <property name="repeatIteration" value="0" />
+          </properties>
+        </test-case>
+        <test-case id="1014" name="TakingSwappingAndEquippingConserveItemInstancesEvenWhenBackpackIsFull" fullname="ArenaInventoryTests.TakingSwappingAndEquippingConserveItemInstancesEvenWhenBackpackIsFull" methodname="TakingSwappingAndEquippingConserveItemInstancesEvenWhenBackpackIsFull" classname="ArenaInventoryTests" runstate="Runnable" seed="731071236" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.000420" asserts="0">
+          <properties>
+            <property name="retryIteration" value="0" />
+            <property name="repeatIteration" value="0" />
+          </properties>
+        </test-case>
+        <test-case id="1016" name="UpgradesConsumeOnceAndHealthUpgradeDoesNotRefillAnExistingShield" fullname="ArenaInventoryTests.UpgradesConsumeOnceAndHealthUpgradeDoesNotRefillAnExistingShield" methodname="UpgradesConsumeOnceAndHealthUpgradeDoesNotRefillAnExistingShield" classname="ArenaInventoryTests" runstate="Runnable" seed="45430890" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.000286" asserts="0">
+          <properties>
+            <property name="retryIteration" value="0" />
+            <property name="repeatIteration" value="0" />
+          </properties>
+        </test-case>
+        <test-case id="1018" name="UsingMedkitAThenBConsumesOnlyAWhenAHealsToFull" fullname="ArenaInventoryTests.UsingMedkitAThenBConsumesOnlyAWhenAHealsToFull" methodname="UsingMedkitAThenBConsumesOnlyAWhenAHealsToFull" classname="ArenaInventoryTests" runstate="Runnable" seed="1442050980" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.000177" asserts="0">
+          <properties>
+            <property name="retryIteration" value="0" />
+            <property name="repeatIteration" value="0" />
+          </properties>
+        </test-case>
+      </test-suite>
+      <test-suite type="TestSuite" id="1065" name="UnityOnlyArena" fullname="UnityOnlyArena" runstate="Runnable" testcasecount="32" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:40Z" duration="0.368885" total="32" passed="32" failed="0" inconclusive="0" skipped="0" asserts="0">
+        <properties />
+        <test-suite type="TestSuite" id="1066" name="Tests" fullname="UnityOnlyArena.Tests" runstate="Runnable" testcasecount="32" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:40Z" duration="0.362183" total="32" passed="32" failed="0" inconclusive="0" skipped="0" asserts="0">
+          <properties />
+          <test-suite type="TestFixture" id="1027" name="ArenaReferenceTests" fullname="UnityOnlyArena.Tests.ArenaReferenceTests" classname="UnityOnlyArena.Tests.ArenaReferenceTests" runstate="Runnable" testcasecount="8" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.302045" total="8" passed="8" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1028" name="CaptureDetachesEntitiesItemsAndRecordedCommands" fullname="UnityOnlyArena.Tests.ArenaReferenceTests.CaptureDetachesEntitiesItemsAndRecordedCommands" methodname="CaptureDetachesEntitiesItemsAndRecordedCommands" classname="UnityOnlyArena.Tests.ArenaReferenceTests" runstate="Runnable" seed="1775200776" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.006121" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1030" name="DuplicatesKeepTheirOriginalResultAndStaleItemsCannotMove" fullname="UnityOnlyArena.Tests.ArenaReferenceTests.DuplicatesKeepTheirOriginalResultAndStaleItemsCannotMove" methodname="DuplicatesKeepTheirOriginalResultAndStaleItemsCannotMove" classname="UnityOnlyArena.Tests.ArenaReferenceTests" runstate="Runnable" seed="776055214" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.001413" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-suite type="ParameterizedMethod" id="1036" name="FrozenTraceReplaysThroughOriginalRules" fullname="UnityOnlyArena.Tests.ArenaReferenceTests.FrozenTraceReplaysThroughOriginalRules" classname="UnityOnlyArena.Tests.ArenaReferenceTests" runstate="Runnable" testcasecount="2" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.289914" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
+              <properties />
+              <test-case id="1034" name="FrozenTraceReplaysThroughOriginalRules(&quot;preparation&quot;)" fullname="UnityOnlyArena.Tests.ArenaReferenceTests.FrozenTraceReplaysThroughOriginalRules(&quot;preparation&quot;)" methodname="FrozenTraceReplaysThroughOriginalRules" classname="UnityOnlyArena.Tests.ArenaReferenceTests" runstate="Runnable" seed="339327600" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.010196" asserts="0">
+                <properties>
+                  <property name="retryIteration" value="0" />
+                  <property name="repeatIteration" value="0" />
+                </properties>
+              </test-case>
+              <test-case id="1035" name="FrozenTraceReplaysThroughOriginalRules(&quot;stock-eleven-death-retry&quot;)" fullname="UnityOnlyArena.Tests.ArenaReferenceTests.FrozenTraceReplaysThroughOriginalRules(&quot;stock-eleven-death-retry&quot;)" methodname="FrozenTraceReplaysThroughOriginalRules" classname="UnityOnlyArena.Tests.ArenaReferenceTests" runstate="Runnable" seed="1952507824" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.279241" asserts="0">
+                <properties>
+                  <property name="retryIteration" value="0" />
+                  <property name="repeatIteration" value="0" />
+                </properties>
+              </test-case>
+            </test-suite>
+            <test-case id="1033" name="InvalidBatchesAndNonContiguousTicksFailBeforeStateMutation" fullname="UnityOnlyArena.Tests.ArenaReferenceTests.InvalidBatchesAndNonContiguousTicksFailBeforeStateMutation" methodname="InvalidBatchesAndNonContiguousTicksFailBeforeStateMutation" classname="UnityOnlyArena.Tests.ArenaReferenceTests" runstate="Runnable" seed="1537459590" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.000835" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1032" name="InvalidChestDestinationsUseTheStableTargetCodeWithoutMovingItems" fullname="UnityOnlyArena.Tests.ArenaReferenceTests.InvalidChestDestinationsUseTheStableTargetCodeWithoutMovingItems" methodname="InvalidChestDestinationsUseTheStableTargetCodeWithoutMovingItems" classname="UnityOnlyArena.Tests.ArenaReferenceTests" runstate="Runnable" seed="610853211" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.000962" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1029" name="PauseConsumesCommandsWithoutAdvancingAnyGameplayClock" fullname="UnityOnlyArena.Tests.ArenaReferenceTests.PauseConsumesCommandsWithoutAdvancingAnyGameplayClock" methodname="PauseConsumesCommandsWithoutAdvancingAnyGameplayClock" classname="UnityOnlyArena.Tests.ArenaReferenceTests" runstate="Runnable" seed="1894733195" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.000636" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1031" name="SuccessfulUpgradeIsNotConsumedTwiceAfterRetry" fullname="UnityOnlyArena.Tests.ArenaReferenceTests.SuccessfulUpgradeIsNotConsumedTwiceAfterRetry" methodname="SuccessfulUpgradeIsNotConsumedTwiceAfterRetry" classname="UnityOnlyArena.Tests.ArenaReferenceTests" runstate="Runnable" seed="245745576" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:39Z" duration="0.000947" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1037" name="ArenaRunScenarioTests" fullname="UnityOnlyArena.Tests.ArenaRunScenarioTests" classname="UnityOnlyArena.Tests.ArenaRunScenarioTests" runstate="Runnable" testcasecount="1" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:40Z" duration="0.048632" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1038" name="StockChestLoadoutAndContinuousMovementCanClearElevenFloors" fullname="UnityOnlyArena.Tests.ArenaRunScenarioTests.StockChestLoadoutAndContinuousMovementCanClearElevenFloors" methodname="StockChestLoadoutAndContinuousMovementCanClearElevenFloors" classname="UnityOnlyArena.Tests.ArenaRunScenarioTests" runstate="Runnable" seed="1014322478" result="Passed" start-time="2026-09-06 00:12:39Z" end-time="2026-09-06 00:12:40Z" duration="0.047462" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1039" name="ArenaSimulationTests" fullname="UnityOnlyArena.Tests.ArenaSimulationTests" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" testcasecount="23" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.010883" total="23" passed="23" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1052" name="ActualPursuerMovementAndMeleeEventuallyKillAnIdlePlayer" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.ActualPursuerMovementAndMeleeEventuallyKillAnIdlePlayer" methodname="ActualPursuerMovementAndMeleeEventuallyKillAnIdlePlayer" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" seed="783238399" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.000477" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1045" name="BossClearHealsOnceAndKeepsRewardContentsAndShieldCharge" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.BossClearHealsOnceAndKeepsRewardContentsAndShieldCharge" methodname="BossClearHealsOnceAndKeepsRewardContentsAndShieldCharge" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" seed="746948745" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.000599" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1059" name="BossTelegraphsThenFiresEightShotsAndDoesNotMeleeDuringTellOrRecovery" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.BossTelegraphsThenFiresEightShotsAndDoesNotMeleeDuringTellOrRecovery" methodname="BossTelegraphsThenFiresEightShotsAndDoesNotMeleeDuringTellOrRecovery" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" seed="1336174386" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.000476" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1055" name="BulletsExpireAtWallOrMaximumRange" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.BulletsExpireAtWallOrMaximumRange" methodname="BulletsExpireAtWallOrMaximumRange" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" seed="1520637850" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.000244" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1050" name="BulletSpawnOverlappingEnemyStillHitsInsteadOfSkippingCloseTarget" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.BulletSpawnOverlappingEnemyStillHitsInsteadOfSkippingCloseTarget" methodname="BulletSpawnOverlappingEnemyStillHitsInsteadOfSkippingCloseTarget" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" seed="1689769464" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.000164" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1061" name="ClearRemovesHostileShotsAndGrenadesBeforeSafeStateCanBeDamaged" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.ClearRemovesHostileShotsAndGrenadesBeforeSafeStateCanBeDamaged" methodname="ClearRemovesHostileShotsAndGrenadesBeforeSafeStateCanBeDamaged" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" seed="1785510659" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.000528" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1053" name="ContactAloneDoesNoDamageAndEnemyWaitsInitialAttackInterval" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.ContactAloneDoesNoDamageAndEnemyWaitsInitialAttackInterval" methodname="ContactAloneDoesNoDamageAndEnemyWaitsInitialAttackInterval" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" seed="981459547" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.000096" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1063" name="DeathSnapshotStaysFixedAndRetryResetsRunWhileMenuClearsIt" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.DeathSnapshotStaysFixedAndRetryResetsRunWhileMenuClearsIt" methodname="DeathSnapshotStaysFixedAndRetryResetsRunWhileMenuClearsIt" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" seed="1913536868" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.000699" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1041" name="EndlessProgressionThroughTwentyOneFloorsUsesSpecifiedRosterAndRewards" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.EndlessProgressionThroughTwentyOneFloorsUsesSpecifiedRosterAndRewards" methodname="EndlessProgressionThroughTwentyOneFloorsUsesSpecifiedRosterAndRewards" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" seed="2048417889" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.001149" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1051" name="EnemyBulletSweepDamagesPlayerAndIgnoresOtherEnemies" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.EnemyBulletSweepDamagesPlayerAndIgnoresOtherEnemies" methodname="EnemyBulletSweepDamagesPlayerAndIgnoresOtherEnemies" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" seed="654593866" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.000265" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1060" name="FloorTransitionCarriesHealthInventoryAndShieldTimersButResetsTransientState" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.FloorTransitionCarriesHealthInventoryAndShieldTimersButResetsTransientState" methodname="FloorTransitionCarriesHealthInventoryAndShieldTimersButResetsTransientState" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" seed="620275607" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.000553" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1056" name="GrenadeRequiresAimConsumesAtThrowAndDealsSnapshotAreaDamageAfterDelay" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.GrenadeRequiresAimConsumesAtThrowAndDealsSnapshotAreaDamageAfterDelay" methodname="GrenadeRequiresAimConsumesAtThrowAndDealsSnapshotAreaDamageAfterDelay" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" seed="89536660" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.000462" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1057" name="GrenadeTargetIsLimitedByThrowRangeAndArena" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.GrenadeTargetIsLimitedByThrowRangeAndArena" methodname="GrenadeTargetIsLimitedByThrowRangeAndArena" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" seed="953371283" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.000181" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1048" name="IndependentWeaponsHitConeOncePerEnemyAndHonorCooldowns" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.IndependentWeaponsHitConeOncePerEnemyAndHonorCooldowns" methodname="IndependentWeaponsHitConeOncePerEnemyAndHonorCooldowns" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" seed="502150715" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.000238" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1058" name="MedkitInputsAreOrderedBeforeIncomingDamageAndSecondFullHealthMedkitIsKept" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.MedkitInputsAreOrderedBeforeIncomingDamageAndSecondFullHealthMedkitIsKept" methodname="MedkitInputsAreOrderedBeforeIncomingDamageAndSecondFullHealthMedkitIsKept" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" seed="923404322" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.000149" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1062" name="MovementIsNormalizedWallBoundAndMaintainsLastValidAim" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.MovementIsNormalizedWallBoundAndMaintainsLastValidAim" methodname="MovementIsNormalizedWallBoundAndMaintainsLastValidAim" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" seed="1508272527" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.000177" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1040" name="OpeningDoesNotRunAndStartingCreatesOnePreparationChest" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.OpeningDoesNotRunAndStartingCreatesOnePreparationChest" methodname="OpeningDoesNotRunAndStartingCreatesOnePreparationChest" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" seed="86911214" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.000223" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1046" name="PortalAppearingUnderPlayerRequiresExitAndReentryAndCannotTransitionTwice" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.PortalAppearingUnderPlayerRequiresExitAndReentryAndCannotTransitionTwice" methodname="PortalAppearingUnderPlayerRequiresExitAndReentryAndCannotTransitionTwice" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" seed="216740128" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.000250" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1047" name="PortalRejectsNoWeaponWithoutDiscardingChest" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.PortalRejectsNoWeaponWithoutDiscardingChest" methodname="PortalRejectsNoWeaponWithoutDiscardingChest" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" seed="144640597" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.000376" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1049" name="ProjectileSweepHitsNearestTargetEvenWhenListOrderIsFarFirst" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.ProjectileSweepHitsNearestTargetEvenWhenListOrderIsFarFirst" methodname="ProjectileSweepHitsNearestTargetEvenWhenListOrderIsFarFirst" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" seed="877757344" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.000203" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1054" name="ShooterApproachesAndFiresTowardPlayerAfterItsInitialDelay" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.ShooterApproachesAndFiresTowardPlayerAfterItsInitialDelay" methodname="ShooterApproachesAndFiresTowardPlayerAfterItsInitialDelay" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" seed="519243879" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.000344" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-suite type="ParameterizedMethod" id="1044" name="SimultaneousPlayerAndLastEnemyDeathRecordsKillButNeverClearsOrRewards" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.SimultaneousPlayerAndLastEnemyDeathRecordsKillButNeverClearsOrRewards" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" testcasecount="2" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.000754" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
+              <properties />
+              <test-case id="1042" name="SimultaneousPlayerAndLastEnemyDeathRecordsKillButNeverClearsOrRewards(1)" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.SimultaneousPlayerAndLastEnemyDeathRecordsKillButNeverClearsOrRewards(1)" methodname="SimultaneousPlayerAndLastEnemyDeathRecordsKillButNeverClearsOrRewards" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" seed="1747463831" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.000357" asserts="0">
+                <properties>
+                  <property name="retryIteration" value="0" />
+                  <property name="repeatIteration" value="0" />
+                </properties>
+              </test-case>
+              <test-case id="1043" name="SimultaneousPlayerAndLastEnemyDeathRecordsKillButNeverClearsOrRewards(5)" fullname="UnityOnlyArena.Tests.ArenaSimulationTests.SimultaneousPlayerAndLastEnemyDeathRecordsKillButNeverClearsOrRewards(5)" methodname="SimultaneousPlayerAndLastEnemyDeathRecordsKillButNeverClearsOrRewards" classname="UnityOnlyArena.Tests.ArenaSimulationTests" runstate="Runnable" seed="829382688" result="Passed" start-time="2026-09-06 00:12:40Z" end-time="2026-09-06 00:12:40Z" duration="0.000065" asserts="0">
+                <properties>
+                  <property name="retryIteration" value="0" />
+                  <property name="repeatIteration" value="0" />
+                </properties>
+                <output><![CDATA[<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: [TestRunnerNoThrottle] Restored Interaction Mode after test run.
+Saving results to: /Users/mujina/Library/Application Support/DefaultCompany/kitu-unity-demo-game/TestResults.xml
+]]></output>
+              </test-case>
+            </test-suite>
+          </test-suite>
+        </test-suite>
+      </test-suite>
+    </test-suite>
+  </test-suite>
+</test-run>

--- a/doc/verification/arena-tsq1/unity-playmode.xml
+++ b/doc/verification/arena-tsq1/unity-playmode.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8"?>
+<test-run id="2" testcasecount="15" result="Passed" total="15" passed="15" failed="0" inconclusive="0" skipped="0" asserts="0" engine-version="3.5.0.0" clr-version="4.0.30319.42000" start-time="2026-09-06 00:20:30Z" end-time="2026-09-06 00:22:11Z" duration="101.4366727">
+  <test-suite type="TestSuite" id="1025" name="kitu-unity-demo-game" fullname="kitu-unity-demo-game" runstate="Runnable" testcasecount="15" result="Passed" start-time="2026-09-06 00:20:30Z" end-time="2026-09-06 00:22:11Z" duration="101.436673" total="15" passed="15" failed="0" inconclusive="0" skipped="0" asserts="0">
+    <properties>
+      <property name="platform" value="PlayMode" />
+    </properties>
+    <test-suite type="Assembly" id="1022" name="UnityOnlyArena.PlayModeTests.dll" fullname="/Users/mujina/.codex/worktrees/e19c/kitu-workspace/kitu-logic-processor/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Library/ScriptAssemblies/UnityOnlyArena.PlayModeTests.dll" runstate="Runnable" testcasecount="15" result="Passed" start-time="2026-09-06 00:20:30Z" end-time="2026-09-06 00:22:11Z" duration="101.431914" total="15" passed="15" failed="0" inconclusive="0" skipped="0" asserts="0">
+      <properties>
+        <property name="_PID" value="90435" />
+        <property name="_APPDOMAIN" value="Unity Child Domain" />
+        <property name="platform" value="PlayMode" />
+        <property name="EditorOnly" value="False" />
+      </properties>
+      <test-suite type="TestSuite" id="1023" name="UnityOnlyArena" fullname="UnityOnlyArena" runstate="Runnable" testcasecount="15" result="Passed" start-time="2026-09-06 00:20:30Z" end-time="2026-09-06 00:22:11Z" duration="101.431336" total="15" passed="15" failed="0" inconclusive="0" skipped="0" asserts="0">
+        <properties />
+        <test-suite type="TestSuite" id="1024" name="Tests" fullname="UnityOnlyArena.Tests" runstate="Runnable" testcasecount="15" result="Passed" start-time="2026-09-06 00:20:30Z" end-time="2026-09-06 00:22:11Z" duration="101.430907" total="15" passed="15" failed="0" inconclusive="0" skipped="0" asserts="0">
+          <properties />
+          <test-suite type="TestFixture" id="1004" name="ArenaFrontendTests" fullname="UnityOnlyArena.Tests.ArenaFrontendTests" classname="UnityOnlyArena.Tests.ArenaFrontendTests" runstate="Runnable" testcasecount="11" result="Passed" start-time="2026-09-06 00:20:30Z" end-time="2026-09-06 00:20:30Z" duration="0.411502" total="11" passed="11" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1013" name="CameraTracksArenaCornersWithoutZoomOrClampingAndSnapsOnRestart" fullname="UnityOnlyArena.Tests.ArenaFrontendTests.CameraTracksArenaCornersWithoutZoomOrClampingAndSnapsOnRestart" methodname="CameraTracksArenaCornersWithoutZoomOrClampingAndSnapsOnRestart" classname="UnityOnlyArena.Tests.ArenaFrontendTests" runstate="Runnable" seed="877198892" result="Passed" start-time="2026-09-06 00:20:30Z" end-time="2026-09-06 00:20:30Z" duration="0.044476" asserts="0">
+              <properties>
+                <property name="_JOINTYPE" value="UnityCombinatorial" />
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1012" name="CardinalKeysMoveAlongScreenAxesWithTheRotatedCamera" fullname="UnityOnlyArena.Tests.ArenaFrontendTests.CardinalKeysMoveAlongScreenAxesWithTheRotatedCamera" methodname="CardinalKeysMoveAlongScreenAxesWithTheRotatedCamera" classname="UnityOnlyArena.Tests.ArenaFrontendTests" runstate="Runnable" seed="1795742093" result="Passed" start-time="2026-09-06 00:20:30Z" end-time="2026-09-06 00:20:30Z" duration="0.071071" asserts="0">
+              <properties>
+                <property name="_JOINTYPE" value="UnityCombinatorial" />
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1014" name="ChestDistanceAndCombatInventoryGatesUseEAndTab" fullname="UnityOnlyArena.Tests.ArenaFrontendTests.ChestDistanceAndCombatInventoryGatesUseEAndTab" methodname="ChestDistanceAndCombatInventoryGatesUseEAndTab" classname="UnityOnlyArena.Tests.ArenaFrontendTests" runstate="Runnable" seed="461380747" result="Passed" start-time="2026-09-06 00:20:30Z" end-time="2026-09-06 00:20:30Z" duration="0.009045" asserts="0">
+              <properties>
+                <property name="_JOINTYPE" value="UnityCombinatorial" />
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1009" name="FullHealthMedkitAndSimultaneousMedkitsDoNotConsumeAnExtraItem" fullname="UnityOnlyArena.Tests.ArenaFrontendTests.FullHealthMedkitAndSimultaneousMedkitsDoNotConsumeAnExtraItem" methodname="FullHealthMedkitAndSimultaneousMedkitsDoNotConsumeAnExtraItem" classname="UnityOnlyArena.Tests.ArenaFrontendTests" runstate="Runnable" seed="1282738211" result="Passed" start-time="2026-09-06 00:20:30Z" end-time="2026-09-06 00:20:30Z" duration="0.070234" asserts="0">
+              <properties>
+                <property name="_JOINTYPE" value="UnityCombinatorial" />
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1010" name="HeldButtonsAcrossInventoryCloseRequireReleaseBeforeWeaponsOrItems" fullname="UnityOnlyArena.Tests.ArenaFrontendTests.HeldButtonsAcrossInventoryCloseRequireReleaseBeforeWeaponsOrItems" methodname="HeldButtonsAcrossInventoryCloseRequireReleaseBeforeWeaponsOrItems" classname="UnityOnlyArena.Tests.ArenaFrontendTests" runstate="Runnable" seed="1239288904" result="Passed" start-time="2026-09-06 00:20:30Z" end-time="2026-09-06 00:20:30Z" duration="0.074569" asserts="0">
+              <properties>
+                <property name="_JOINTYPE" value="UnityCombinatorial" />
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1005" name="OpeningStartAndReturnToMenuOwnTheSceneAndRunLifetime" fullname="UnityOnlyArena.Tests.ArenaFrontendTests.OpeningStartAndReturnToMenuOwnTheSceneAndRunLifetime" methodname="OpeningStartAndReturnToMenuOwnTheSceneAndRunLifetime" classname="UnityOnlyArena.Tests.ArenaFrontendTests" runstate="Runnable" seed="1223106252" result="Passed" start-time="2026-09-06 00:20:30Z" end-time="2026-09-06 00:20:30Z" duration="0.006946" asserts="0">
+              <properties>
+                <property name="_JOINTYPE" value="UnityCombinatorial" />
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1007" name="PauseSettingsAndFocusLossFreezeCombatAndReturnToPause" fullname="UnityOnlyArena.Tests.ArenaFrontendTests.PauseSettingsAndFocusLossFreezeCombatAndReturnToPause" methodname="PauseSettingsAndFocusLossFreezeCombatAndReturnToPause" classname="UnityOnlyArena.Tests.ArenaFrontendTests" runstate="Runnable" seed="194654251" result="Passed" start-time="2026-09-06 00:20:30Z" end-time="2026-09-06 00:20:30Z" duration="0.008538" asserts="0">
+              <properties>
+                <property name="_JOINTYPE" value="UnityCombinatorial" />
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1006" name="SettingsDraftCancelResetAndApplyReturnToOpeningWithoutAdvancingRun" fullname="UnityOnlyArena.Tests.ArenaFrontendTests.SettingsDraftCancelResetAndApplyReturnToOpeningWithoutAdvancingRun" methodname="SettingsDraftCancelResetAndApplyReturnToOpeningWithoutAdvancingRun" classname="UnityOnlyArena.Tests.ArenaFrontendTests" runstate="Runnable" seed="1355780558" result="Passed" start-time="2026-09-06 00:20:30Z" end-time="2026-09-06 00:20:30Z" duration="0.004923" asserts="0">
+              <properties>
+                <property name="_JOINTYPE" value="UnityCombinatorial" />
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1015" name="SettingsSaveLoadUsesAnIsolatedPrefixAndRejectsInvalidSavedValues" fullname="UnityOnlyArena.Tests.ArenaFrontendTests.SettingsSaveLoadUsesAnIsolatedPrefixAndRejectsInvalidSavedValues" methodname="SettingsSaveLoadUsesAnIsolatedPrefixAndRejectsInvalidSavedValues" classname="UnityOnlyArena.Tests.ArenaFrontendTests" runstate="Runnable" seed="1323841394" result="Passed" start-time="2026-09-06 00:20:30Z" end-time="2026-09-06 00:20:30Z" duration="0.004487" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1011" name="WasdAimAndBothMouseButtonsReachTheRunningSimulation" fullname="UnityOnlyArena.Tests.ArenaFrontendTests.WasdAimAndBothMouseButtonsReachTheRunningSimulation" methodname="WasdAimAndBothMouseButtonsReachTheRunningSimulation" classname="UnityOnlyArena.Tests.ArenaFrontendTests" runstate="Runnable" seed="925574580" result="Passed" start-time="2026-09-06 00:20:30Z" end-time="2026-09-06 00:20:30Z" duration="0.037167" asserts="0">
+              <properties>
+                <property name="_JOINTYPE" value="UnityCombinatorial" />
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1008" name="ZAndXUseTheirOwnSlotsThroughTheInputSystem" fullname="UnityOnlyArena.Tests.ArenaFrontendTests.ZAndXUseTheirOwnSlotsThroughTheInputSystem" methodname="ZAndXUseTheirOwnSlotsThroughTheInputSystem" classname="UnityOnlyArena.Tests.ArenaFrontendTests" runstate="Runnable" seed="128600323" result="Passed" start-time="2026-09-06 00:20:30Z" end-time="2026-09-06 00:20:30Z" duration="0.070669" asserts="0">
+              <properties>
+                <property name="_JOINTYPE" value="UnityCombinatorial" />
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1016" name="ArenaSceneScenarioTests" fullname="UnityOnlyArena.Tests.ArenaSceneScenarioTests" classname="UnityOnlyArena.Tests.ArenaSceneScenarioTests" runstate="Runnable" testcasecount="1" result="Passed" start-time="2026-09-06 00:20:30Z" end-time="2026-09-06 00:20:30Z" duration="0.115159" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1017" name="ActualSceneStockRunReachesElevenThenDiesAndRestarts" fullname="UnityOnlyArena.Tests.ArenaSceneScenarioTests.ActualSceneStockRunReachesElevenThenDiesAndRestarts" methodname="ActualSceneStockRunReachesElevenThenDiesAndRestarts" classname="UnityOnlyArena.Tests.ArenaSceneScenarioTests" runstate="Runnable" seed="1480543388" result="Passed" start-time="2026-09-06 00:20:30Z" end-time="2026-09-06 00:20:30Z" duration="0.114515" asserts="0">
+              <properties>
+                <property name="_JOINTYPE" value="UnityCombinatorial" />
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <output><![CDATA[[scene run] Actual saved scene; ArenaGame.AdvanceSimulation accelerates the stock input bot. ArenaGame.Update, WorldView.LateUpdate and HUD.OnGUI remain enabled. Physical input is covered separately.
+[scene visual] SKIPPED in batch mode: opening; native/interactive capture is required for screenshot evidence.
+[scene visual] SKIPPED in batch mode: chest; native/interactive capture is required for screenshot evidence.
+[scene run] selected stock chest 0F Preparing; t=1.23; HP=110/110; enemies=0; kills=0; cleared=0; bosses=0
+[scene run] entered 1F Combat; t=2.83; HP=110/110; enemies=3; kills=0; cleared=0; bosses=0
+[scene visual] SKIPPED in batch mode: combat; native/interactive capture is required for screenshot evidence.
+[scene run] cleared 1F Cleared; t=5.65; HP=110/110; enemies=0; kills=3; cleared=1; bosses=0
+[scene run] entered 2F Combat; t=7.28; HP=110/110; enemies=4; kills=3; cleared=1; bosses=0
+[scene run] cleared 2F Cleared; t=10.70; HP=110/110; enemies=0; kills=7; cleared=2; bosses=0
+[scene run] entered 3F Combat; t=11.85; HP=110/110; enemies=5; kills=7; cleared=2; bosses=0
+[scene run] cleared 3F Cleared; t=16.77; HP=110/110; enemies=0; kills=12; cleared=3; bosses=0
+[scene run] entered 4F Combat; t=17.22; HP=110/110; enemies=6; kills=12; cleared=3; bosses=0
+[scene run] cleared 4F Cleared; t=22.33; HP=110/110; enemies=0; kills=18; cleared=4; bosses=0
+[scene run] entered 5F Combat; t=22.35; HP=110/110; enemies=1; kills=18; cleared=4; bosses=0
+[scene visual] SKIPPED in batch mode: boss; native/interactive capture is required for screenshot evidence.
+[scene run] cleared 5F Cleared; t=27.18; HP=110/110; enemies=0; kills=19; cleared=5; bosses=1
+[scene run] selected stock chest 5F Cleared; t=29.20; HP=120/120; enemies=0; kills=19; cleared=5; bosses=1
+[scene run] entered 6F Combat; t=30.33; HP=120/120; enemies=8; kills=19; cleared=5; bosses=1
+[scene run] cleared 6F Cleared; t=37.45; HP=120/120; enemies=0; kills=27; cleared=6; bosses=1
+[scene run] entered 7F Combat; t=39.23; HP=120/120; enemies=9; kills=27; cleared=6; bosses=1
+[scene run] cleared 7F Cleared; t=47.13; HP=120/120; enemies=0; kills=36; cleared=7; bosses=1
+[scene run] entered 8F Combat; t=49.42; HP=120/120; enemies=10; kills=36; cleared=7; bosses=1
+[scene run] cleared 8F Cleared; t=58.82; HP=120/120; enemies=0; kills=46; cleared=8; bosses=1
+[scene run] entered 9F Combat; t=61.62; HP=120/120; enemies=11; kills=46; cleared=8; bosses=1
+[scene run] cleared 9F Cleared; t=72.48; HP=120/120; enemies=0; kills=57; cleared=9; bosses=1
+[scene run] entered 10F Combat; t=75.07; HP=120/120; enemies=1; kills=57; cleared=9; bosses=1
+[scene run] cleared 10F Cleared; t=80.39; HP=120/120; enemies=0; kills=58; cleared=10; bosses=2
+[scene run] selected stock chest 10F Cleared; t=81.59; HP=130/130; enemies=0; kills=58; cleared=10; bosses=2
+[scene run] entered 11F Combat; t=82.69; HP=130/130; enemies=12; kills=58; cleared=10; bosses=2
+[scene run] stock run reached 11F; cease movement, firing and item use for natural AI death.
+[scene run] natural death 11F Results; t=88.62; HP=0/130; enemies=12; kills=58; cleared=10; bosses=2
+[scene visual] SKIPPED in batch mode: result; native/interactive capture is required for screenshot evidence.
+[scene run] actual scene completed opening -> stock 1F..11F -> natural death -> clean retry.
+]]></output>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1018" name="KituArenaConnectionTests" fullname="UnityOnlyArena.Tests.KituArenaConnectionTests" classname="UnityOnlyArena.Tests.KituArenaConnectionTests" runstate="Runnable" testcasecount="3" result="Passed" start-time="2026-09-06 00:20:30Z" end-time="2026-09-06 00:22:11Z" duration="100.903222" total="3" passed="3" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1021" name="LiveStockRunReachesElevenDiesAndRetriesWithLocalSettings" fullname="UnityOnlyArena.Tests.KituArenaConnectionTests.LiveStockRunReachesElevenDiesAndRetriesWithLocalSettings" methodname="LiveStockRunReachesElevenDiesAndRetriesWithLocalSettings" classname="UnityOnlyArena.Tests.KituArenaConnectionTests" runstate="Runnable" seed="736819033" result="Passed" start-time="2026-09-06 00:20:30Z" end-time="2026-09-06 00:22:03Z" duration="92.677654" asserts="0">
+              <properties>
+                <property name="_JOINTYPE" value="UnityCombinatorial" />
+                <property name="Category" value="ArenaNetwork" />
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <output><![CDATA[Kitu live stock: cleared 1F at runtime tick 1744, HP 110
+Kitu live stock: cleared 2F at runtime tick 2065, HP 110
+Kitu live stock: cleared 3F at runtime tick 2446, HP 110
+Kitu live stock: cleared 4F at runtime tick 2798, HP 110
+Kitu live stock: cleared 5F at runtime tick 3108, HP 110
+Kitu live stock: cleared 6F at runtime tick 3724, HP 120
+Kitu live stock: cleared 7F at runtime tick 4323, HP 120
+Kitu live stock: cleared 8F at runtime tick 5043, HP 120
+Kitu live stock: cleared 9F at runtime tick 5880, HP 120
+Kitu live stock: cleared 10F at runtime tick 6372, HP 120
+]]></output>
+            </test-case>
+            <test-case id="1019" name="LiveTanuConfigurationIsProjectedInNewRuns" fullname="UnityOnlyArena.Tests.KituArenaConnectionTests.LiveTanuConfigurationIsProjectedInNewRuns" methodname="LiveTanuConfigurationIsProjectedInNewRuns" classname="UnityOnlyArena.Tests.KituArenaConnectionTests" runstate="Runnable" seed="30262725" result="Passed" start-time="2026-09-06 00:22:03Z" end-time="2026-09-06 00:22:03Z" duration="0.444282" asserts="0">
+              <properties>
+                <property name="_JOINTYPE" value="UnityCombinatorial" />
+                <property name="Category" value="ArenaNetwork" />
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <output><![CDATA[Live Tanu content: starter damage=20, two new runs projected through Kitu.
+]]></output>
+            </test-case>
+            <test-case id="1020" name="RealRuntimeMovesPausesAndResynchronizesWithoutRunningLocalRules" fullname="UnityOnlyArena.Tests.KituArenaConnectionTests.RealRuntimeMovesPausesAndResynchronizesWithoutRunningLocalRules" methodname="RealRuntimeMovesPausesAndResynchronizesWithoutRunningLocalRules" classname="UnityOnlyArena.Tests.KituArenaConnectionTests" runstate="Runnable" seed="2066041647" result="Passed" start-time="2026-09-06 00:22:03Z" end-time="2026-09-06 00:22:11Z" duration="7.780434" asserts="0">
+              <properties>
+                <property name="_JOINTYPE" value="UnityCombinatorial" />
+                <property name="Category" value="ArenaNetwork" />
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <output><![CDATA[<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: [TestRunnerNoThrottle] Restored Interaction Mode after test run.
+Saving results to: /Users/mujina/Library/Application Support/DefaultCompany/kitu-unity-demo-game/TestResults.xml
+]]></output>
+            </test-case>
+          </test-suite>
+        </test-suite>
+      </test-suite>
+    </test-suite>
+  </test-suite>
+</test-run>

--- a/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Tests/PlayMode/KituArenaConnectionTests.cs
+++ b/kitu-integration-runner/unity-demo-game/kitu-unity-demo-game/Assets/KituDemoApp/EndlessArena/Tests/PlayMode/KituArenaConnectionTests.cs
@@ -310,7 +310,9 @@ namespace UnityOnlyArena.Tests
                     { client.Command("use", 3); usedItem = item; }
                 }
                 client.Frame(move, aim, fire, fire, fire);
-                yield return null;
+                // Drive one intent per projected Runtime update, independent of
+                // uncapped batchmode render FPS (the device path is also 60 Hz).
+                yield return Until(() => client.State.tick > state.tick, "stock input applied");
             }
             Assert.That(client.State.phase, Is.EqualTo(5), "stock run must naturally reach results");
             Assert.That(client.State.floor, Is.EqualTo(11), "stock loadout must survive ten floors");


### PR DESCRIPTION
Closes #142. Implements stage 7 of #129 from merged stage 6 (#141).

Arena now records committed inputs into actual binary TSQ1 using the pinned public TSQ1/OSC APIs. Explicit ticks, same-tick order, queue sequence and producer IDs survive file round trips, alongside typed OSC bundles, initial evaluated content, later configuration edits, execution/contract versions and every tick's state/output proofs.

The host can export, atomically save, download, import and re-execute recordings. Re-execution creates the same Runtime with saved initial content and uses ordinary input validation, queue admission and tick processing. Current Tanu edits cannot alter old runs. Malformed/incompatible data or divergent states/events return diagnostics. Binary/OSC conversion stays in kitu-tsq1; game manifests and replay stay in the Arena application. No TSQ1 source change is needed.

Validation:
- Dev Container: 165 Rust tests/doctests; workspace format, all-target/all-feature Clippy, rustdoc with warnings denied and changed internal package lists passed. Final host diagnostic change: all 9 host tests and affected Clippy passed again.
- macOS Unity 6000.6.0f1: 47 EditMode and 15 PlayMode tests passed, including real 11F, natural death and retry. The uncapped test bot initially exceeded the 64 MiB file bound; it now waits for each Runtime projection, matching the production client's existing 60 Hz input pacing. The full PlayMode suite passed again.
- Frozen stock: 5528 ticks, 550 C# checkpoints, 53 command outcomes; saved TSQ1 replays 5581 input bundles and both runs with every state and ordered output matching. HTTP import/download is byte-identical and HTTP verification passes.
- Actual Unity session: 30144 inputs, 10122 ticks and 5 runs saved in an 11.9 MB TSQ1 file; every state/output/run manifest matched when re-executed through the host API.
- Width/order/bundle round trips include i32 versus i64, negative-zero f32, strings/booleans and ticks above JavaScript's exact integer range. Duplicate IDs, pauses, Tanu changes, corrupt proofs and incompatible versions have regression coverage. Oracle source/fixture hashes remain unchanged.

[Replay/file/API contract and reproduction](doc/specs/arena-replay.md); [validation evidence](doc/verification/arena-tsq1/results.json).

Initial bounds are one hour of management ticks, one million input bundles and 64 MiB encoded files. This is an in-memory recorder, not arbitrary-duration streaming. Admin playback/step/seek and Unity replay projection are stage 8; live CLI is stage 9. The parent workspace pointer publication currently awaits restored GitHub integration write access (403); Kitu's PR/merge access remains available.