### PR TITLE
feat(native): embed the complete Arena Runtime through a versioned C ABI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,6 +931,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "kitu-demo-game-native"
+version = "0.1.0"
+dependencies = [
+ "kitu-demo-game",
+ "kitu-osc-ir",
+ "kitu-runtime",
+ "kitu-transport",
+ "kitu-unity-ffi",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "kitu-ecs"
 version = "0.1.0"
 dependencies = [
@@ -1007,6 +1020,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_bytes",
+ "serde_json",
  "thiserror",
 ]
 
@@ -1031,6 +1045,8 @@ dependencies = [
  "kitu-osc-ir",
  "kitu-runtime",
  "kitu-transport",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/kitu-web-admin-backend",
     "crates/kitu-unity-ffi",
     "apps/demo-game",
+    "apps/demo-game/native",
     "tools/kitu-cli",
     "tools/kitu-replay-runner",
 ]

--- a/README.md
+++ b/README.md
@@ -306,3 +306,10 @@ A detailed, versioned roadmap will be published once the core architecture and w
 
 
 Kitu is intended as a long‑term foundation for building modern, data‑driven games with Rust and Unity. This README provides a high‑level architectural overview; individual crates, packages, and tools should provide more detailed API‑level documentation.
+
+The full Endless Arena native C ABI is implemented in
+[`apps/demo-game/native`](apps/demo-game/native/README.md). It builds a dynamic or
+static library around the same application Runtime, with typed ordered inputs,
+complete outputs, inspection, bounded caller-owned buffers and explicit lifecycle.
+See the [ABI contract and native verification](doc/specs/arena-native-abi.md).
+Unity standalone packaging and the development tooling bridge are the next stage.

--- a/apps/demo-game/README.md
+++ b/apps/demo-game/README.md
@@ -183,3 +183,13 @@ Run `kitu-cli help`, `app action run arena.start`, `inspect application` or
 available in **Kitu general → Shell**. Their JSON results include actual applied
 ticks or refusal reasons. `replay load <id>`, `replay seek 5526` and `replay step`
 control the connected Unity replay.
+
+## Native application library
+
+The complete Arena application can also run through the C ABI in
+[`native`](native/README.md). The application factory uses the same Runtime and
+embedded TMD as the server; typed input, tick, complete output and state inspection
+are verified against all stock scenario states/events and the frozen C# oracle.
+The [native ABI contract](../../doc/specs/arena-native-abi.md) includes macOS build
+and actual C-caller commands. Unity standalone packaging and the local Admin/CLI
+bridge follow in stage 11.

--- a/apps/demo-game/native/Cargo.toml
+++ b/apps/demo-game/native/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "kitu-demo-game-native"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Native C ABI factory for the complete Endless Arena reference application."
+license = "MIT"
+repository = "https://github.com/Nagitch/kitu-logic-processor"
+readme = "README.md"
+keywords = ["kitu", "arena", "ffi", "unity"]
+categories = ["api-bindings", "game-development"]
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
+
+[lib]
+crate-type = ["rlib", "cdylib", "staticlib"]
+
+[dependencies]
+kitu-demo-game = { path = ".." }
+kitu-unity-ffi = { path = "../../../crates/kitu-unity-ffi" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+kitu-osc-ir = { path = "../../../crates/kitu-osc-ir" }
+kitu-runtime = { path = "../../../crates/kitu-runtime" }
+kitu-transport = { path = "../../../crates/kitu-transport" }

--- a/apps/demo-game/native/README.md
+++ b/apps/demo-game/native/README.md
@@ -1,0 +1,20 @@
+# Endless Arena native library
+
+This application-owned crate builds `kitu_demo_game_native` as a dynamic library,
+static library and Rust library. It creates the same complete Arena Runtime as
+the server. The generic ABI and C header live in `kitu-unity-ffi`; no Arena rules
+are duplicated in the native crate.
+
+Create with ABI 1 and empty configuration to use the embedded, real Tanu TMD.
+Alternatively pass `{"contractVersion":1,"content":<ContentVersion>}` with a
+previously evaluated, hashed configuration. Invalid values, hashes, unknown
+fields and incompatible contracts are rejected before returning a handle.
+
+The caller owns the one 60 Hz scheduler, submits typed input without advancing
+time, ticks once and retrieves the complete output batch. Inspect is read-only.
+A short read does not consume output; the next tick is refused until the previous
+batch is retrieved. Destroy on the owning thread exactly once.
+
+See [`arena-native-abi.md`](../../../doc/specs/arena-native-abi.md) for the complete
+contract, reproducible builds and full-scenario C verification. Unity packaging
+and the shared development Admin/CLI bridge follow in stage 11.

--- a/apps/demo-game/native/src/lib.rs
+++ b/apps/demo-game/native/src/lib.rs
@@ -1,0 +1,168 @@
+//! Application-owned native factory for the complete Endless Arena Runtime.
+//!
+//! The shared `kitu-unity-ffi` crate owns ABI lifetimes, ordered input admission,
+//! output buffering and diagnostics. This crate selects the same application
+//! factory and validated content used by the server, then exports thin C wrappers.
+//! No socket, scheduler or separate copy of game rules is created here.
+//!
+//! See `doc/specs/arena-native-abi.md` and the shared C header for caller rules.
+
+use kitu_demo_game::{arena, build_arena_runtime, build_demo_runtime};
+use kitu_unity_ffi::application::{
+    self as ffi, ApplicationDriver, ApplicationHandle, RuntimeDriver,
+};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct NativeConfig {
+    #[serde(default = "contract_version")]
+    contract_version: u32,
+    #[serde(default)]
+    content: Option<arena::config::ContentVersion>,
+}
+fn contract_version() -> u32 {
+    arena::SCHEMA_VERSION
+}
+
+fn factory(bytes: &[u8]) -> Result<Box<dyn ApplicationDriver>, String> {
+    let config: NativeConfig = serde_json::from_slice(if bytes.is_empty() { b"{}" } else { bytes })
+        .map_err(|error| format!("invalid Arena native configuration: {error}"))?;
+    if config.contract_version != arena::SCHEMA_VERSION {
+        return Err(format!(
+            "Arena contract version must be {}",
+            arena::SCHEMA_VERSION
+        ));
+    }
+    let runtime = if let Some(content) = config.content {
+        content.validate().map_err(|error| error.to_string())?;
+        let mut runtime = build_demo_runtime().map_err(|error| error.to_string())?;
+        arena::install_with_content(&mut runtime, content).map_err(|error| error.to_string())?;
+        runtime
+    } else {
+        build_arena_runtime().map_err(|error| error.to_string())?
+    };
+    Ok(Box::new(RuntimeDriver::new(runtime)))
+}
+
+/// Returns the supported C ABI version without creating a Runtime.
+///
+/// # Examples
+/// ```
+/// assert_eq!(kitu_demo_game_native::kitu_application_abi_version(), 1);
+/// ```
+#[no_mangle]
+pub extern "C" fn kitu_application_abi_version() -> u32 {
+    ffi::ABI_VERSION
+}
+
+/// Creates an unstarted Arena, using embedded TMD or detached validated content.
+/// Empty configuration means defaults. Failures return no handle and report the
+/// required diagnostic length without truncating into short buffers.
+///
+/// # Safety
+/// All non-null pointers must be valid for their declared lengths; output pointers
+/// must be writable and disjoint. See the shared header for exact buffer rules.
+#[no_mangle]
+pub unsafe extern "C" fn kitu_application_create(
+    requested_abi: u32,
+    config: *const u8,
+    config_len: usize,
+    out_handle: *mut *mut ApplicationHandle,
+    error_buffer: *mut u8,
+    error_capacity: usize,
+    out_error_required: *mut usize,
+) -> i32 {
+    ffi::create_json(
+        requested_abi,
+        config,
+        config_len,
+        out_handle,
+        error_buffer,
+        error_capacity,
+        out_error_required,
+        factory,
+    )
+}
+
+/// Destroys a live handle exactly once on its owning thread.
+///
+/// # Safety
+/// `handle` must be null or a still-live pointer returned by creation. No call may
+/// race with destruction; the pointer must never be used after OK or PANIC.
+#[no_mangle]
+pub unsafe extern "C" fn kitu_application_destroy(handle: *mut ApplicationHandle) -> i32 {
+    ffi::destroy(handle)
+}
+
+/// Admits one typed JSON bundle without advancing the clock.
+/// Success returns its queue sequence; game acceptance is an emitted receipt.
+///
+/// # Safety
+/// The live handle belongs to this thread. Input and output pointers are valid,
+/// non-overlapping and remain alive for the call. Null input is valid only at zero length.
+#[no_mangle]
+pub unsafe extern "C" fn kitu_application_submit_json(
+    handle: *mut ApplicationHandle,
+    input: *const u8,
+    input_len: usize,
+    out_sequence: *mut u64,
+) -> i32 {
+    ffi::submit_json(handle, input, input_len, out_sequence)
+}
+
+/// Advances the same application Runtime once at 60 Hz logical time.
+/// Pending output must be retrieved before another tick; no wall clock is read.
+///
+/// # Safety
+/// `handle` must be null or a live handle owned by the calling thread.
+#[no_mangle]
+pub unsafe extern "C" fn kitu_application_tick(handle: *mut ApplicationHandle) -> i32 {
+    ffi::tick(handle)
+}
+
+/// Retrieves the entire ordered JSON output batch from the last tick.
+/// A length query or short buffer does not consume output.
+///
+/// # Safety
+/// The handle must be live and owned by this thread. The writable buffer and
+/// required-length pointer must be valid, disjoint, and not alias any handle data.
+#[no_mangle]
+pub unsafe extern "C" fn kitu_application_read_output(
+    handle: *mut ApplicationHandle,
+    buffer: *mut u8,
+    capacity: usize,
+    out_required: *mut usize,
+) -> i32 {
+    ffi::read_output(handle, buffer, capacity, out_required)
+}
+
+/// Inspects detached application projection bundles without consuming events.
+///
+/// # Safety
+/// The live handle is owned by this thread. Buffer and length output pointers
+/// must be valid, disjoint, and follow the shared header's capacity rules.
+#[no_mangle]
+pub unsafe extern "C" fn kitu_application_inspect_json(
+    handle: *mut ApplicationHandle,
+    buffer: *mut u8,
+    capacity: usize,
+    out_required: *mut usize,
+) -> i32 {
+    ffi::inspect_json(handle, buffer, capacity, out_required)
+}
+
+/// Reads the latest diagnostic without truncation or clearing it.
+///
+/// # Safety
+/// The live handle is owned by this thread. Buffer and length output pointers
+/// must be valid, disjoint, and follow the shared header's capacity rules.
+#[no_mangle]
+pub unsafe extern "C" fn kitu_application_last_error(
+    handle: *mut ApplicationHandle,
+    buffer: *mut u8,
+    capacity: usize,
+    out_required: *mut usize,
+) -> i32 {
+    ffi::last_error(handle, buffer, capacity, out_required)
+}

--- a/apps/demo-game/native/tests/arena_native.rs
+++ b/apps/demo-game/native/tests/arena_native.rs
@@ -1,0 +1,428 @@
+//! Exercises the exported C boundary with the full frozen C# scenarios.
+#[allow(dead_code)]
+#[path = "../../tests/support/mod.rs"]
+mod support;
+
+use kitu_demo_game::{arena, build_arena_runtime, build_demo_runtime, DemoRuntime};
+use kitu_demo_game_native::*;
+use kitu_osc_ir::{OscArg, OscBundle};
+use kitu_runtime::InputMetadata;
+use kitu_transport::wire::WireBundle;
+use kitu_unity_ffi::application::{ApplicationHandle, BUFFER_TOO_SMALL, EMPTY, OK, PENDING_OUTPUT};
+use serde_json::{json, Value};
+use std::{fs::File, io::Write, path::Path, ptr};
+
+type Read = unsafe extern "C" fn(*mut ApplicationHandle, *mut u8, usize, *mut usize) -> i32;
+
+struct Native(*mut ApplicationHandle);
+impl Native {
+    fn create(config: &[u8]) -> Self {
+        let mut handle = ptr::null_mut();
+        let mut error = [0u8; 1024];
+        let mut required = 0;
+        let code = unsafe {
+            kitu_application_create(
+                1,
+                config.as_ptr(),
+                config.len(),
+                &mut handle,
+                error.as_mut_ptr(),
+                error.len(),
+                &mut required,
+            )
+        };
+        assert_eq!(
+            code,
+            OK,
+            "{}",
+            String::from_utf8_lossy(&error[..required.min(error.len())])
+        );
+        assert!(!handle.is_null());
+        Self(handle)
+    }
+    fn read(&self, read: Read) -> Vec<u8> {
+        let mut required = 0;
+        assert_eq!(
+            unsafe { read(self.0, ptr::null_mut(), 0, &mut required) },
+            BUFFER_TOO_SMALL
+        );
+        assert!(required > 0);
+        let mut bytes = vec![0x55; required];
+        assert_eq!(
+            unsafe { read(self.0, bytes.as_mut_ptr(), required - 1, &mut required) },
+            BUFFER_TOO_SMALL
+        );
+        assert!(
+            bytes.iter().all(|byte| *byte == 0x55),
+            "short read must not partially write"
+        );
+        assert_eq!(
+            unsafe { read(self.0, bytes.as_mut_ptr(), bytes.len(), &mut required) },
+            OK
+        );
+        bytes
+    }
+    fn submit(
+        &self,
+        bundle: &OscBundle,
+        metadata: Option<InputMetadata>,
+        sequence: u64,
+    ) -> Vec<u8> {
+        let bytes = serde_json::to_vec(
+            &json!({"bundle":WireBundle::try_from(bundle).unwrap(), "metadata":metadata}),
+        )
+        .unwrap();
+        let mut actual = u64::MAX;
+        assert_eq!(
+            unsafe {
+                kitu_application_submit_json(self.0, bytes.as_ptr(), bytes.len(), &mut actual)
+            },
+            OK
+        );
+        assert_eq!(actual, sequence);
+        bytes
+    }
+}
+impl Drop for Native {
+    fn drop(&mut self) {
+        assert_eq!(unsafe { kitu_application_destroy(self.0) }, OK);
+    }
+}
+
+fn wire(bundles: &[OscBundle]) -> Value {
+    serde_json::to_value(
+        bundles
+            .iter()
+            .map(|bundle| WireBundle::try_from(bundle).unwrap())
+            .collect::<Vec<_>>(),
+    )
+    .unwrap()
+}
+fn state(bundles: &Value) -> Value {
+    serde_json::from_str(
+        bundles[0]["messages"][0]["args"][0]["value"]
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap()
+}
+fn compare_tick(native: &Native, runtime: &DemoRuntime, outputs: &[OscBundle]) -> Value {
+    assert_eq!(unsafe { kitu_application_tick(native.0) }, OK);
+    assert_eq!(unsafe { kitu_application_tick(native.0) }, PENDING_OUTPUT);
+    let actual: Value = serde_json::from_slice(&native.read(kitu_application_read_output)).unwrap();
+    assert_eq!(
+        actual,
+        wire(outputs),
+        "complete output bundle/type/order mismatch"
+    );
+    let mut length = 999;
+    assert_eq!(
+        unsafe { kitu_application_read_output(native.0, ptr::null_mut(), 0, &mut length) },
+        EMPTY
+    );
+    assert_eq!(length, 0);
+    let projection: Value =
+        serde_json::from_slice(&native.read(kitu_application_inspect_json)).unwrap();
+    assert_eq!(
+        projection,
+        wire(&runtime.inspect_application()),
+        "complete state projection mismatch"
+    );
+    assert_eq!(
+        native.read(kitu_application_inspect_json),
+        serde_json::to_vec(&projection).unwrap()
+    );
+    json!({"tick":runtime.current_tick().get()-1, "output":actual, "state":projection})
+}
+
+fn full_scenario(name: &str, expected_counts: (usize, usize)) {
+    let native = Native::create(&[]);
+    let initial: Value =
+        serde_json::from_slice(&native.read(kitu_application_inspect_json)).unwrap();
+    assert_eq!(state(&initial)["tick"], -1);
+    assert_eq!(
+        initial,
+        wire(&build_arena_runtime().unwrap().inspect_application())
+    );
+    let directory = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../kitu-integration-runner/scenarios/arena/reference")
+        .join(name);
+    let mut evidence = std::env::var_os("KITU_NATIVE_EVIDENCE_DIR").map(|directory| {
+        std::fs::create_dir_all(&directory).unwrap();
+        let path = Path::new(&directory);
+        (
+            File::create(path.join(format!("{name}.trace"))).unwrap(),
+            File::create(path.join(format!("{name}.expected.ndjson"))).unwrap(),
+        )
+    });
+    let mut ticks = 0;
+    let mut inputs = 0;
+    let counts = support::replay_reference_from_directory(
+        &directory,
+        name,
+        usize::MAX,
+        |_| {},
+        |runtime, outputs| {
+            for input in runtime.committed_input_records() {
+                let bytes = native.submit(&input.bundle, input.metadata.clone(), input.sequence);
+                if let Some((trace, _)) = &mut evidence {
+                    trace.write_all(b"I").unwrap();
+                    trace.write_all(&bytes).unwrap();
+                    trace.write_all(b"\n").unwrap();
+                }
+                inputs += 1;
+            }
+            let result = compare_tick(&native, runtime, outputs);
+            if name == "stock-eleven-death-retry" && ticks == 5526 {
+                let value = state(&result["state"]);
+                assert_eq!(value["phase"], 5);
+                assert_eq!(value["floor"], 11);
+                assert_eq!(value["inventory"]["health"], 0);
+            }
+            if let Some((trace, expected)) = &mut evidence {
+                trace.write_all(b"T\n").unwrap();
+                serde_json::to_writer(&mut *expected, &result).unwrap();
+                expected.write_all(b"\n").unwrap();
+            }
+            ticks += 1;
+        },
+    );
+    assert_eq!(counts, expected_counts);
+    if name == "stock-eleven-death-retry" {
+        assert_eq!((ticks, inputs), (5528, 5581));
+    }
+}
+
+#[test]
+fn complete_stock_run_matches_c_abi_server_and_frozen_csharp_oracle() {
+    full_scenario("stock-eleven-death-retry", (550, 53));
+}
+#[test]
+fn preparation_inventory_and_equipment_match_c_abi_and_frozen_csharp_oracle() {
+    full_scenario("preparation", (12, 12));
+}
+
+#[test]
+fn native_uses_detached_validated_content_and_refuses_incompatible_configuration() {
+    let mut values = arena::config::ArenaConfig::default();
+    values.items[0].damage = 37;
+    let content = arena::config::ContentVersion::from_tmd(&values.to_tmd().unwrap()).unwrap();
+    let native = Native::create(
+        &serde_json::to_vec(&json!({"contractVersion":1,"content":content})).unwrap(),
+    );
+    let mut runtime = build_demo_runtime().unwrap();
+    arena::install_with_content(&mut runtime, content.clone()).unwrap();
+    support::send(&mut runtime, "native-test", 1, "/input/arena/start", vec![]);
+    runtime.tick_once().unwrap();
+    for input in runtime.committed_input_records() {
+        native.submit(&input.bundle, input.metadata.clone(), input.sequence);
+    }
+    let output = runtime.drain_output_buffer();
+    compare_tick(&native, &runtime, &output);
+    for config in [json!({"contractVersion":2}), json!({"unknown":true}), {
+        let mut invalid = content;
+        invalid.hash = "0".repeat(64);
+        json!({"content":invalid})
+    }] {
+        let bytes = serde_json::to_vec(&config).unwrap();
+        let mut handle = ptr::null_mut();
+        let mut required = 0;
+        assert!(
+            unsafe {
+                kitu_application_create(
+                    1,
+                    bytes.as_ptr(),
+                    bytes.len(),
+                    &mut handle,
+                    ptr::null_mut(),
+                    0,
+                    &mut required,
+                )
+            } < 0
+        );
+        assert!(handle.is_null());
+        assert!(required > 0);
+    }
+}
+
+#[test]
+fn inputs_do_not_advance_time_and_duplicate_operations_keep_server_receipts() {
+    let native = Native::create(&[]);
+    let mut runtime = build_arena_runtime().unwrap();
+    let before = native.read(kitu_application_inspect_json);
+    for _ in 0..2 {
+        support::send(&mut runtime, "retry", 1, "/input/arena/start", vec![]);
+    }
+    runtime.tick_once().unwrap();
+    for input in runtime.committed_input_records() {
+        native.submit(&input.bundle, input.metadata.clone(), input.sequence);
+    }
+    assert_eq!(native.read(kitu_application_inspect_json), before);
+    let output = runtime.drain_output_buffer();
+    assert_eq!(
+        output
+            .iter()
+            .flat_map(|b| &b.messages)
+            .filter(|m| m.address == "/game/arena/run")
+            .count(),
+        1
+    );
+    compare_tick(&native, &runtime, &output);
+    // Invalid contract input cannot consume the next sequence or advance either clock.
+    let bad = serde_json::to_vec(&json!({"metadata":{"source":"retry","messageId":2,"schemaVersion":99},"bundle":{"messages":[{"address":"/input/arena/menu","args":[]}]}})).unwrap();
+    let mut sequence = u64::MAX;
+    assert!(
+        unsafe { kitu_application_submit_json(native.0, bad.as_ptr(), bad.len(), &mut sequence) }
+            < 0
+    );
+    support::send(&mut runtime, "retry", 2, "/input/arena/pause", vec![]);
+    runtime.tick_once().unwrap();
+    for input in runtime.committed_input_records() {
+        native.submit(&input.bundle, input.metadata.clone(), input.sequence);
+    }
+    let output = runtime.drain_output_buffer();
+    compare_tick(&native, &runtime, &output);
+    let elapsed = state(&wire(&runtime.inspect_application()))["elapsed"].clone();
+    for _ in 0..5 {
+        runtime.tick_once().unwrap();
+        let output = runtime.drain_output_buffer();
+        let result = compare_tick(&native, &runtime, &output);
+        assert_eq!(state(&result["state"])["elapsed"], elapsed);
+    }
+    // Ordinary ordered generic movement retains its string/float types through the same C boundary.
+    let mut bundle = OscBundle::new();
+    let mut message = kitu_osc_ir::OscMessage::new("/input/move");
+    message.args = vec![
+        OscArg::Str("marker".into()),
+        OscArg::Float(-0.0),
+        OscArg::Float(2.0),
+    ];
+    bundle.push(message);
+    let seq = runtime.try_enqueue_input(bundle.clone(), None).unwrap();
+    native.submit(&bundle, None, seq);
+    runtime.tick_once().unwrap();
+    let output = runtime.drain_output_buffer();
+    compare_tick(&native, &runtime, &output);
+}
+
+#[test]
+fn native_consumable_intents_cancel_on_pause_and_duplicate_use_consumes_once() {
+    fn advance(native: &Native, runtime: &mut DemoRuntime) -> Value {
+        runtime.tick_once().unwrap();
+        for input in runtime.committed_input_records() {
+            native.submit(&input.bundle, input.metadata.clone(), input.sequence);
+        }
+        let output = runtime.drain_output_buffer();
+        compare_tick(native, runtime, &output)
+    }
+    fn command(runtime: &mut DemoRuntime, id: u64, name: &str, args: Vec<OscArg>) {
+        support::send(
+            runtime,
+            "consumables",
+            id,
+            &format!("/input/arena/{name}"),
+            args,
+        );
+    }
+    let native = Native::create(&[]);
+    let mut runtime = build_arena_runtime().unwrap();
+    command(&mut runtime, 1, "start", vec![]);
+    let length = 58.0_f32.sqrt();
+    support::send(
+        &mut runtime,
+        "frames",
+        1,
+        "/input/arena/frame",
+        vec![
+            OscArg::Float(-3.0 / length),
+            OscArg::Float(7.0 / length),
+            OscArg::Bool(true),
+            OscArg::Float(0.0),
+            OscArg::Float(5.0),
+            OscArg::Bool(false),
+            OscArg::Bool(false),
+        ],
+    );
+    for _ in 0..75 {
+        advance(&native, &mut runtime);
+    }
+    for (id, name, args) in [
+        (2, "chest", vec![]),
+        (3, "take", vec![OscArg::Int(9), OscArg::Int(0)]),
+        (
+            4,
+            "equip",
+            vec![OscArg::Int(9), OscArg::Int(0), OscArg::Int(2)],
+        ),
+        (5, "close", vec![]),
+    ] {
+        command(&mut runtime, id, name, args);
+    }
+    advance(&native, &mut runtime);
+    command(&mut runtime, 6, "use", vec![OscArg::Int(2)]);
+    command(&mut runtime, 7, "pause", vec![]);
+    advance(&native, &mut runtime);
+    command(&mut runtime, 8, "resume", vec![]);
+    let resumed = advance(&native, &mut runtime);
+    assert_eq!(
+        state(&resumed["state"])["inventory"]["equipment"][2]["id"],
+        9
+    );
+    support::send(
+        &mut runtime,
+        "frames",
+        2,
+        "/input/arena/frame",
+        vec![
+            OscArg::Float(0.0),
+            OscArg::Float(0.0),
+            OscArg::Bool(true),
+            OscArg::Float(0.0),
+            OscArg::Float(5.0),
+            OscArg::Bool(false),
+            OscArg::Bool(false),
+        ],
+    );
+    for id in [9, 9, 10] {
+        command(&mut runtime, id, "use", vec![OscArg::Int(2)]);
+    }
+    let used = advance(&native, &mut runtime);
+    assert_eq!(
+        state(&used["state"])["grenades"].as_array().unwrap().len(),
+        1
+    );
+    assert_eq!(state(&used["state"])["inventory"]["equipment"][2]["id"], 0);
+    let addresses: Vec<_> = used["output"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .flat_map(|b| b["messages"].as_array().unwrap())
+        .map(|m| m["address"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        addresses.iter().filter(|a| **a == "/ui/arena/use").count(),
+        1
+    );
+    assert_eq!(
+        addresses
+            .iter()
+            .filter(|a| **a == "/game/arena/inventory")
+            .count(),
+        1
+    );
+    command(&mut runtime, 10, "use", vec![OscArg::Int(2)]);
+    let duplicate = advance(&native, &mut runtime);
+    assert!(!duplicate["output"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .flat_map(|b| b["messages"].as_array().unwrap())
+        .any(|m| m["address"] == "/ui/arena/use"));
+    for _ in 0..35 {
+        advance(&native, &mut runtime);
+    }
+    assert!(support::projection(&runtime)["grenades"]
+        .as_array()
+        .unwrap()
+        .is_empty());
+}

--- a/apps/demo-game/native/tests/c_abi.c
+++ b/apps/demo-game/native/tests/c_abi.c
@@ -1,0 +1,336 @@
+/* Actual C caller for the application-owned native library.
+ *
+ * Usage: c_abi TRACE_PATH ACTUAL_NDJSON_PATH
+ * Trace records are I<JSON InputRequest> or T, one record per line. The Rust
+ * fixture generator supplies expected output from an ordinary Runtime. This
+ * caller writes the native library's unmodified JSON for an external comparison;
+ * it does not implement a second game simulation or a JSON parser.
+ */
+#define _POSIX_C_SOURCE 200809L
+
+#include "kitu_application.h"
+
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+
+#define MAX_BATCH_BYTES ((size_t)64 * 1024 * 1024)
+
+typedef int32_t (*Reader)(KituApplication *, uint8_t *, size_t, size_t *);
+
+static KituApplication *application;
+static FILE *trace_file;
+static FILE *actual_file;
+static char *trace_line;
+static size_t trace_line_number;
+
+static void cleanup(void) {
+    if (application != NULL) {
+        (void)kitu_application_destroy(application);
+        application = NULL;
+    }
+    if (trace_file != NULL) {
+        (void)fclose(trace_file);
+        trace_file = NULL;
+    }
+    if (actual_file != NULL) {
+        (void)fclose(actual_file);
+        actual_file = NULL;
+    }
+    free(trace_line);
+    trace_line = NULL;
+}
+
+static void fail(const char *message, int source_line) {
+    fprintf(stderr, "C ABI failure at source line %d, trace line %zu: %s\n",
+            source_line, trace_line_number, message);
+    exit(EXIT_FAILURE);
+}
+
+#define REQUIRE(condition, message)                                             \
+    do {                                                                        \
+        if (!(condition)) {                                                     \
+            fail((message), __LINE__);                                          \
+        }                                                                       \
+    } while (0)
+
+static void expect_status(int32_t actual, int32_t expected,
+                          const char *operation, int source_line) {
+    if (actual != expected) {
+        fprintf(stderr,
+                "C ABI status at source line %d, trace line %zu: %s returned "
+                "%" PRId32 ", expected %" PRId32 "\n",
+                source_line, trace_line_number, operation, actual, expected);
+        exit(EXIT_FAILURE);
+    }
+}
+
+#define EXPECT(operation, status)                                               \
+    expect_status((operation), (status), #operation, __LINE__)
+
+static uint8_t *allocate_bytes(size_t length) {
+    REQUIRE(length <= MAX_BATCH_BYTES, "batch exceeds documented 64 MiB limit");
+    uint8_t *bytes = malloc(length + 1);
+    REQUIRE(bytes != NULL, "cannot allocate caller-owned buffer");
+    return bytes;
+}
+
+/* Verify that a query and a deliberately short buffer leave the complete batch
+ * available. Sentinels detect partial writes even when the function returns the
+ * expected error. The final successful call uses the exact required capacity.
+ */
+static char *read_checked(Reader reader, size_t *out_length) {
+    size_t required = SIZE_MAX;
+    EXPECT(reader(application, NULL, 0, &required),
+           KITU_APPLICATION_BUFFER_TOO_SMALL);
+    REQUIRE(required > 0, "nonempty batch must report a positive byte count");
+    uint8_t *bytes = allocate_bytes(required);
+    memset(bytes, 0xa5, required);
+
+    size_t short_required = SIZE_MAX;
+    EXPECT(reader(application, bytes, required - 1, &short_required),
+           KITU_APPLICATION_BUFFER_TOO_SMALL);
+    REQUIRE(short_required == required, "short read changed the required size");
+    for (size_t index = 0; index < required; ++index) {
+        REQUIRE(bytes[index] == 0xa5, "short read partially modified the buffer");
+    }
+
+    size_t copied = SIZE_MAX;
+    EXPECT(reader(application, bytes, required, &copied), KITU_APPLICATION_OK);
+    REQUIRE(copied == required, "full read changed the required size");
+    bytes[copied] = '\0';
+    REQUIRE(memchr(bytes, '\0', copied) == NULL,
+            "UTF-8 JSON or diagnostic unexpectedly contains a raw NUL byte");
+    *out_length = copied;
+    return (char *)bytes;
+}
+
+static char *inspect_stable(size_t *out_length) {
+    size_t first_length = 0;
+    char *first = read_checked(kitu_application_inspect_json, &first_length);
+    size_t second_length = 0;
+    char *second = read_checked(kitu_application_inspect_json, &second_length);
+    REQUIRE(first_length == second_length &&
+                memcmp(first, second, first_length) == 0,
+            "inspection advanced or mutated the application");
+    free(second);
+    *out_length = first_length;
+    return first;
+}
+
+static void create_default(void) {
+    size_t error_required = SIZE_MAX;
+    REQUIRE(application == NULL, "create would overwrite an owned handle");
+    EXPECT(kitu_application_create(KITU_APPLICATION_ABI_VERSION, NULL, 0,
+                                   &application, NULL, 0, &error_required),
+           KITU_APPLICATION_OK);
+    REQUIRE(application != NULL, "successful creation returned a null handle");
+    REQUIRE(error_required == 0, "successful creation returned an error");
+}
+
+static void check_failed_creation(uint32_t abi, const uint8_t *config,
+                                  size_t config_length, int32_t expected) {
+    KituApplication *rejected = NULL;
+    size_t required = SIZE_MAX;
+    EXPECT(kitu_application_create(abi, config, config_length, &rejected, NULL,
+                                   0, &required),
+           expected);
+    REQUIRE(rejected == NULL, "failed creation returned an owned handle");
+    REQUIRE(required > 0, "failed creation did not provide a diagnostic size");
+    uint8_t *diagnostic = allocate_bytes(required);
+    size_t copied = SIZE_MAX;
+    EXPECT(kitu_application_create(abi, config, config_length, &rejected,
+                                   diagnostic, required, &copied),
+           expected);
+    REQUIRE(rejected == NULL, "repeated failed creation returned a handle");
+    REQUIRE(copied == required, "creation diagnostic changed between queries");
+    REQUIRE(memchr(diagnostic, '\0', copied) == NULL,
+            "creation diagnostic includes an undocumented NUL terminator");
+    free(diagnostic);
+}
+
+static void check_creation_and_invalid_arguments(void) {
+    REQUIRE(kitu_application_abi_version() == 1,
+            "native library reports an unexpected ABI version");
+    REQUIRE(KITU_APPLICATION_ABI_VERSION == 1,
+            "header and test disagree on the ABI version");
+    check_failed_creation(999, NULL, 0, KITU_APPLICATION_ABI_MISMATCH);
+    const char bad_contract[] = "{\"contractVersion\":999}";
+    check_failed_creation(KITU_APPLICATION_ABI_VERSION,
+                          (const uint8_t *)bad_contract,
+                          sizeof(bad_contract) - 1,
+                          KITU_APPLICATION_DRIVER_ERROR);
+
+    size_t required = SIZE_MAX;
+    KituApplication *rejected = NULL;
+    EXPECT(kitu_application_create(KITU_APPLICATION_ABI_VERSION, NULL, 0, NULL,
+                                   NULL, 0, &required),
+           KITU_APPLICATION_INVALID_ARGUMENT);
+    EXPECT(kitu_application_create(KITU_APPLICATION_ABI_VERSION, NULL, 1,
+                                   &rejected, NULL, 0, &required),
+           KITU_APPLICATION_INVALID_ARGUMENT);
+    REQUIRE(rejected == NULL, "invalid creation arguments returned a handle");
+    EXPECT(kitu_application_create(KITU_APPLICATION_ABI_VERSION, NULL, 0,
+                                   &rejected, NULL, 0, NULL),
+           KITU_APPLICATION_INVALID_ARGUMENT);
+    REQUIRE(rejected == NULL, "missing error length pointer returned a handle");
+
+    EXPECT(kitu_application_destroy(NULL), KITU_APPLICATION_INVALID_ARGUMENT);
+    EXPECT(kitu_application_tick(NULL), KITU_APPLICATION_INVALID_ARGUMENT);
+    EXPECT(kitu_application_read_output(NULL, NULL, 0, &required),
+           KITU_APPLICATION_INVALID_ARGUMENT);
+    EXPECT(kitu_application_inspect_json(NULL, NULL, 0, &required),
+           KITU_APPLICATION_INVALID_ARGUMENT);
+    EXPECT(kitu_application_last_error(NULL, NULL, 0, &required),
+           KITU_APPLICATION_INVALID_ARGUMENT);
+
+    create_default();
+    EXPECT(kitu_application_last_error(application, NULL, 0, &required),
+           KITU_APPLICATION_OK);
+    REQUIRE(required == 0, "new handle unexpectedly has a diagnostic");
+    size_t initial_length = 0;
+    char *initial = inspect_stable(&initial_length);
+
+    uint64_t sequence = UINT64_MAX;
+    const uint8_t invalid_utf8[] = {0xff};
+    EXPECT(kitu_application_submit_json(application, invalid_utf8,
+                                        sizeof(invalid_utf8), &sequence),
+           KITU_APPLICATION_INVALID_INPUT);
+    REQUIRE(sequence == UINT64_MAX, "invalid UTF-8 modified output sequence");
+    size_t diagnostic_length = 0;
+    char *diagnostic = read_checked(kitu_application_last_error,
+                                    &diagnostic_length);
+    REQUIRE(diagnostic_length > 0, "invalid UTF-8 has no diagnostic");
+    free(diagnostic);
+
+    EXPECT(kitu_application_submit_json(NULL, invalid_utf8,
+                                        sizeof(invalid_utf8), &sequence),
+           KITU_APPLICATION_INVALID_ARGUMENT);
+    EXPECT(kitu_application_submit_json(application, NULL, 1, &sequence),
+           KITU_APPLICATION_INVALID_ARGUMENT);
+    const char empty_bundle[] = "{\"bundle\":{\"messages\":[]}}";
+    EXPECT(kitu_application_submit_json(application,
+                                        (const uint8_t *)empty_bundle,
+                                        sizeof(empty_bundle) - 1, NULL),
+           KITU_APPLICATION_INVALID_ARGUMENT);
+    REQUIRE(sequence == UINT64_MAX, "invalid arguments modified sequence");
+    EXPECT(kitu_application_read_output(application, NULL, 0, NULL),
+           KITU_APPLICATION_INVALID_ARGUMENT);
+    EXPECT(kitu_application_read_output(application, NULL, 1, &required),
+           KITU_APPLICATION_INVALID_ARGUMENT);
+    EXPECT(kitu_application_inspect_json(application, NULL, 0, NULL),
+           KITU_APPLICATION_INVALID_ARGUMENT);
+    EXPECT(kitu_application_inspect_json(application, NULL, 1, &required),
+           KITU_APPLICATION_INVALID_ARGUMENT);
+    EXPECT(kitu_application_last_error(application, NULL, 0, NULL),
+           KITU_APPLICATION_INVALID_ARGUMENT);
+    EXPECT(kitu_application_last_error(application, NULL, 1, &required),
+           KITU_APPLICATION_INVALID_ARGUMENT);
+
+    size_t after_length = 0;
+    char *after = inspect_stable(&after_length);
+    REQUIRE(initial_length == after_length &&
+                memcmp(initial, after, initial_length) == 0,
+            "rejected arguments or inspection changed the initial state");
+    free(initial);
+    free(after);
+    EXPECT(kitu_application_read_output(application, NULL, 0, &required),
+           KITU_APPLICATION_EMPTY);
+    REQUIRE(required == 0, "rejected requests created tick output");
+}
+
+static char *tick_and_drain(size_t *output_length) {
+    EXPECT(kitu_application_tick(application), KITU_APPLICATION_OK);
+    EXPECT(kitu_application_tick(application), KITU_APPLICATION_PENDING_OUTPUT);
+    EXPECT(kitu_application_read_output(application, NULL, 0, NULL),
+           KITU_APPLICATION_INVALID_ARGUMENT);
+    char *output = read_checked(kitu_application_read_output, output_length);
+    size_t required = SIZE_MAX;
+    EXPECT(kitu_application_read_output(application, NULL, 0, &required),
+           KITU_APPLICATION_EMPTY);
+    REQUIRE(required == 0, "consumed output remained available");
+    return output;
+}
+
+static void destroy_owned(void) {
+    KituApplication *owned = application;
+    application = NULL;
+    EXPECT(kitu_application_destroy(owned), KITU_APPLICATION_OK);
+}
+
+int main(int argc, char **argv) {
+    REQUIRE(atexit(cleanup) == 0, "cannot install cleanup handler");
+    REQUIRE(argc == 3, "usage: c_abi TRACE_PATH ACTUAL_NDJSON_PATH");
+    trace_file = fopen(argv[1], "r");
+    REQUIRE(trace_file != NULL, "cannot open trace input");
+    actual_file = fopen(argv[2], "w");
+    REQUIRE(actual_file != NULL, "cannot open actual NDJSON output");
+    check_creation_and_invalid_arguments();
+
+    uint64_t inputs = 0;
+    uint64_t ticks = 0;
+    size_t line_capacity = 0;
+    ssize_t line_length;
+    while ((line_length = getline(&trace_line, &line_capacity, trace_file)) >= 0) {
+        ++trace_line_number;
+        size_t length = (size_t)line_length;
+        if (length > 0 && trace_line[length - 1] == '\n') {
+            --length;
+        }
+        if (length > 0 && trace_line[length - 1] == '\r') {
+            --length;
+        }
+        REQUIRE(length > 0, "empty trace record");
+        if (trace_line[0] == 'I') {
+            REQUIRE(length > 1, "input record contains no JSON");
+            uint64_t sequence = UINT64_MAX;
+            EXPECT(kitu_application_submit_json(
+                       application, (const uint8_t *)trace_line + 1, length - 1,
+                       &sequence),
+                   KITU_APPLICATION_OK);
+            REQUIRE(sequence == inputs, "admission sequence is not monotonic");
+            REQUIRE(inputs < UINT64_MAX, "input counter overflow");
+            ++inputs;
+        } else if (trace_line[0] == 'T' && length == 1) {
+            size_t output_length = 0;
+            char *output = tick_and_drain(&output_length);
+            size_t state_length = 0;
+            char *state = inspect_stable(&state_length);
+            REQUIRE(output_length >= 2 && state_length >= 2,
+                    "output or state is not a serialized JSON array");
+            REQUIRE(fprintf(actual_file,
+                            "{\"tick\":%" PRIu64 ",\"output\":%s,\"state\":%s}\n",
+                            ticks, output, state) >= 0,
+                    "cannot write native observation");
+            free(output);
+            free(state);
+            REQUIRE(ticks < UINT64_MAX, "tick counter overflow");
+            ++ticks;
+        } else {
+            fail("trace records must start with I or contain exactly T",
+                 __LINE__);
+        }
+    }
+    REQUIRE(!ferror(trace_file), "error while reading trace input");
+    REQUIRE(ticks > 0, "trace did not exercise any tick");
+    REQUIRE(fflush(actual_file) == 0, "cannot flush native observations");
+    destroy_owned();
+
+    for (unsigned cycle = 0; cycle < 10; ++cycle) {
+        create_default();
+        size_t length = 0;
+        char *output = tick_and_drain(&length);
+        free(output);
+        char *state = inspect_stable(&length);
+        free(state);
+        destroy_owned();
+    }
+    REQUIRE(printf("{\"ticks\":%" PRIu64 ",\"inputs\":%" PRIu64
+                   ",\"lifetimeCycles\":10}\n",
+                   ticks, inputs) >= 0,
+            "cannot write verification summary");
+    return EXIT_SUCCESS;
+}

--- a/apps/demo-game/tests/support/mod.rs
+++ b/apps/demo-game/tests/support/mod.rs
@@ -77,12 +77,22 @@ pub fn replay_reference_observing(
 pub fn replay_reference_observing_ticks(
     name: &str,
     limit: usize,
-    mut observe: impl FnMut(&OscMessage),
-    mut on_tick: impl FnMut(&DemoRuntime, &[OscBundle]),
+    observe: impl FnMut(&OscMessage),
+    on_tick: impl FnMut(&DemoRuntime, &[OscBundle]),
 ) -> (usize, usize) {
     let directory = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../kitu-integration-runner/scenarios/arena/reference")
         .join(name);
+    replay_reference_from_directory(&directory, name, limit, observe, on_tick)
+}
+
+pub fn replay_reference_from_directory(
+    directory: &std::path::Path,
+    name: &str,
+    limit: usize,
+    mut observe: impl FnMut(&OscMessage),
+    mut on_tick: impl FnMut(&DemoRuntime, &[OscBundle]),
+) -> (usize, usize) {
     let scenario: Value =
         serde_json::from_str(&std::fs::read_to_string(directory.join("scenario.json")).unwrap())
             .unwrap();

--- a/crates/kitu-transport/Cargo.toml
+++ b/crates/kitu-transport/Cargo.toml
@@ -19,3 +19,6 @@ rmp-serde = "=1.3.1"
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
 thiserror = { workspace = true }
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/kitu-transport/README.md
+++ b/crates/kitu-transport/README.md
@@ -62,6 +62,13 @@ JSON consumers must preserve signed 64-bit integer values; converting the JSON
 through a JavaScript `Number` can lose precision. MessagePack and native Rust
 decoding retain the integer width without inference.
 
+For output serialization, `WireBundleRef::new(&bundle)` and
+`WireBundlesRef::new(&bundles)` borrow the original OSC values. They produce the
+same wire representation while validating each visited value without cloning
+messages, strings, or the complete batch. Serialize these views directly into
+a bounded writer to enforce output limits before allocating another copy of a
+large batch. On serialization failure, discard any prefix written so far.
+
 ## Publish readiness
 - Status: internal-only (`publish = false`) while the MVP takes shape; metadata now aligns with crates.io requirements.
 - Before enabling publication, run the workspace gates:

--- a/crates/kitu-transport/README.md
+++ b/crates/kitu-transport/README.md
@@ -38,6 +38,30 @@ Supported OSC packet shapes:
 Nested OSC bundles, blobs, arrays, and additional scalar tags remain unsupported
 until a concrete Kitu client or runtime path requires them.
 
+## Typed JSON, MessagePack, and FFI values
+
+`wire::{WireBundle, WireMessage, WireArg}` supplies a shared Serde representation:
+
+```json
+{"messages":[{"address":"/example/count","args":[{"type":"int64","value":1}]}]}
+```
+
+Tags `int`, `int64`, `float`, `str`, and `bool` preserve OSC scalar types. Message
+and argument order, empty bundles, and empty argument lists are retained. Unknown
+fields and unsupported argument tags are rejected. The representation has no
+nested bundles or timetags; tick scheduling belongs to the runtime envelope.
+
+Use `WireBundle::try_from(&osc_bundle)` for output and
+`OscBundle::try_from(wire_bundle)` after deserializing input. These conversions
+require finite float32 values, addresses starting with `/`, and no embedded NUL
+bytes in addresses or string arguments. Deserialization alone does not validate
+all these conditions. Adapters apply their own payload limits and application
+admission rules. Existing binary OSC helpers retain their compatibility behavior.
+
+JSON consumers must preserve signed 64-bit integer values; converting the JSON
+through a JavaScript `Number` can lose precision. MessagePack and native Rust
+decoding retain the integer width without inference.
+
 ## Publish readiness
 - Status: internal-only (`publish = false`) while the MVP takes shape; metadata now aligns with crates.io requirements.
 - Before enabling publication, run the workspace gates:

--- a/crates/kitu-transport/src/lib.rs
+++ b/crates/kitu-transport/src/lib.rs
@@ -11,7 +11,7 @@
 
 pub mod wire;
 
-pub use wire::{WireArg, WireBundle, WireMessage};
+pub use wire::{WireArg, WireBundle, WireBundleRef, WireBundlesRef, WireMessage};
 
 use std::collections::VecDeque;
 

--- a/crates/kitu-transport/src/lib.rs
+++ b/crates/kitu-transport/src/lib.rs
@@ -9,6 +9,10 @@
 //! Transports bridge OSC/IR types (`kitu-osc-ir`) with the runtime loop (`kitu-runtime`). See
 //! `doc/crates-overview.md` for adapter expectations and how events flow into ECS systems.
 
+pub mod wire;
+
+pub use wire::{WireArg, WireBundle, WireMessage};
+
 use std::collections::VecDeque;
 
 use kitu_core::{KituError, Result};

--- a/crates/kitu-transport/src/wire.rs
+++ b/crates/kitu-transport/src/wire.rs
@@ -11,7 +11,10 @@
 //! the core OSC-IR model, and unknown fields are rejected.
 
 use kitu_osc_ir::{OscArg, OscBundle, OscMessage};
-use serde::{Deserialize, Serialize};
+use serde::{
+    ser::{Error as _, SerializeSeq, SerializeStruct},
+    Deserialize, Serialize, Serializer,
+};
 
 use crate::KepCodecError;
 
@@ -76,6 +79,146 @@ pub struct WireMessage {
 pub struct WireBundle {
     /// Messages in delivery order; no flattening or sorting is performed.
     pub messages: Vec<WireMessage>,
+}
+
+/// A serialization view that borrows an OSC bundle without cloning its messages
+/// or strings.
+///
+/// The serialized representation is identical to [`WireBundle`]. Validation
+/// occurs as the serializer visits each value, so a bounded writer can stop
+/// before later messages are traversed or copied. A failed serialization may
+/// have written a prefix; callers must discard it rather than publish it.
+#[derive(Debug, Clone, Copy)]
+pub struct WireBundleRef<'a>(&'a OscBundle);
+
+impl<'a> WireBundleRef<'a> {
+    /// Borrows a bundle for streaming serialization with OSC validation.
+    ///
+    /// # Examples
+    /// ```
+    /// use kitu_osc_ir::OscBundle;
+    /// use kitu_transport::wire::WireBundleRef;
+    /// let bundle = OscBundle::new();
+    /// assert_eq!(serde_json::to_string(&WireBundleRef::new(&bundle))?,
+    ///     r#"{"messages":[]}"#);
+    /// # Ok::<(), serde_json::Error>(())
+    /// ```
+    pub fn new(bundle: &'a OscBundle) -> Self {
+        Self(bundle)
+    }
+}
+
+/// A borrowed sequence of OSC bundles serialized without an intermediate owned
+/// wire collection.
+///
+/// Bundles, messages, and arguments retain their original order. Validation and
+/// writer errors stop iteration immediately. Like [`WireBundleRef`], this view
+/// may write a prefix before reporting an error.
+#[derive(Debug, Clone, Copy)]
+pub struct WireBundlesRef<'a>(&'a [OscBundle]);
+
+impl<'a> WireBundlesRef<'a> {
+    /// Borrows an entire output batch for incremental serialization.
+    ///
+    /// # Examples
+    /// ```
+    /// use kitu_osc_ir::OscBundle;
+    /// use kitu_transport::wire::WireBundlesRef;
+    /// let bundles = [OscBundle::new()];
+    /// assert_eq!(serde_json::to_string(&WireBundlesRef::new(&bundles))?,
+    ///     r#"[{"messages":[]}]"#);
+    /// # Ok::<(), serde_json::Error>(())
+    /// ```
+    pub fn new(bundles: &'a [OscBundle]) -> Self {
+        Self(bundles)
+    }
+}
+
+impl Serialize for WireBundlesRef<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for bundle in self.0 {
+            sequence.serialize_element(&WireBundleRef::new(bundle))?;
+        }
+        sequence.end()
+    }
+}
+
+impl Serialize for WireBundleRef<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut object = serializer.serialize_struct("WireBundle", 1)?;
+        object.serialize_field("messages", &WireMessagesRef(&self.0.messages))?;
+        object.end()
+    }
+}
+
+struct WireMessagesRef<'a>(&'a [OscMessage]);
+
+impl Serialize for WireMessagesRef<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for message in self.0 {
+            sequence.serialize_element(&WireMessageRef(message))?;
+        }
+        sequence.end()
+    }
+}
+
+struct WireMessageRef<'a>(&'a OscMessage);
+
+impl Serialize for WireMessageRef<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        validate_address(&self.0.address).map_err(S::Error::custom)?;
+        let mut object = serializer.serialize_struct("WireMessage", 2)?;
+        object.serialize_field("address", &self.0.address)?;
+        object.serialize_field("args", &WireArgsRef(&self.0.args))?;
+        object.end()
+    }
+}
+
+struct WireArgsRef<'a>(&'a [OscArg]);
+
+impl Serialize for WireArgsRef<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for arg in self.0 {
+            sequence.serialize_element(&WireArgRef(arg))?;
+        }
+        sequence.end()
+    }
+}
+
+struct WireArgRef<'a>(&'a OscArg);
+
+impl Serialize for WireArgRef<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut object = serializer.serialize_struct("WireArg", 2)?;
+        match self.0 {
+            OscArg::Int(value) => {
+                object.serialize_field("type", "int")?;
+                object.serialize_field("value", value)?;
+            }
+            OscArg::Int64(value) => {
+                object.serialize_field("type", "int64")?;
+                object.serialize_field("value", value)?;
+            }
+            OscArg::Float(value) => {
+                validate_float(*value).map_err(S::Error::custom)?;
+                object.serialize_field("type", "float")?;
+                object.serialize_field("value", value)?;
+            }
+            OscArg::Str(value) => {
+                validate_string(value).map_err(S::Error::custom)?;
+                object.serialize_field("type", "str")?;
+                object.serialize_field("value", value)?;
+            }
+            OscArg::Bool(value) => {
+                object.serialize_field("type", "bool")?;
+                object.serialize_field("value", value)?;
+            }
+        }
+        object.end()
+    }
 }
 
 impl TryFrom<&OscBundle> for WireBundle {
@@ -236,6 +379,111 @@ mod tests {
             let osc = crate::encode_osc_bundle(&OscBundle::try_from(wire).unwrap()).unwrap();
             assert_exact(&crate::decode_osc_bundle(&osc).unwrap(), &bundle);
         }
+    }
+
+    #[test]
+    fn borrowed_encoding_matches_owned_json_and_messagepack_bytes() {
+        let bundles = [all_types(), OscBundle::new()];
+        for bundle in &bundles {
+            let owned = WireBundle::try_from(bundle).unwrap();
+            let borrowed = WireBundleRef::new(bundle);
+            assert_eq!(
+                serde_json::to_vec(&borrowed).unwrap(),
+                serde_json::to_vec(&owned).unwrap()
+            );
+            assert_eq!(
+                rmp_serde::to_vec_named(&borrowed).unwrap(),
+                rmp_serde::to_vec_named(&owned).unwrap()
+            );
+            assert_eq!(
+                rmp_serde::to_vec(&borrowed).unwrap(),
+                rmp_serde::to_vec(&owned).unwrap()
+            );
+        }
+        for batch in [bundles.as_slice(), &[]] {
+            let owned: Vec<_> = batch
+                .iter()
+                .map(|bundle| WireBundle::try_from(bundle).unwrap())
+                .collect();
+            let borrowed = WireBundlesRef::new(batch);
+            assert_eq!(
+                serde_json::to_vec(&borrowed).unwrap(),
+                serde_json::to_vec(&owned).unwrap()
+            );
+            assert_eq!(
+                rmp_serde::to_vec_named(&borrowed).unwrap(),
+                rmp_serde::to_vec_named(&owned).unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn borrowed_serialization_rejects_the_same_invalid_osc_values() {
+        let mut cases: Vec<_> = ["", "relative", "/a\0b"]
+            .into_iter()
+            .map(|address| OscBundle {
+                messages: vec![OscMessage::new(address)],
+            })
+            .collect();
+        for arg in [
+            OscArg::Str("a\0b".into()),
+            OscArg::Float(f32::NAN),
+            OscArg::Float(f32::INFINITY),
+            OscArg::Float(f32::NEG_INFINITY),
+        ] {
+            cases.push(OscBundle {
+                messages: vec![OscMessage {
+                    address: "/example/invalid".into(),
+                    args: vec![arg],
+                }],
+            });
+        }
+        for bundle in &cases {
+            let borrowed = WireBundleRef::new(bundle);
+            assert!(WireBundle::try_from(bundle).is_err());
+            assert!(serde_json::to_vec(&borrowed).is_err());
+            assert!(rmp_serde::to_vec_named(&borrowed).is_err());
+        }
+    }
+
+    #[test]
+    fn bounded_writer_stops_before_visiting_later_bundles() {
+        struct Budget {
+            written: usize,
+            limit: usize,
+        }
+        impl std::io::Write for Budget {
+            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+                if bytes.len() > self.limit - self.written {
+                    return Err(std::io::Error::other("test byte budget exhausted"));
+                }
+                self.written += bytes.len();
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        let bundles = [
+            OscBundle {
+                messages: vec![OscMessage {
+                    address: "/example/large".into(),
+                    args: vec![OscArg::Str("x".repeat(1024 * 1024))],
+                }],
+            },
+            // A pre-conversion of the complete batch would fail on this address
+            // before the writer's earlier byte limit could take effect.
+            OscBundle {
+                messages: vec![OscMessage::new("invalid")],
+            },
+        ];
+        let mut writer = Budget {
+            written: 0,
+            limit: 128,
+        };
+        let error = serde_json::to_writer(&mut writer, &WireBundlesRef::new(&bundles)).unwrap_err();
+        assert!(error.to_string().contains("test byte budget exhausted"));
+        assert!(writer.written <= writer.limit);
     }
 
     #[test]

--- a/crates/kitu-transport/src/wire.rs
+++ b/crates/kitu-transport/src/wire.rs
@@ -1,0 +1,333 @@
+//! Typed Serde representation of flat, immediate OSC-IR bundles.
+//!
+//! JSON, MessagePack, and native-library adapters share these data types instead
+//! of inferring OSC argument widths from the serialization format. Conversion
+//! to or from [`OscBundle`] validates OSC-safe strings and finite floats. The
+//! wire types themselves are data transfer objects: deserialization must be
+//! followed by [`OscBundle::try_from`] before admitting input to a runtime.
+//!
+//! This module does not apply application rules, schedule ticks, or impose
+//! transport-specific size limits. Nested bundles and timetags are not part of
+//! the core OSC-IR model, and unknown fields are rejected.
+
+use kitu_osc_ir::{OscArg, OscBundle, OscMessage};
+use serde::{Deserialize, Serialize};
+
+use crate::KepCodecError;
+
+/// An OSC argument whose explicit tag preserves its scalar type and width.
+///
+/// For example, `Int64(1)` serializes as `{"type":"int64","value":1}`;
+/// it remains distinct from `Int(1)` even though their numeric values match.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(
+    tag = "type",
+    content = "value",
+    rename_all = "lowercase",
+    deny_unknown_fields
+)]
+pub enum WireArg {
+    /// A signed 32-bit integer (`int`).
+    Int(i32),
+    /// A signed 64-bit integer (`int64`), including values outside JSON clients'
+    /// floating-point safe integer range.
+    Int64(i64),
+    /// A 32-bit floating-point value (`float`); conversion requires finiteness.
+    Float(f32),
+    /// A UTF-8 string (`str`); conversion rejects embedded NUL bytes.
+    Str(String),
+    /// A Boolean value (`bool`).
+    Bool(bool),
+}
+
+/// A typed OSC message with arguments in their original order.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WireMessage {
+    /// OSC address beginning with `/`, without embedded NUL bytes.
+    pub address: String,
+    /// Explicitly typed arguments, including an empty list when appropriate.
+    pub args: Vec<WireArg>,
+}
+
+/// An ordered collection of immediate OSC messages, including an empty bundle.
+///
+/// Convert through [`TryFrom`] in both directions to validate OSC-compatible
+/// values. Addresses must start with `/`; addresses and strings cannot contain
+/// NUL bytes, and floats must be finite. Application admission remains a
+/// separate concern.
+///
+/// # Examples
+///
+/// ```
+/// use kitu_osc_ir::{OscArg, OscBundle, OscMessage};
+/// use kitu_transport::wire::WireBundle;
+///
+/// let mut message = OscMessage::new("/example/count");
+/// message.push_arg(OscArg::Int64(i64::MAX));
+/// let bundle = OscBundle { messages: vec![message] };
+/// let wire = WireBundle::try_from(&bundle)?;
+/// let restored = OscBundle::try_from(wire)?;
+/// assert_eq!(restored, bundle);
+/// # Ok::<(), kitu_transport::KepCodecError>(())
+/// ```
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WireBundle {
+    /// Messages in delivery order; no flattening or sorting is performed.
+    pub messages: Vec<WireMessage>,
+}
+
+impl TryFrom<&OscBundle> for WireBundle {
+    type Error = KepCodecError;
+
+    fn try_from(bundle: &OscBundle) -> Result<Self, Self::Error> {
+        let messages = bundle
+            .messages
+            .iter()
+            .map(|message| {
+                validate_address(&message.address)?;
+                let args = message
+                    .args
+                    .iter()
+                    .map(|arg| {
+                        Ok(match arg {
+                            OscArg::Int(value) => WireArg::Int(*value),
+                            OscArg::Int64(value) => WireArg::Int64(*value),
+                            OscArg::Float(value) => {
+                                validate_float(*value)?;
+                                WireArg::Float(*value)
+                            }
+                            OscArg::Str(value) => {
+                                validate_string(value)?;
+                                WireArg::Str(value.clone())
+                            }
+                            OscArg::Bool(value) => WireArg::Bool(*value),
+                        })
+                    })
+                    .collect::<Result<_, KepCodecError>>()?;
+                Ok(WireMessage {
+                    address: message.address.clone(),
+                    args,
+                })
+            })
+            .collect::<Result<_, KepCodecError>>()?;
+        Ok(Self { messages })
+    }
+}
+
+impl TryFrom<WireBundle> for OscBundle {
+    type Error = KepCodecError;
+
+    fn try_from(bundle: WireBundle) -> Result<Self, Self::Error> {
+        let messages = bundle
+            .messages
+            .into_iter()
+            .map(|message| {
+                validate_address(&message.address)?;
+                let args = message
+                    .args
+                    .into_iter()
+                    .map(|arg| {
+                        Ok(match arg {
+                            WireArg::Int(value) => OscArg::Int(value),
+                            WireArg::Int64(value) => OscArg::Int64(value),
+                            WireArg::Float(value) => {
+                                validate_float(value)?;
+                                OscArg::Float(value)
+                            }
+                            WireArg::Str(value) => {
+                                validate_string(&value)?;
+                                OscArg::Str(value)
+                            }
+                            WireArg::Bool(value) => OscArg::Bool(value),
+                        })
+                    })
+                    .collect::<Result<_, KepCodecError>>()?;
+                Ok(OscMessage {
+                    address: message.address,
+                    args,
+                })
+            })
+            .collect::<Result<_, KepCodecError>>()?;
+        Ok(Self { messages })
+    }
+}
+
+fn validate_address(address: &str) -> Result<(), KepCodecError> {
+    if !address.starts_with('/') || address.contains('\0') {
+        return Err(KepCodecError::InvalidOsc(
+            "address must start with / and contain no NUL bytes",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_string(value: &str) -> Result<(), KepCodecError> {
+    if value.contains('\0') {
+        return Err(KepCodecError::InvalidOsc(
+            "string argument must contain no NUL bytes",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_float(value: f32) -> Result<(), KepCodecError> {
+    if !value.is_finite() {
+        return Err(KepCodecError::InvalidOsc("float argument must be finite"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn all_types() -> OscBundle {
+        OscBundle {
+            messages: vec![
+                OscMessage {
+                    address: "/example/all".into(),
+                    args: vec![
+                        OscArg::Int(i32::MIN),
+                        OscArg::Int(i32::MAX),
+                        OscArg::Int64(i64::MIN),
+                        OscArg::Int64(i64::MAX),
+                        OscArg::Int(1),
+                        OscArg::Int64(1),
+                        OscArg::Float(-0.0),
+                        OscArg::Float(f32::MAX),
+                        OscArg::Float(f32::from_bits(1)),
+                        OscArg::Str("日本語 /,\n\"".into()),
+                        OscArg::Str(String::new()),
+                        OscArg::Bool(true),
+                        OscArg::Bool(false),
+                    ],
+                },
+                OscMessage::new("/example/empty"),
+                OscMessage::new("/example/all"),
+            ],
+        }
+    }
+
+    fn assert_exact(actual: &OscBundle, expected: &OscBundle) {
+        assert_eq!(actual, expected);
+        for (actual, expected) in actual.messages.iter().zip(&expected.messages) {
+            for (actual, expected) in actual.args.iter().zip(&expected.args) {
+                if let (OscArg::Float(actual), OscArg::Float(expected)) = (actual, expected) {
+                    assert_eq!(actual.to_bits(), expected.to_bits());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn json_and_messagepack_preserve_argument_widths_float_bits_and_order() {
+        for bundle in [all_types(), OscBundle::new()] {
+            let wire = WireBundle::try_from(&bundle).unwrap();
+            let json = serde_json::to_vec(&wire).unwrap();
+            let from_json: WireBundle = serde_json::from_slice(&json).unwrap();
+            assert_exact(&OscBundle::try_from(from_json).unwrap(), &bundle);
+
+            let messagepack = rmp_serde::to_vec_named(&wire).unwrap();
+            let from_messagepack: WireBundle = rmp_serde::from_slice(&messagepack).unwrap();
+            assert_exact(&OscBundle::try_from(from_messagepack).unwrap(), &bundle);
+
+            let osc = crate::encode_osc_bundle(&OscBundle::try_from(wire).unwrap()).unwrap();
+            assert_exact(&crate::decode_osc_bundle(&osc).unwrap(), &bundle);
+        }
+    }
+
+    #[test]
+    fn explicit_wire_tags_do_not_infer_numeric_widths() {
+        let wire = WireBundle::try_from(&all_types()).unwrap();
+        let json = serde_json::to_value(wire).unwrap();
+        let args = &json["messages"][0]["args"];
+        assert_eq!(args[0]["type"], "int");
+        assert_eq!(args[2]["type"], "int64");
+        assert_eq!(args[2]["value"].as_i64(), Some(i64::MIN));
+        assert_eq!(args[3]["value"].as_i64(), Some(i64::MAX));
+        assert_eq!(args[6]["type"], "float");
+        assert_eq!(args[9]["type"], "str");
+        assert_eq!(args[11]["type"], "bool");
+    }
+
+    #[test]
+    fn malformed_unknown_and_unsupported_wire_shapes_are_rejected() {
+        for json in [
+            r#"{}"#,
+            r#"{"messages":[],"timetag":1}"#,
+            r#"{"messages":[{"address":"/a","args":[],"extra":1}]}"#,
+            r#"{"messages":[{"address":"/a"}]}"#,
+            r#"{"messages":[{"messages":[]}]}"#,
+            r#"{"messages":[{"address":"/a","args":[{"type":"int","value":1,"extra":0}]}]}"#,
+            r#"{"messages":[{"address":"/a","args":[{"type":"int","value":2147483648}]}]}"#,
+            r#"{"messages":[{"address":"/a","args":[{"type":"int64","value":9223372036854775808}]}]}"#,
+            r#"{"messages":[{"address":"/a","args":[{"type":"float","value":null}]}]}"#,
+            r#"{"messages":[{"address":"/a","args":[{"type":"bool","value":1}]}]}"#,
+            r#"{"messages":[{"address":"/a","args":[{"type":"blob","value":[]}]}]}"#,
+            r#"{"messages":[{"address":"/a","args":[{"value":1}]}]}"#,
+        ] {
+            assert!(serde_json::from_str::<WireBundle>(json).is_err(), "{json}");
+        }
+    }
+
+    #[test]
+    fn invalid_addresses_and_nul_strings_fail_in_both_directions() {
+        let valid = WireBundle {
+            messages: vec![WireMessage {
+                address: "/example/check".into(),
+                args: Vec::new(),
+            }],
+        };
+        for address in ["", "relative", "#bundle", "/a\0b"] {
+            let mut wire = valid.clone();
+            wire.messages[0].address = address.into();
+            assert!(OscBundle::try_from(wire).is_err());
+            let raw = OscBundle {
+                messages: vec![OscMessage::new(address)],
+            };
+            assert!(WireBundle::try_from(&raw).is_err());
+        }
+
+        let mut wire = valid;
+        wire.messages[0].args.push(WireArg::Str("a\0b".into()));
+        assert!(OscBundle::try_from(wire).is_err());
+        let mut raw = OscBundle::new();
+        let mut message = OscMessage::new("/example/check");
+        message.push_arg(OscArg::Str("a\0b".into()));
+        raw.push(message);
+        assert!(WireBundle::try_from(&raw).is_err());
+    }
+
+    #[test]
+    fn nonfinite_floats_fail_before_runtime_admission_or_output_encoding() {
+        for value in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let wire = WireBundle {
+                messages: vec![WireMessage {
+                    address: "/example/check".into(),
+                    args: vec![WireArg::Float(value)],
+                }],
+            };
+            // MessagePack can carry nonfinite floats, so Serde alone is not
+            // sufficient validation of an incoming bundle.
+            let bytes = rmp_serde::to_vec_named(&wire).unwrap();
+            let decoded: WireBundle = rmp_serde::from_slice(&bytes).unwrap();
+            assert!(OscBundle::try_from(decoded).is_err());
+            let raw = OscBundle {
+                messages: vec![OscMessage {
+                    address: "/example/check".into(),
+                    args: vec![OscArg::Float(value)],
+                }],
+            };
+            assert!(WireBundle::try_from(&raw).is_err());
+        }
+
+        let oversized = r#"{"messages":[{"address":"/a","args":[{"type":"float","value":1e39}]}]}"#;
+        // Depending on the deserializer, a finite JSON number outside f32's
+        // range can fail decoding or become infinity. Neither may be admitted.
+        if let Ok(wire) = serde_json::from_str::<WireBundle>(oversized) {
+            assert!(OscBundle::try_from(wire).is_err());
+        }
+    }
+}

--- a/crates/kitu-unity-ffi/Cargo.toml
+++ b/crates/kitu-unity-ffi/Cargo.toml
@@ -9,10 +9,12 @@ repository = "https://github.com/Nagitch/kitu-logic-processor"
 readme = "README.md"
 keywords = ["kitu", "unity", "ffi"]
 categories = ["api-bindings", "game-development"]
-include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
+include = ["src/**", "include/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 kitu-core = { path = "../kitu-core" }
 kitu-osc-ir = { path = "../kitu-osc-ir" }
 kitu-runtime = { path = "../kitu-runtime" }
 kitu-transport = { path = "../kitu-transport" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/kitu-unity-ffi/README.md
+++ b/crates/kitu-unity-ffi/README.md
@@ -7,13 +7,83 @@ C ABI bindings that expose the Kitu runtime to Unity hosts.
 - Provide a stable ABI surface appropriate for a `cdylib` target.
 - Keep Unity-facing details isolated from core runtime logic.
 
-## Current MVP surface
+## Full application ABI
+
+The `application` module provides an application-independent C boundary. Each
+application owns its native library and exports the thin wrappers declared in
+[`include/kitu_application.h`](include/kitu_application.h). Its factory installs
+the same rules used by its server, using `RuntimeDriver` for an ordinary
+`Runtime<LocalChannel>` or `ApplicationDriver` for an application-owned host.
+This crate does not depend on Endless Arena or any other application.
+
+- `kitu_application_abi_version` and `kitu_application_create` negotiate ABI 1 and
+  construct a run. Configuration is application-owned; an empty buffer can select
+  that application's defaults. Creation failures return diagnostics without a handle.
+- `kitu_application_submit_json` validates and admits one ordered OSC bundle with
+  optional producer metadata. Queue admission and application acceptance are
+  separate: the next authoritative tick emits the application command receipt.
+- `kitu_application_tick` advances exactly one management tick. The embedding host
+  schedules the application's agreed tick rate independently of input/render frequency.
+- `kitu_application_read_output` drains a complete tick's ordered bundle array.
+- `kitu_application_inspect_json` copies a detached projection without changing state.
+- `kitu_application_last_error` exposes failure diagnostics;
+  `kitu_application_destroy` releases the run on its creating thread.
+
+Typed JSON uses the shared `kitu-transport::wire` representation, preserving i32,
+i64, finite f32, string and boolean types and bundle/message/argument order:
+
+```json
+{
+  "metadata": { "source": "unity", "messageId": 1, "schemaVersion": 1 },
+  "bundle": {
+    "messages": [{ "address": "/input/arena/start", "args": [] }]
+  }
+}
+```
+
+Unknown fields are rejected. Metadata, when present, requires a producer of
+1–128 UTF-8 bytes without NUL, a positive message ID, and a positive application
+schema version. The application enforces its actual contract version and input
+requirements. Legacy `/input/move` can omit metadata and keeps its delta meaning.
+
+### Ownership and failure contract
+
+All calls on a handle are sequential on its creating thread, including destruction.
+Wrong-thread calls refuse without changing the run. Do not share buffers or call
+concurrently. The caller owns all byte buffers; Rust borrows them only for the
+duration of the call. No cross-allocator free operation exists.
+
+Buffers carry explicit byte lengths with no NUL terminator. A null pointer with
+capacity zero queries the exact required size. Short buffers get no partial copy
+and do not consume output. Required-length pointers must be valid and writable.
+One successful output read consumes the whole batch; subsequent reads return
+`EMPTY`. Every tick produces a batch, including `[]`; another tick returns
+`PENDING_OUTPUT` until the previous batch is consumed. Inspection does not consume
+output and may run before or after reads. Invalid output arguments never advance
+the application or discard its pending batch.
+
+Each input/configuration is limited to 1 MiB, with at most 4096 queued requests and
+16 MiB of input JSON before a tick. Output/inspection JSON is limited to 64 MiB.
+The boundary retains at most one output batch. These limits bound boundary-owned
+buffers; the application is still responsible for bounding its internal state.
+
+The library must use panic unwinding. Panics never cross the boundary; a caught
+driver panic or failed/unencodable tick permanently disables its handle because
+state may already have advanced. Only diagnosis and destruction remain available.
+An input rejection leaves the handle usable; a custom driver must validate before
+mutating its queue. Allocation failure/process abort cannot be recovered by the ABI.
+Invalid/dangling memory, aliasing, concurrent calls, double destruction and unloading
+the library with live handles remain caller violations.
+
+## Legacy movement surface
 - `kitu_init` creates a runtime handle for an embedding host.
 - `kitu_submit_move_input` submits one `/input/move` intent into runtime-owned processing.
 - `kitu_tick` advances the runtime by one authoritative tick.
 - `kitu_pop_render_transform` drains one `/render/player/transform` event for presentation consumers.
 
-The crate intentionally keeps gameplay rules inside `kitu-runtime`; this boundary only translates host calls into runtime input/output.
+This original movement API remains available for compatibility. New complete
+applications use the versioned application API above; game rules stay in their
+application crate and are executed by `kitu-runtime`.
 
 ## Publish readiness
 - Status: internal (`publish = false`), but metadata and README prepare the crate for crates.io packaging.

--- a/crates/kitu-unity-ffi/include/kitu_application.h
+++ b/crates/kitu-unity-ffi/include/kitu_application.h
@@ -1,0 +1,127 @@
+#ifndef KITU_APPLICATION_H
+#define KITU_APPLICATION_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Opaque, application-owned allocation. Never dereference or free() this pointer. */
+typedef struct KituApplication KituApplication;
+
+#define KITU_APPLICATION_ABI_VERSION UINT32_C(1)
+#define KITU_APPLICATION_OK INT32_C(0)
+#define KITU_APPLICATION_EMPTY INT32_C(1)
+#define KITU_APPLICATION_BUFFER_TOO_SMALL INT32_C(2)
+#define KITU_APPLICATION_INVALID_ARGUMENT (-INT32_C(1))
+#define KITU_APPLICATION_INVALID_INPUT (-INT32_C(2))
+#define KITU_APPLICATION_WRONG_THREAD (-INT32_C(3))
+#define KITU_APPLICATION_PENDING_OUTPUT (-INT32_C(4))
+#define KITU_APPLICATION_FAILED (-INT32_C(5))
+#define KITU_APPLICATION_PANIC (-INT32_C(6))
+#define KITU_APPLICATION_QUEUE_FULL (-INT32_C(7))
+#define KITU_APPLICATION_DRIVER_ERROR (-INT32_C(8))
+#define KITU_APPLICATION_ABI_MISMATCH (-INT32_C(9))
+
+#define KITU_APPLICATION_MAX_INPUT_BYTES ((size_t)1048576)
+#define KITU_APPLICATION_MAX_PENDING_INPUTS ((size_t)4096)
+#define KITU_APPLICATION_MAX_PENDING_INPUT_BYTES ((size_t)16777216)
+#define KITU_APPLICATION_MAX_OUTPUT_BYTES ((size_t)67108864)
+
+/*
+ * Every operation on a handle, including destroy, must be sequential on the
+ * creating thread. Callers must not concurrently access a handle or its buffers.
+ * Pointers must be valid/aligned for their complete lengths, and must not alias
+ * the handle or another input/output argument. Dangling pointers, double destroy,
+ * and invalid memory remain caller errors; this API cannot validate addresses.
+ *
+ * All byte buffers belong to the caller and are borrowed only during a call.
+ * Text is UTF-8 with an explicit byte length, never a trailing NUL requirement.
+ * NULL byte buffers are valid only with zero length/capacity. Required-length
+ * pointers are mandatory. A short buffer receives no partial bytes and the
+ * exact required length is returned. Input JSON/configuration is limited to
+ * MAX_INPUT_BYTES; configuration schema belongs to the application factory.
+ */
+uint32_t kitu_application_abi_version(void);
+
+/*
+ * Creates exclusively owned application state. NULL config with length zero
+ * requests the application's defaults, when supported by its factory.
+ * On failure, *out_handle is NULL and no handle ownership is transferred.
+ * Creation errors are written only if the entire diagnostic fits error_capacity;
+ * *out_error_required always reports its complete size. The original error
+ * status is preserved for a short diagnostic buffer. Repeat only FAILED creation
+ * to retrieve a longer diagnostic; repeating success would create a second run.
+ * The application library must be built with panic unwinding to catch Rust panics.
+ */
+int32_t kitu_application_create(
+    uint32_t requested_abi,
+    const uint8_t *config,
+    size_t config_length,
+    KituApplication **out_handle,
+    uint8_t *error_buffer,
+    size_t error_capacity,
+    size_t *out_error_required);
+
+/* OK or PANIC consumes ownership. Other statuses leave ownership with the caller. */
+int32_t kitu_application_destroy(KituApplication *handle);
+
+/*
+ * Queues one InputRequest JSON: {"metadata":optional_metadata,"bundle":bundle}.
+ * Metadata: {"source":"producer","messageId":1,"schemaVersion":1}.
+ * Bundle: {"messages":[{"address":"/input/...","args":[{"type":"int","value":1}]}]}.
+ * Argument types: int (i32), int64 (i64), float (finite f32), str (UTF-8), bool.
+ * Unknown JSON fields are rejected. OSC messages/args retain their order.
+ * Metadata requires source 1..128 UTF-8 bytes without NUL and positive IDs/version.
+ * Application validation determines whether metadata is required and which schema
+ * and addresses it supports. OK writes admission order to *out_sequence; an error
+ * leaves it unchanged. Admission does not mean application acceptance: consume
+ * the later tick's command receipt for success/refusal at the authoritative tick.
+ */
+int32_t kitu_application_submit_json(
+    KituApplication *handle,
+    const uint8_t *input,
+    size_t input_length,
+    uint64_t *out_sequence);
+
+/*
+ * Advances exactly one management tick. The caller schedules the agreed tick rate
+ * independently of input submission and rendering; the library starts no timer.
+ * PENDING_OUTPUT refuses before advancing. Even [] is a batch requiring a read.
+ * A driver/encoding error or panic during ticking permanently disables the handle.
+ * After failure only last_error and destroy are permitted.
+ */
+int32_t kitu_application_tick(KituApplication *handle);
+
+/*
+ * Reads one complete JSON array of typed OSC bundles. OK consumes the whole batch.
+ * BUFFER_TOO_SMALL/invalid arguments retain it. NULL buffer/capacity 0 queries
+ * size. EMPTY reports required length 0 after consumption or before the first tick.
+ */
+int32_t kitu_application_read_output(
+    KituApplication *handle,
+    uint8_t *buffer,
+    size_t capacity,
+    size_t *out_required);
+
+/* Nonmutating projection, same JSON array shape; no output is consumed. */
+int32_t kitu_application_inspect_json(
+    KituApplication *handle,
+    uint8_t *buffer,
+    size_t capacity,
+    size_t *out_required);
+
+/* Persistent last UTF-8 diagnostic, including on a failed handle. Initially empty. */
+int32_t kitu_application_last_error(
+    KituApplication *handle,
+    uint8_t *buffer,
+    size_t capacity,
+    size_t *out_required);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* KITU_APPLICATION_H */

--- a/crates/kitu-unity-ffi/src/application.rs
+++ b/crates/kitu-unity-ffi/src/application.rs
@@ -36,7 +36,10 @@ use std::{
 
 use kitu_osc_ir::OscBundle;
 use kitu_runtime::{InputMetadata, Runtime};
-use kitu_transport::{wire::WireBundle, LocalChannel};
+use kitu_transport::{
+    wire::{WireBundle, WireBundlesRef},
+    LocalChannel,
+};
 use serde::{Deserialize, Serialize};
 
 /// C ABI version; application contract versions are carried separately in metadata.
@@ -537,13 +540,9 @@ unsafe fn copy_bytes(bytes: &[u8], buffer: *mut u8, capacity: usize, required: *
 }
 
 fn encode_bundles(bundles: Vec<OscBundle>) -> Result<Vec<u8>, String> {
-    let wire: Vec<WireBundle> = bundles
-        .iter()
-        .map(WireBundle::try_from)
-        .collect::<Result<_, _>>()
-        .map_err(|error| error.to_string())?;
     let mut writer = LimitedBuffer(Vec::new());
-    serde_json::to_writer(&mut writer, &wire).map_err(|error| error.to_string())?;
+    serde_json::to_writer(&mut writer, &WireBundlesRef::new(&bundles))
+        .map_err(|error| error.to_string())?;
     Ok(writer.0)
 }
 
@@ -553,6 +552,17 @@ impl Write for LimitedBuffer {
     fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
         if bytes.len() > MAX_OUTPUT_BYTES - self.0.len() {
             return Err(io::Error::other("output exceeds 64 MiB ABI limit"));
+        }
+        let required = self.0.len() + bytes.len();
+        if required > self.0.capacity() {
+            // Preserve amortized growth without allowing Vec's next doubling
+            // to reserve beyond the output limit before serialization stops.
+            let capacity = required
+                .max(self.0.capacity().max(256) * 2)
+                .min(MAX_OUTPUT_BYTES);
+            self.0
+                .try_reserve_exact(capacity - self.0.len())
+                .map_err(io::Error::other)?;
         }
         self.0.extend_from_slice(bytes);
         Ok(bytes.len())
@@ -1109,6 +1119,96 @@ mod tests {
             );
             assert!(output.is_null());
             assert!(required > 0);
+        }
+    }
+
+    fn string_batch(length: usize) -> Vec<OscBundle> {
+        vec![OscBundle {
+            messages: vec![OscMessage {
+                address: "/test/large".into(),
+                args: vec![OscArg::Str("x".repeat(length))],
+            }],
+        }]
+    }
+
+    #[test]
+    fn output_limit_uses_exact_encoded_bytes_and_stops_before_later_values() {
+        let overhead = encode_bundles(string_batch(0)).unwrap().len();
+        assert_eq!(
+            encode_bundles(string_batch(MAX_OUTPUT_BYTES - overhead))
+                .unwrap()
+                .len(),
+            MAX_OUTPUT_BYTES,
+            "an exactly fitting batch must not be rejected by a size estimate"
+        );
+        let mut bundles = string_batch(MAX_OUTPUT_BYTES + 1);
+        bundles.push(OscBundle {
+            messages: vec![OscMessage::new("invalid")],
+        });
+        let error = encode_bundles(bundles).unwrap_err();
+        assert!(
+            error.contains("output exceeds 64 MiB ABI limit"),
+            "the writer must stop on the first oversized string before any \
+             conversion of later bundles: {error}"
+        );
+
+        // A normal doubling from half the maximum plus one would reserve more
+        // than the limit when the remaining, still valid bytes are written.
+        let bytes = vec![b'x'; MAX_OUTPUT_BYTES];
+        let mut writer = LimitedBuffer(Vec::new());
+        let split = MAX_OUTPUT_BYTES / 2 + 1;
+        writer.write_all(&bytes[..split]).unwrap();
+        writer.write_all(&bytes[split..]).unwrap();
+        assert_eq!(writer.0.len(), MAX_OUTPUT_BYTES);
+        assert!(writer.0.capacity() <= MAX_OUTPUT_BYTES);
+        assert!(writer.write_all(b"x").is_err());
+        assert_eq!(writer.0.len(), MAX_OUTPUT_BYTES);
+    }
+
+    #[test]
+    fn oversized_inspection_is_recoverable_but_a_tick_batch_failure_poisons() {
+        struct LargeOutput {
+            ticks: Arc<AtomicUsize>,
+        }
+        impl ApplicationDriver for LargeOutput {
+            fn submit(&mut self, _: OscBundle, _: Option<InputMetadata>) -> Result<u64, String> {
+                Ok(0)
+            }
+            fn tick(&mut self) -> Result<Vec<OscBundle>, String> {
+                self.ticks.fetch_add(1, Ordering::SeqCst);
+                Ok(string_batch(MAX_OUTPUT_BYTES + 1))
+            }
+            fn inspect(&self) -> Result<Vec<OscBundle>, String> {
+                Ok(string_batch(MAX_OUTPUT_BYTES + 1))
+            }
+        }
+        unsafe {
+            let ticks = Arc::new(AtomicUsize::new(0));
+            let handle = Box::into_raw(Box::new(ApplicationHandle::new(Box::new(LargeOutput {
+                ticks: Arc::clone(&ticks),
+            }))));
+            let mut required = 99;
+            assert_eq!(
+                inspect_json(handle, ptr::null_mut(), 0, &mut required),
+                DRIVER_ERROR
+            );
+            assert_eq!(ticks.load(Ordering::SeqCst), 0);
+            assert!(String::from_utf8(read(handle, last_error))
+                .unwrap()
+                .contains("output exceeds 64 MiB ABI limit"));
+            assert_eq!(tick(handle), DRIVER_ERROR);
+            assert_eq!(ticks.load(Ordering::SeqCst), 1);
+            assert_eq!(tick(handle), FAILED);
+            assert_eq!(ticks.load(Ordering::SeqCst), 1);
+            assert_eq!(
+                read_output(handle, ptr::null_mut(), 0, &mut required),
+                FAILED,
+                "no partial serialization may escape from a failed tick"
+            );
+            assert!(String::from_utf8(read(handle, last_error))
+                .unwrap()
+                .contains("output exceeds 64 MiB ABI limit"));
+            assert_eq!(destroy(handle), OK);
         }
     }
 }

--- a/crates/kitu-unity-ffi/src/application.rs
+++ b/crates/kitu-unity-ffi/src/application.rs
@@ -1,0 +1,1114 @@
+//! Full-application, thread-affine C ABI helpers for application-owned libraries.
+//!
+//! Applications export thin `extern "C"` wrappers using `include/kitu_application.h`.
+//! Their factory installs the same application used by the server; this crate has
+//! no game dependency. Typed JSON preserves OSC widths, bundle and message order.
+//! A successful submit acknowledges admission. Application acceptance or refusal
+//! is a later output from the ordinary authoritative tick.
+//!
+//! # Examples
+//! ```
+//! use kitu_runtime::build_runtime;
+//! use kitu_transport::LocalChannel;
+//! use kitu_unity_ffi::application::{self, ApplicationHandle, RuntimeDriver};
+//! let runtime = build_runtime(LocalChannel::connected());
+//! let handle = Box::into_raw(Box::new(ApplicationHandle::new(Box::new(
+//!     RuntimeDriver::new(runtime),
+//! ))));
+//! unsafe {
+//!     assert_eq!(application::tick(handle), application::OK);
+//!     let mut required = 0;
+//!     assert_eq!(application::read_output(handle, std::ptr::null_mut(), 0, &mut required),
+//!         application::BUFFER_TOO_SMALL);
+//!     let mut bytes = vec![0; required];
+//!     assert_eq!(application::read_output(handle, bytes.as_mut_ptr(), bytes.len(), &mut required),
+//!         application::OK);
+//!     assert_eq!(application::destroy(handle), application::OK);
+//! }
+//! ```
+
+use std::{
+    io::{self, Write},
+    panic::{catch_unwind, AssertUnwindSafe},
+    ptr,
+    thread::{self, ThreadId},
+};
+
+use kitu_osc_ir::OscBundle;
+use kitu_runtime::{InputMetadata, Runtime};
+use kitu_transport::{wire::WireBundle, LocalChannel};
+use serde::{Deserialize, Serialize};
+
+/// C ABI version; application contract versions are carried separately in metadata.
+pub const ABI_VERSION: u32 = 1;
+/// The operation completed; submission means queued, not application acceptance.
+pub const OK: i32 = 0;
+/// No pending output batch exists.
+pub const EMPTY: i32 = 1;
+/// The required length was returned and no bytes or output ownership changed.
+pub const BUFFER_TOO_SMALL: i32 = 2;
+/// A required pointer or pointer/length combination was invalid.
+pub const INVALID_ARGUMENT: i32 = -1;
+/// Input JSON, metadata or typed OSC was invalid.
+pub const INVALID_INPUT: i32 = -2;
+/// This call came from a thread other than the handle's creating thread.
+pub const WRONG_THREAD: i32 = -3;
+/// Read the previous tick's complete output batch before advancing again.
+pub const PENDING_OUTPUT: i32 = -4;
+/// A previous panic or failed tick permanently disabled this handle.
+pub const FAILED: i32 = -5;
+/// A Rust panic was caught; the existing handle is permanently disabled.
+pub const PANIC: i32 = -6;
+/// The per-tick request count or serialized input byte budget was exhausted.
+pub const QUEUE_FULL: i32 = -7;
+/// The application driver rejected the request or could not complete the operation.
+pub const DRIVER_ERROR: i32 = -8;
+/// The caller requested an unsupported C ABI version.
+pub const ABI_MISMATCH: i32 = -9;
+
+/// Maximum bytes in one submitted JSON request or factory configuration (1 MiB).
+pub const MAX_INPUT_BYTES: usize = 1024 * 1024;
+/// Maximum requests admitted between successful ticks.
+pub const MAX_PENDING_INPUTS: usize = 4096;
+/// Maximum cumulative JSON request bytes admitted between ticks (16 MiB).
+pub const MAX_PENDING_INPUT_BYTES: usize = 16 * 1024 * 1024;
+/// Maximum serialized output or inspection batch (64 MiB).
+pub const MAX_OUTPUT_BYTES: usize = 64 * 1024 * 1024;
+
+/// A host-independent application interface, invoked exclusively by its owner thread.
+///
+/// Drivers must use the application's normal ordered input queue and tick path.
+/// They must not create a competing timer or execute inputs during submission.
+/// Driver panics are caught at the ABI boundary. An error from `tick` is fatal
+/// because a driver may already have partially advanced.
+pub trait ApplicationDriver: Send {
+    /// Validates and queues one bundle, returning its authoritative admission order.
+    ///
+    /// On error, the driver must leave its input queue and state unchanged.
+    fn submit(&mut self, bundle: OscBundle, metadata: Option<InputMetadata>)
+        -> Result<u64, String>;
+
+    /// Advances exactly one management tick and returns all outputs in emission order.
+    fn tick(&mut self) -> Result<Vec<OscBundle>, String>;
+
+    /// Returns a detached application projection without advancing or mutating state.
+    fn inspect(&self) -> Result<Vec<OscBundle>, String>;
+}
+
+/// An adapter around an ordinary local runtime with an application installed by its owner.
+pub struct RuntimeDriver {
+    runtime: Runtime<LocalChannel>,
+}
+
+impl RuntimeDriver {
+    /// Takes exclusive ownership of a runtime; no second tick loop is started.
+    ///
+    /// # Examples
+    /// ```
+    /// use kitu_runtime::build_runtime;
+    /// use kitu_transport::LocalChannel;
+    /// use kitu_unity_ffi::application::{ApplicationDriver, RuntimeDriver};
+    /// let mut driver = RuntimeDriver::new(build_runtime(LocalChannel::connected()));
+    /// driver.tick().unwrap();
+    /// assert!(driver.inspect().unwrap().is_empty());
+    /// ```
+    pub fn new(runtime: Runtime<LocalChannel>) -> Self {
+        Self { runtime }
+    }
+}
+
+impl ApplicationDriver for RuntimeDriver {
+    fn submit(
+        &mut self,
+        bundle: OscBundle,
+        metadata: Option<InputMetadata>,
+    ) -> Result<u64, String> {
+        self.runtime
+            .try_enqueue_input(bundle, metadata)
+            .map_err(|error| error.to_string())
+    }
+
+    fn tick(&mut self) -> Result<Vec<OscBundle>, String> {
+        self.runtime
+            .tick_once()
+            .map_err(|error| error.to_string())?;
+        let output = self.runtime.drain_output_buffer();
+        self.runtime.drain_committed_inputs();
+        Ok(output)
+    }
+
+    fn inspect(&self) -> Result<Vec<OscBundle>, String> {
+        Ok(self.runtime.inspect_application())
+    }
+}
+
+/// Typed JSON request accepted by [`submit_json`]. Unknown fields are rejected.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct InputRequest {
+    /// Producer identity and application contract version; legacy inputs may omit it.
+    pub metadata: Option<InputMetadata>,
+    /// Ordered OSC messages and explicitly typed arguments.
+    pub bundle: WireBundle,
+}
+
+/// Opaque C handle; its layout and Rust allocations are never exposed to the caller.
+///
+/// All calls, including destruction, must be sequential on the creating thread.
+/// Callers own all byte buffers. No Rust allocation must be freed by another
+/// allocator. The only transfer of ownership is `create_json` / `destroy`.
+pub struct ApplicationHandle {
+    driver: Box<dyn ApplicationDriver>,
+    owner: ThreadId,
+    pending_output: Option<Vec<u8>>,
+    pending_inputs: usize,
+    pending_input_bytes: usize,
+    last_error: String,
+    failed: bool,
+}
+
+impl ApplicationHandle {
+    /// Wraps an application driver and binds all future calls to this thread.
+    ///
+    /// See the module example for converting this value to an opaque pointer.
+    pub fn new(driver: Box<dyn ApplicationDriver>) -> Self {
+        Self {
+            driver,
+            owner: thread::current().id(),
+            pending_output: None,
+            pending_inputs: 0,
+            pending_input_bytes: 0,
+            last_error: String::new(),
+            failed: false,
+        }
+    }
+
+    fn error(&mut self, status: i32, message: impl Into<String>) -> i32 {
+        self.last_error = message.into();
+        status
+    }
+}
+
+/// Creates a handle through an application-owned factory with bounded configuration.
+///
+/// `out_handle` is cleared before invoking the factory and remains null on every
+/// failure. An empty configuration is legal; the factory defines its meaning.
+/// Failure diagnostics use caller-owned storage: `out_error_required` always
+/// receives the full UTF-8 byte count, and bytes are written only when they all
+/// fit. The original error status is preserved when that buffer is too small.
+/// Repeating failed creation with a larger buffer creates no duplicate handle.
+///
+/// # Safety
+/// Pointer/length pairs must refer to readable configuration and writable output
+/// storage for their complete stated lengths. Null byte pointers require zero
+/// length/capacity. `out_handle` and `out_error_required` must be valid, aligned,
+/// writable pointers. All referenced storage must be disjoint and remain valid
+/// until this call returns. The factory must return exclusively owned state.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn create_json(
+    requested_abi: u32,
+    config: *const u8,
+    config_length: usize,
+    out_handle: *mut *mut ApplicationHandle,
+    error_buffer: *mut u8,
+    error_capacity: usize,
+    out_error_required: *mut usize,
+    factory: impl FnOnce(&[u8]) -> Result<Box<dyn ApplicationDriver>, String>,
+) -> i32 {
+    let diagnostic_valid = valid_destination(error_buffer, error_capacity, out_error_required);
+    if !out_handle.is_null() {
+        ptr::write(out_handle, ptr::null_mut());
+    }
+    if diagnostic_valid {
+        ptr::write(out_error_required, 0);
+    }
+    let outcome = catch_unwind(AssertUnwindSafe(move || {
+        // Keep the factory's captured values inside the unwind boundary even
+        // when invalid arguments prevent invoking it: their Drop may panic.
+        if out_handle.is_null() || !diagnostic_valid {
+            return Err((
+                INVALID_ARGUMENT,
+                "invalid creation output pointers".to_string(),
+            ));
+        }
+        if requested_abi != ABI_VERSION {
+            return Err((ABI_MISMATCH, "unsupported C ABI version".to_string()));
+        }
+        let config = checked_bytes(config, config_length).map_err(|status| {
+            (
+                status,
+                "invalid configuration pointer or length".to_string(),
+            )
+        })?;
+        let driver = factory(config).map_err(|message| (DRIVER_ERROR, message))?;
+        Ok(Box::into_raw(Box::new(ApplicationHandle::new(driver))))
+    }));
+    match outcome {
+        Ok(Ok(handle)) => {
+            ptr::write(out_handle, handle);
+            OK
+        }
+        Ok(Err((status, message))) => {
+            if diagnostic_valid {
+                copy_bytes(
+                    message.as_bytes(),
+                    error_buffer,
+                    error_capacity,
+                    out_error_required,
+                );
+            }
+            status
+        }
+        Err(payload) => {
+            // A user-provided panic payload may itself panic during Drop.
+            std::mem::forget(payload);
+            if diagnostic_valid {
+                copy_bytes(
+                    b"application factory panicked",
+                    error_buffer,
+                    error_capacity,
+                    out_error_required,
+                );
+            }
+            PANIC
+        }
+    }
+}
+
+/// Destroys exactly one owned handle; null is invalid and double destruction is UB.
+///
+/// A failed handle can still be destroyed on its owner thread. A caught destructor
+/// panic returns [`PANIC`], but ownership is consumed in that case too.
+///
+/// # Safety
+/// `handle` must be null or a live pointer returned by `create_json` (or an owned
+/// `Box<ApplicationHandle>` converted with `Box::into_raw`). No other call may
+/// overlap. Never use the pointer again after this returns `OK` or `PANIC`.
+pub unsafe fn destroy(handle: *mut ApplicationHandle) -> i32 {
+    let Some(reference) = handle.as_ref() else {
+        return INVALID_ARGUMENT;
+    };
+    if reference.owner != thread::current().id() {
+        return WRONG_THREAD;
+    }
+    match catch_unwind(AssertUnwindSafe(|| drop(Box::from_raw(handle)))) {
+        Ok(()) => OK,
+        Err(payload) => {
+            std::mem::forget(payload);
+            PANIC
+        }
+    }
+}
+
+/// Admits typed JSON to the next tick's ordered queue and writes its sequence.
+///
+/// Validating arguments, JSON and metadata precedes driver submission. Queued
+/// inputs are limited by [`MAX_PENDING_INPUTS`] and [`MAX_PENDING_INPUT_BYTES`].
+/// Refusal leaves `out_sequence` unchanged. Application acceptance is reported
+/// by a later output receipt, not by this function's admission status.
+///
+/// # Safety
+/// The handle must satisfy [`destroy`]'s live, exclusive ownership requirements.
+/// `input` must reference `length` readable bytes (null only when length is zero).
+/// `out_sequence` must be aligned and writable. Storage must be disjoint from
+/// the handle and input, with no concurrent access until this call returns.
+pub unsafe fn submit_json(
+    handle: *mut ApplicationHandle,
+    input: *const u8,
+    length: usize,
+    out_sequence: *mut u64,
+) -> i32 {
+    with_handle(handle, false, |handle| {
+        if out_sequence.is_null() {
+            return handle.error(INVALID_ARGUMENT, "out_sequence must not be null");
+        }
+        let bytes = match checked_bytes(input, length) {
+            Ok(bytes) => bytes,
+            Err(status) => return handle.error(status, "invalid input pointer or length"),
+        };
+        if handle.pending_inputs >= MAX_PENDING_INPUTS
+            || length > MAX_PENDING_INPUT_BYTES - handle.pending_input_bytes
+        {
+            return handle.error(QUEUE_FULL, "pending input budget exhausted; advance a tick");
+        }
+        let request: InputRequest = match serde_json::from_slice(bytes) {
+            Ok(request) => request,
+            Err(error) => {
+                return handle.error(INVALID_INPUT, format!("invalid input JSON: {error}"))
+            }
+        };
+        if let Some(metadata) = &request.metadata {
+            if metadata.source.is_empty()
+                || metadata.source.len() > 128
+                || metadata.source.contains('\0')
+                || metadata.message_id == 0
+                || metadata.schema_version == 0
+            {
+                return handle.error(INVALID_INPUT, "metadata requires source 1..128 bytes without NUL, positive messageId and schemaVersion");
+            }
+        }
+        let bundle = match OscBundle::try_from(request.bundle) {
+            Ok(bundle) => bundle,
+            Err(error) => return handle.error(INVALID_INPUT, error.to_string()),
+        };
+        match handle.driver.submit(bundle, request.metadata) {
+            Ok(sequence) => {
+                handle.pending_inputs += 1;
+                handle.pending_input_bytes += length;
+                ptr::write(out_sequence, sequence);
+                OK
+            }
+            Err(message) => handle.error(DRIVER_ERROR, message),
+        }
+    })
+}
+
+/// Advances exactly one application tick, retaining one complete JSON output batch.
+///
+/// A pending batch causes [`PENDING_OUTPUT`] before any state change. A tick with
+/// no events still produces `[]`, which must be drained. Driver or encoding
+/// errors permanently disable the handle because the tick may have advanced.
+///
+/// # Safety
+/// The handle must satisfy [`destroy`]'s live, exclusive ownership requirements.
+pub unsafe fn tick(handle: *mut ApplicationHandle) -> i32 {
+    with_handle(handle, false, |handle| {
+        if handle.pending_output.is_some() {
+            return handle.error(
+                PENDING_OUTPUT,
+                "read the previous tick output before advancing",
+            );
+        }
+        let result = handle.driver.tick().and_then(encode_bundles);
+        match result {
+            Ok(bytes) => {
+                handle.pending_output = Some(bytes);
+                handle.pending_inputs = 0;
+                handle.pending_input_bytes = 0;
+                OK
+            }
+            Err(message) => {
+                handle.failed = true;
+                handle.error(DRIVER_ERROR, message)
+            }
+        }
+    })
+}
+
+/// Reads and consumes one whole tick batch after a successful complete copy.
+///
+/// A zero-capacity query or short buffer returns [`BUFFER_TOO_SMALL`] and retains
+/// every byte. `out_required` receives the exact count, excluding any NUL byte.
+/// After consumption a repeated read returns [`EMPTY`] with length zero.
+///
+/// # Safety
+/// The handle must satisfy [`destroy`]'s live, exclusive ownership requirements.
+/// The destination must satisfy [`inspect_json`]'s output-buffer requirements.
+pub unsafe fn read_output(
+    handle: *mut ApplicationHandle,
+    buffer: *mut u8,
+    capacity: usize,
+    out_required: *mut usize,
+) -> i32 {
+    with_handle(handle, false, |handle| {
+        if !valid_destination(buffer, capacity, out_required) {
+            return handle.error(
+                INVALID_ARGUMENT,
+                "invalid output buffer or required-length pointer",
+            );
+        }
+        let Some(bytes) = &handle.pending_output else {
+            ptr::write(out_required, 0);
+            return EMPTY;
+        };
+        let result = copy_bytes(bytes, buffer, capacity, out_required);
+        if result == OK {
+            handle.pending_output = None;
+        }
+        result
+    })
+}
+
+/// Copies a detached typed-JSON projection without consuming output or advancing.
+///
+/// The projection is a JSON array of ordered `WireBundle` objects. Length queries
+/// use a null buffer with capacity zero. Short buffers receive no partial bytes.
+///
+/// # Safety
+/// The handle must satisfy [`destroy`]'s live, exclusive ownership requirements.
+/// `buffer` must be writable for `capacity` bytes; null requires capacity zero.
+/// `out_required` must be non-null, aligned and writable. These allocations must
+/// not overlap each other or the handle, and must remain exclusively accessible
+/// until this function returns. No buffer is retained by Rust.
+pub unsafe fn inspect_json(
+    handle: *mut ApplicationHandle,
+    buffer: *mut u8,
+    capacity: usize,
+    out_required: *mut usize,
+) -> i32 {
+    with_handle(handle, false, |handle| {
+        if !valid_destination(buffer, capacity, out_required) {
+            return handle.error(
+                INVALID_ARGUMENT,
+                "invalid inspection buffer or required-length pointer",
+            );
+        }
+        match handle.driver.inspect().and_then(encode_bundles) {
+            Ok(bytes) => copy_bytes(&bytes, buffer, capacity, out_required),
+            Err(message) => handle.error(DRIVER_ERROR, message),
+        }
+    })
+}
+
+/// Copies the last diagnostic, including on a permanently failed handle.
+///
+/// The text is UTF-8 with no NUL terminator; it persists until another error.
+/// Buffer queries never replace it. Initially the diagnostic is empty (`OK`,
+/// required length zero). A wrong-thread call cannot inspect or change it.
+///
+/// # Safety
+/// The handle and destination must satisfy [`inspect_json`]'s requirements.
+pub unsafe fn last_error(
+    handle: *mut ApplicationHandle,
+    buffer: *mut u8,
+    capacity: usize,
+    out_required: *mut usize,
+) -> i32 {
+    with_handle(handle, true, |handle| {
+        if !valid_destination(buffer, capacity, out_required) {
+            return INVALID_ARGUMENT;
+        }
+        copy_bytes(handle.last_error.as_bytes(), buffer, capacity, out_required)
+    })
+}
+
+unsafe fn with_handle(
+    pointer: *mut ApplicationHandle,
+    allow_failed: bool,
+    operation: impl FnOnce(&mut ApplicationHandle) -> i32,
+) -> i32 {
+    let Some(handle) = pointer.as_mut() else {
+        return INVALID_ARGUMENT;
+    };
+    if handle.owner != thread::current().id() {
+        return WRONG_THREAD;
+    }
+    if handle.failed && !allow_failed {
+        return FAILED;
+    }
+    match catch_unwind(AssertUnwindSafe(|| operation(handle))) {
+        Ok(status) => status,
+        Err(payload) => {
+            std::mem::forget(payload);
+            handle.failed = true;
+            handle.last_error = "application driver panicked; destroy this handle".to_string();
+            PANIC
+        }
+    }
+}
+
+unsafe fn checked_bytes<'a>(pointer: *const u8, length: usize) -> Result<&'a [u8], i32> {
+    if length > MAX_INPUT_BYTES {
+        return Err(INVALID_INPUT);
+    }
+    if pointer.is_null() && length != 0 {
+        return Err(INVALID_ARGUMENT);
+    }
+    if length == 0 {
+        Ok(&[])
+    } else {
+        Ok(std::slice::from_raw_parts(pointer, length))
+    }
+}
+
+fn valid_destination(buffer: *mut u8, capacity: usize, required: *mut usize) -> bool {
+    !required.is_null() && (!buffer.is_null() || capacity == 0) && capacity <= isize::MAX as usize
+}
+
+unsafe fn copy_bytes(bytes: &[u8], buffer: *mut u8, capacity: usize, required: *mut usize) -> i32 {
+    ptr::write(required, bytes.len());
+    if capacity < bytes.len() {
+        return BUFFER_TOO_SMALL;
+    }
+    if !bytes.is_empty() {
+        ptr::copy_nonoverlapping(bytes.as_ptr(), buffer, bytes.len());
+    }
+    OK
+}
+
+fn encode_bundles(bundles: Vec<OscBundle>) -> Result<Vec<u8>, String> {
+    let wire: Vec<WireBundle> = bundles
+        .iter()
+        .map(WireBundle::try_from)
+        .collect::<Result<_, _>>()
+        .map_err(|error| error.to_string())?;
+    let mut writer = LimitedBuffer(Vec::new());
+    serde_json::to_writer(&mut writer, &wire).map_err(|error| error.to_string())?;
+    Ok(writer.0)
+}
+
+struct LimitedBuffer(Vec<u8>);
+
+impl Write for LimitedBuffer {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        if bytes.len() > MAX_OUTPUT_BYTES - self.0.len() {
+            return Err(io::Error::other("output exceeds 64 MiB ABI limit"));
+        }
+        self.0.extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kitu_osc_ir::{OscArg, OscMessage};
+    use kitu_runtime::build_runtime;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    struct Probe {
+        count: u64,
+        submissions: usize,
+        drops: Arc<AtomicUsize>,
+        panic_tick: bool,
+        fail_tick: bool,
+    }
+
+    impl ApplicationDriver for Probe {
+        fn submit(&mut self, bundle: OscBundle, _: Option<InputMetadata>) -> Result<u64, String> {
+            if bundle
+                .messages
+                .iter()
+                .any(|message| message.address == "/reject")
+            {
+                return Err("structural rejection".to_string());
+            }
+            let sequence = self.submissions as u64;
+            self.submissions += 1;
+            Ok(sequence)
+        }
+
+        fn tick(&mut self) -> Result<Vec<OscBundle>, String> {
+            self.count += 1;
+            assert!(!self.panic_tick, "tick panicked");
+            if self.fail_tick {
+                return Err("partially advanced tick failed".to_string());
+            }
+            self.inspect()
+        }
+
+        fn inspect(&self) -> Result<Vec<OscBundle>, String> {
+            let mut message = OscMessage::new("/test/state");
+            message.push_arg(OscArg::Int64(self.count as i64));
+            message.push_arg(OscArg::Int(self.submissions as i32));
+            let mut bundle = OscBundle::new();
+            bundle.push(message);
+            Ok(vec![bundle])
+        }
+    }
+
+    impl Drop for Probe {
+        fn drop(&mut self) {
+            self.drops.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn probe(panic_tick: bool, fail_tick: bool) -> (Box<dyn ApplicationDriver>, Arc<AtomicUsize>) {
+        let drops = Arc::new(AtomicUsize::new(0));
+        (
+            Box::new(Probe {
+                count: 0,
+                submissions: 0,
+                drops: Arc::clone(&drops),
+                panic_tick,
+                fail_tick,
+            }),
+            drops,
+        )
+    }
+
+    fn handle() -> *mut ApplicationHandle {
+        Box::into_raw(Box::new(ApplicationHandle::new(probe(false, false).0)))
+    }
+
+    type Reader = unsafe fn(*mut ApplicationHandle, *mut u8, usize, *mut usize) -> i32;
+
+    unsafe fn read(handle: *mut ApplicationHandle, reader: Reader) -> Vec<u8> {
+        let mut required = usize::MAX;
+        let status = reader(handle, ptr::null_mut(), 0, &mut required);
+        assert!(status == BUFFER_TOO_SMALL || (status == OK && required == 0));
+        let mut bytes = vec![0; required];
+        assert_eq!(
+            reader(handle, bytes.as_mut_ptr(), bytes.len(), &mut required),
+            OK
+        );
+        bytes
+    }
+
+    fn input(address: &str) -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "metadata":{"source":"test", "messageId":1, "schemaVersion":1},
+            "bundle":{"messages":[{"address":address, "args":[]}]}
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn buffer_queries_keep_the_entire_batch_and_never_advance() {
+        unsafe {
+            let handle = handle();
+            let initial = read(handle, inspect_json);
+            assert_eq!(tick(handle), OK);
+            let after_tick = read(handle, inspect_json);
+            assert_ne!(initial, after_tick);
+            assert_eq!(tick(handle), PENDING_OUTPUT);
+            assert_eq!(read(handle, inspect_json), after_tick);
+            let mut required = 0;
+            assert_eq!(
+                read_output(handle, ptr::null_mut(), 1, &mut required),
+                INVALID_ARGUMENT
+            );
+            assert_eq!(
+                read_output(handle, ptr::null_mut(), 0, ptr::null_mut()),
+                INVALID_ARGUMENT
+            );
+            assert_eq!(
+                read_output(handle, ptr::null_mut(), 0, &mut required),
+                BUFFER_TOO_SMALL
+            );
+            let mut short = vec![0xa5; required - 1];
+            assert_eq!(
+                read_output(handle, short.as_mut_ptr(), short.len(), &mut required),
+                BUFFER_TOO_SMALL
+            );
+            assert!(short.iter().all(|byte| *byte == 0xa5));
+            assert_eq!(read(handle, read_output), after_tick);
+            assert_eq!(
+                read_output(handle, ptr::null_mut(), 0, &mut required),
+                EMPTY
+            );
+            assert_eq!(required, 0);
+            assert_eq!(tick(handle), OK);
+            read(handle, read_output);
+            assert_eq!(destroy(handle), OK);
+        }
+    }
+
+    #[test]
+    fn malformed_requests_and_output_pointers_never_admit_an_input() {
+        unsafe {
+            let handle = handle();
+            let initial = read(handle, inspect_json);
+            let valid = input("/test/input");
+            let mut sequence = 99;
+            assert_eq!(
+                submit_json(handle, valid.as_ptr(), valid.len(), ptr::null_mut()),
+                INVALID_ARGUMENT
+            );
+            assert_eq!(
+                submit_json(handle, ptr::null(), 1, &mut sequence),
+                INVALID_ARGUMENT
+            );
+            assert_eq!(
+                submit_json(handle, ptr::null(), MAX_INPUT_BYTES + 1, &mut sequence),
+                INVALID_INPUT
+            );
+            let mut invalid = vec![vec![0xff], b"{}".to_vec(), b"null".to_vec(), Vec::new()];
+            for (key, value) in [
+                ("source", serde_json::json!("")),
+                ("source", serde_json::json!("x".repeat(129))),
+                ("source", serde_json::json!("a\0b")),
+                ("messageId", serde_json::json!(0)),
+                ("schemaVersion", serde_json::json!(0)),
+            ] {
+                let mut request: serde_json::Value = serde_json::from_slice(&valid).unwrap();
+                request["metadata"][key] = value;
+                invalid.push(serde_json::to_vec(&request).unwrap());
+            }
+            let mut unknown: serde_json::Value = serde_json::from_slice(&valid).unwrap();
+            unknown["extra"] = serde_json::json!(true);
+            invalid.push(serde_json::to_vec(&unknown).unwrap());
+            for bytes in invalid {
+                assert_eq!(
+                    submit_json(handle, bytes.as_ptr(), bytes.len(), &mut sequence),
+                    INVALID_INPUT
+                );
+                assert_eq!(sequence, 99);
+            }
+            let mut required = 99;
+            assert_eq!(
+                inspect_json(handle, ptr::null_mut(), 1, &mut required),
+                INVALID_ARGUMENT
+            );
+            assert_eq!(
+                inspect_json(handle, ptr::null_mut(), 0, ptr::null_mut()),
+                INVALID_ARGUMENT
+            );
+            assert_eq!(read(handle, inspect_json), initial);
+            assert_eq!(
+                submit_json(handle, valid.as_ptr(), valid.len(), &mut sequence),
+                OK
+            );
+            assert_eq!(sequence, 0);
+            let rejected = input("/reject");
+            sequence = 99;
+            assert_eq!(
+                submit_json(handle, rejected.as_ptr(), rejected.len(), &mut sequence),
+                DRIVER_ERROR
+            );
+            assert_eq!(sequence, 99);
+            assert_eq!(
+                submit_json(handle, valid.as_ptr(), valid.len(), &mut sequence),
+                OK
+            );
+            assert_eq!(sequence, 1);
+            assert_eq!(destroy(handle), OK);
+        }
+    }
+
+    #[test]
+    fn admission_budgets_reset_only_after_a_successful_tick() {
+        unsafe {
+            let handle = handle();
+            let bytes = input("/test/input");
+            let mut sequence = 0;
+            for expected in 0..MAX_PENDING_INPUTS {
+                assert_eq!(
+                    submit_json(handle, bytes.as_ptr(), bytes.len(), &mut sequence),
+                    OK
+                );
+                assert_eq!(sequence, expected as u64);
+            }
+            assert_eq!(
+                submit_json(handle, bytes.as_ptr(), bytes.len(), &mut sequence),
+                QUEUE_FULL
+            );
+            assert_eq!(tick(handle), OK);
+            read(handle, read_output);
+            // Whitespace counts toward the serialized byte budget too.
+            let mut large = bytes;
+            large.resize(MAX_INPUT_BYTES, b' ');
+            for _ in 0..MAX_PENDING_INPUT_BYTES / MAX_INPUT_BYTES {
+                assert_eq!(
+                    submit_json(handle, large.as_ptr(), large.len(), &mut sequence),
+                    OK
+                );
+            }
+            assert_eq!(
+                submit_json(handle, large.as_ptr(), large.len(), &mut sequence),
+                QUEUE_FULL
+            );
+            assert_eq!(destroy(handle), OK);
+        }
+    }
+
+    #[test]
+    fn creation_negotiates_abi_and_preserves_failure_diagnostics_without_handles() {
+        unsafe {
+            let mut output = ptr::dangling_mut();
+            let mut required = 0;
+            assert_eq!(
+                create_json(
+                    ABI_VERSION + 1,
+                    ptr::null(),
+                    0,
+                    &mut output,
+                    ptr::null_mut(),
+                    0,
+                    &mut required,
+                    |_| panic!("must not call factory")
+                ),
+                ABI_MISMATCH
+            );
+            assert!(output.is_null());
+            assert!(required > 0);
+            let mut error = vec![0xa5; 3];
+            assert_eq!(
+                create_json(
+                    ABI_VERSION,
+                    ptr::null(),
+                    0,
+                    &mut output,
+                    error.as_mut_ptr(),
+                    error.len(),
+                    &mut required,
+                    |_| Err("invalid application configuration".to_string())
+                ),
+                DRIVER_ERROR
+            );
+            assert!(output.is_null());
+            assert_eq!(error, vec![0xa5; 3]);
+            error.resize(required, 0);
+            assert_eq!(
+                create_json(
+                    ABI_VERSION,
+                    ptr::null(),
+                    0,
+                    &mut output,
+                    error.as_mut_ptr(),
+                    error.len(),
+                    &mut required,
+                    |_| Err("invalid application configuration".to_string())
+                ),
+                DRIVER_ERROR
+            );
+            assert_eq!(
+                String::from_utf8(error).unwrap(),
+                "invalid application configuration"
+            );
+            let (driver, drops) = probe(false, false);
+            assert_eq!(
+                create_json(
+                    ABI_VERSION,
+                    ptr::null(),
+                    0,
+                    &mut output,
+                    ptr::null_mut(),
+                    0,
+                    &mut required,
+                    |bytes| {
+                        assert!(bytes.is_empty());
+                        Ok(driver)
+                    }
+                ),
+                OK
+            );
+            assert!(!output.is_null());
+            assert_eq!(required, 0);
+            assert_eq!(destroy(output), OK);
+            assert_eq!(drops.load(Ordering::SeqCst), 1);
+        }
+    }
+
+    #[test]
+    fn creation_validates_required_pointers_before_invoking_factory() {
+        unsafe {
+            let mut output = ptr::null_mut();
+            let mut required = 0;
+            assert_eq!(
+                create_json(
+                    ABI_VERSION,
+                    ptr::null(),
+                    0,
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    0,
+                    &mut required,
+                    |_| panic!("unreachable")
+                ),
+                INVALID_ARGUMENT
+            );
+            assert_eq!(
+                create_json(
+                    ABI_VERSION,
+                    ptr::null(),
+                    0,
+                    &mut output,
+                    ptr::null_mut(),
+                    0,
+                    ptr::null_mut(),
+                    |_| panic!("unreachable")
+                ),
+                INVALID_ARGUMENT
+            );
+            assert_eq!(
+                create_json(
+                    ABI_VERSION,
+                    ptr::null(),
+                    0,
+                    &mut output,
+                    ptr::null_mut(),
+                    1,
+                    &mut required,
+                    |_| panic!("unreachable")
+                ),
+                INVALID_ARGUMENT
+            );
+            assert_eq!(
+                create_json(
+                    ABI_VERSION,
+                    ptr::null(),
+                    1,
+                    &mut output,
+                    ptr::null_mut(),
+                    0,
+                    &mut required,
+                    |_| panic!("unreachable")
+                ),
+                INVALID_ARGUMENT
+            );
+            assert!(output.is_null());
+            assert_eq!(tick(ptr::null_mut()), INVALID_ARGUMENT);
+            assert_eq!(destroy(ptr::null_mut()), INVALID_ARGUMENT);
+        }
+    }
+
+    #[test]
+    fn wrong_thread_calls_cannot_change_or_destroy_the_handle() {
+        unsafe {
+            let (driver, drops) = probe(false, false);
+            let handle = Box::into_raw(Box::new(ApplicationHandle::new(driver)));
+            let before = read(handle, inspect_json);
+            let address = handle as usize;
+            thread::spawn(move || {
+                let handle = address as *mut ApplicationHandle;
+                assert_eq!(tick(handle), WRONG_THREAD);
+                assert_eq!(destroy(handle), WRONG_THREAD);
+                let mut required = 0;
+                assert_eq!(
+                    last_error(handle, ptr::null_mut(), 0, &mut required),
+                    WRONG_THREAD
+                );
+            })
+            .join()
+            .unwrap();
+            assert_eq!(drops.load(Ordering::SeqCst), 0);
+            assert_eq!(read(handle, inspect_json), before);
+            assert_eq!(destroy(handle), OK);
+            assert_eq!(drops.load(Ordering::SeqCst), 1);
+        }
+    }
+
+    #[test]
+    fn panic_and_failed_ticks_poison_the_handle_but_allow_diagnosis_and_destruction() {
+        unsafe {
+            for (panic_tick, fail_tick, expected) in
+                [(true, false, PANIC), (false, true, DRIVER_ERROR)]
+            {
+                let (driver, drops) = probe(panic_tick, fail_tick);
+                let handle = Box::into_raw(Box::new(ApplicationHandle::new(driver)));
+                assert_eq!(tick(handle), expected);
+                assert_eq!(tick(handle), FAILED);
+                let diagnostic = read(handle, last_error);
+                assert!(!diagnostic.is_empty());
+                assert_eq!(read(handle, last_error), diagnostic);
+                let mut required = 0;
+                assert_eq!(
+                    inspect_json(handle, ptr::null_mut(), 0, &mut required),
+                    FAILED
+                );
+                assert_eq!(destroy(handle), OK);
+                assert_eq!(drops.load(Ordering::SeqCst), 1);
+            }
+            let mut output = ptr::null_mut();
+            let mut required = 0;
+            assert_eq!(
+                create_json(
+                    ABI_VERSION,
+                    ptr::null(),
+                    0,
+                    &mut output,
+                    ptr::null_mut(),
+                    0,
+                    &mut required,
+                    |_| panic!("factory panicked")
+                ),
+                PANIC
+            );
+            assert!(output.is_null());
+            assert!(required > 0);
+        }
+    }
+
+    #[test]
+    fn runtime_adapter_uses_the_existing_queue_and_tick_order() {
+        let mut direct = build_runtime(LocalChannel::connected());
+        let runtime = build_runtime(LocalChannel::connected());
+        let handle = Box::into_raw(Box::new(ApplicationHandle::new(Box::new(
+            RuntimeDriver::new(runtime),
+        ))));
+        let request: InputRequest = serde_json::from_value(serde_json::json!({
+            "bundle":{"messages":[{"address":"/input/move", "args":[
+                {"type":"str","value":"player"},
+                {"type":"float","value":0.5},
+                {"type":"float","value":-0.75}
+            ]}]}
+        }))
+        .unwrap();
+        let expected_sequence = direct
+            .try_enqueue_input(OscBundle::try_from(request.bundle.clone()).unwrap(), None)
+            .unwrap();
+        let bytes = serde_json::to_vec(&request).unwrap();
+        unsafe {
+            let mut sequence = u64::MAX;
+            assert_eq!(
+                submit_json(handle, bytes.as_ptr(), bytes.len(), &mut sequence),
+                OK
+            );
+            assert_eq!(sequence, expected_sequence);
+            assert_eq!(read(handle, inspect_json), b"[]");
+            assert_eq!(tick(handle), OK);
+            direct.tick_once().unwrap();
+            assert_eq!(
+                read(handle, read_output),
+                encode_bundles(direct.drain_output_buffer()).unwrap()
+            );
+            assert_eq!(tick(handle), OK);
+            direct.tick_once().unwrap();
+            assert_eq!(
+                read(handle, read_output),
+                encode_bundles(direct.drain_output_buffer()).unwrap()
+            );
+            assert_eq!(destroy(handle), OK);
+        }
+    }
+
+    #[test]
+    fn factory_capture_destructors_and_panic_payloads_cannot_unwind_through_the_boundary() {
+        struct PanicOnDrop;
+        impl Drop for PanicOnDrop {
+            fn drop(&mut self) {
+                panic!("captured value or panic payload dropped");
+            }
+        }
+
+        unsafe {
+            let mut output = ptr::dangling_mut();
+            let capture = PanicOnDrop;
+            // Invalid pointers prevent invoking the factory, but its owned
+            // capture still drops inside the catch boundary.
+            assert_eq!(
+                create_json(
+                    ABI_VERSION,
+                    ptr::null(),
+                    0,
+                    &mut output,
+                    ptr::null_mut(),
+                    0,
+                    ptr::null_mut(),
+                    move |_| {
+                        drop(capture);
+                        unreachable!("invalid output arguments must prevent factory invocation")
+                    }
+                ),
+                PANIC
+            );
+            assert!(output.is_null());
+            let mut required = 0;
+            assert_eq!(
+                create_json(
+                    ABI_VERSION,
+                    ptr::null(),
+                    0,
+                    &mut output,
+                    ptr::null_mut(),
+                    0,
+                    &mut required,
+                    |_| {
+                        std::panic::panic_any(PanicOnDrop);
+                    }
+                ),
+                PANIC
+            );
+            assert!(output.is_null());
+            assert!(required > 0);
+        }
+    }
+}

--- a/crates/kitu-unity-ffi/src/lib.rs
+++ b/crates/kitu-unity-ffi/src/lib.rs
@@ -9,6 +9,8 @@
 //! This crate wraps the runtime (`kitu-runtime`) and transports (`kitu-transport`) behind a
 //! Unity-friendly API. See `doc/crates-overview.md` for how the FFI sits atop the core runtime.
 
+pub mod application;
+
 use std::{
     collections::VecDeque,
     ffi::CStr,

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -580,3 +580,15 @@ This list tracks scenario coverage and should remain aligned with runtime and to
 5. **Persistence model**: Save/load snapshot granularity and schema evolution policy.
 6. **Web admin security**: Authentication/authorization model for remote operations.
 7. **Unity package layout**: Final package boundaries and release/versioning strategy under `unity-packages/`.
+
+### Full application native boundary
+
+`kitu-unity-ffi::application` owns the versioned driver/handle/buffer contract;
+`kitu-transport::wire` supplies a shared typed OSC Serde representation. The
+application-owned `kitu-demo-game-native` factory creates the same complete Arena
+Runtime as the server and exports C wrappers as a dynamic/static library. It
+starts no timer or network host. The embedder owns one tick scheduler and must
+retrieve complete output batches before advancing. The later development bridge
+must reuse the existing application host state, queue, recording and playback;
+creating a second Runtime for Admin would observe a different run. See
+[`specs/arena-native-abi.md`](specs/arena-native-abi.md).

--- a/doc/publish-readiness.md
+++ b/doc/publish-readiness.md
@@ -52,3 +52,11 @@ For each candidate crate before MVP publication:
 - Public APIs have tests or a documented exception.
 - `cargo package --list -p <crate>` has been executed after metadata changes and the result is captured in the PR or issue.
 - `cargo publish --dry-run -p <crate>` is deferred until the project intentionally changes the crate's `publish = false` gate as part of MVP publication.
+
+### Stage 10 native embedding
+
+`kitu-transport` and `kitu-unity-ffi` remain internal (`publish = false`), with
+shared wire and C ABI documentation. The FFI package includes its C header.
+`apps/demo-game/native` is an application factory, also explicitly non-publishable;
+it provides metadata, README and dynamic/static library outputs. Verification
+uses `cargo package --list` for package contents; no crates.io publication occurs.

--- a/doc/specs/arena-native-abi.md
+++ b/doc/specs/arena-native-abi.md
@@ -1,0 +1,119 @@
+# Full application native ABI
+
+Stage 10 of the Endless Arena migration exposes the complete application through
+an application-owned `cdylib`/`staticlib`. `apps/demo-game/native` selects the same
+`build_arena_runtime` factory used by the server; `kitu-unity-ffi::application`
+owns handles, diagnostics, buffering and a replaceable `ApplicationDriver`.
+`kitu-transport::wire` owns the typed OSC representation. The common crates do not
+depend on the Arena application.
+
+## Version and lifetime
+
+The C declarations and numeric results are authoritative in
+`crates/kitu-unity-ffi/include/kitu_application.h`. Ask
+`kitu_application_abi_version()` before creating an instance. ABI 1 creation
+requires ABI 1 and returns no handle on failure. Configuration is UTF-8 JSON:
+empty means embedded TMD defaults; `contractVersion` defaults to 1; optional
+`content` contains a detached, validated `ContentVersion`, including its exact
+hash, source identity and evaluated values. Unknown fields and invalid content
+are refused. Creation diagnostics use a caller-owned buffer and required length.
+
+One live opaque handle owns one application and belongs to the creating thread.
+Calls must be serialized on that thread; destruction cannot race another call.
+Call destroy once, then never use the pointer again. NULL is detected where
+specified, but arbitrary dangling or fabricated pointers cannot be validated by
+a C ABI. All non-null memory ranges must be valid, nonoverlapping and remain alive
+for the call. Rust never frees caller buffers and C never frees the handle itself.
+A caught panic permanently fails the handle; diagnostics and destruction remain
+available. The historical movement-only `kitu_*` ABI remains a separate API.
+
+## Input and tick ownership
+
+`submit_json` accepts one JSON request:
+
+```json
+{"metadata":{"source":"unity-native","messageId":1,"schemaVersion":1},"bundle":{"messages":[{"address":"/input/arena/start","args":[]}]}}
+```
+
+Arguments have explicit tags `int` (i32), `int64` (i64), `float` (finite f32),
+`str` (UTF-8 without NUL) and `bool`. Bundles and arguments retain order. Empty
+bundles are supported; nested or scheduled bundles are unsupported by the core
+OSC-IR model and are rejected, not flattened. Integer consumers must preserve
+64-bit values without conversion through a JavaScript floating-point number.
+An OSC address begins with `/` and contains no NUL. Metadata may be omitted for
+ordinary legacy input; Arena enforces its existing versioned input contract.
+
+Admission returns the Runtime queue sequence and does not advance time. Success
+means queued; application acceptance/refusal arrives in the ordinary output
+receipts. Invalid structure cannot consume a sequence or modify queued inputs.
+Arena retains operation identity and duplicate-consumption protection.
+
+The owner calls `tick` once per 1/60 second of logical time, independently of input
+frequency. No sleep or wall clock is hidden in the ABI. Pausing stops game time;
+management ticks still advance. Inspection before any tick reports Arena tick
+`-1`; the Runtime's internal next-tick counter is not the last applied tick.
+
+## Complete outputs and bounded memory
+
+`read_output` returns UTF-8 JSON `WireBundle[]` for the complete latest tick,
+including every state, receipt and game event. It never filters to transforms.
+`inspect_json` returns detached application projection bundles without consuming
+events or ticking. `last_error` returns UTF-8 diagnostics. Buffers do not include a
+NUL terminator; `out_required` is the exact byte count.
+
+Query with NULL and capacity zero, allocate the reported size, then read. A short
+buffer writes no partial payload and does not consume output. Successful output
+read consumes the whole batch; another read returns EMPTY. Even an empty batch
+`[]` must be read before ticking again. A pending batch returns PENDING_OUTPUT
+before any clock advance. Tick/serialization failure poisons the handle because
+an already-started tick cannot safely be retried as if it had never run.
+
+Limits are 1 MiB per configuration/input request, 4096 queued requests and 16 MiB
+of queued serialized input per tick, and 64 MiB per output batch. The application
+keeps its own lower structural bounds. Required output pointers and capacities
+are checked before mutating operations. Capacity exhaustion returns a diagnostic.
+
+## Verification and native builds
+
+Normal Rust checks run in the repository Dev Container. The native integration
+test feeds the frozen preparation and stock scenarios through exported C
+functions and compares every tick's complete state/output with the ordinary
+server Runtime. The shared oracle also compares C# checkpoints/outcomes using
+the established 1e-4 numeric tolerance and exact discrete/event ordering rules.
+The stock case reaches 11F, natural death at tick 5526 and retry at 5527.
+
+On macOS with Rust 1.96.0 and Apple command-line SDK tools:
+
+```sh
+export CARGO_TARGET_DIR="$PWD/.tmp/native-target"
+export CARGO_INCREMENTAL=0
+export CARGO_PROFILE_DEV_DEBUG=0
+export CARGO_PROFILE_TEST_DEBUG=0
+export KITU_NATIVE_EVIDENCE_DIR="$PWD/.tmp/native-evidence"
+cargo test --locked -p kitu-demo-game-native
+cargo build --locked -p kitu-demo-game-native
+clang -std=c11 -Wall -Wextra -Werror \
+  -I crates/kitu-unity-ffi/include \
+  apps/demo-game/native/tests/c_abi.c \
+  -L "$CARGO_TARGET_DIR/debug" -lkitu_demo_game_native \
+  -Wl,-rpath,"$CARGO_TARGET_DIR/debug" \
+  -o "$KITU_NATIVE_EVIDENCE_DIR/c-abi"
+"$KITU_NATIVE_EVIDENCE_DIR/c-abi" \
+  "$KITU_NATIVE_EVIDENCE_DIR/stock-eleven-death-retry.trace" \
+  "$KITU_NATIVE_EVIDENCE_DIR/stock-eleven-death-retry.actual.ndjson"
+python3 tools/verify-arena-native.py \
+  "$KITU_NATIVE_EVIDENCE_DIR/stock-eleven-death-retry.expected.ndjson" \
+  "$KITU_NATIVE_EVIDENCE_DIR/stock-eleven-death-retry.actual.ndjson"
+```
+
+The actual C program invokes the built library and checks version/configuration,
+input sequence, short-buffer retries, pending-output backpressure, inspection and
+creation/destruction. Compare its NDJSON against the ordinary Runtime trace with
+`tools/verify-arena-native.py`; generation and comparison must use the same build
+and target. Cross-target checks retain the frozen C# tolerance rather than
+pretending different execution identities are replay-compatible.
+
+Stage 11 adds the Unity native adapter, standalone packaging and the development
+CLI/Admin bridge. That bridge must share the same application host state,
+recording/playback and input queue. Server and embedded schedulers must never run
+simultaneously against one instance. No structural impossibility is known.

--- a/doc/specs/arena-native-abi.md
+++ b/doc/specs/arena-native-abi.md
@@ -69,7 +69,10 @@ before any clock advance. Tick/serialization failure poisons the handle because
 an already-started tick cannot safely be retried as if it had never run.
 
 Limits are 1 MiB per configuration/input request, 4096 queued requests and 16 MiB
-of queued serialized input per tick, and 64 MiB per output batch. The application
+of queued serialized input per tick, and 64 MiB per output batch. Borrowed OSC
+views serialize incrementally without cloning the batch or its strings. The
+writer caps geometric buffer growth and stops at the exact encoded-byte limit.
+The application
 keeps its own lower structural bounds. Required output pointers and capacities
 are checked before mutating operations. Capacity exhaustion returns a diagnostic.
 

--- a/doc/verification/arena-native/macos.json
+++ b/doc/verification/arena-native/macos.json
@@ -1,0 +1,150 @@
+{
+  "verifiedAtUtc": "2026-09-06T06:52:47.521294+00:00",
+  "baseRevision": "04e5dc17313b0ffd83c9d348ef2a7c2f4466e588",
+  "sourceState": "stage10 worktree before commit; no repository edits by native verifier",
+  "toolchain": {
+    "rustc": "rustc 1.96.0 (ac68faa20 2026-05-25)\nbinary: rustc\ncommit-hash: ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96\ncommit-date: 2026-05-25\nhost: aarch64-apple-darwin\nrelease: 1.96.0\nLLVM version: 22.1.2",
+    "cargo": "cargo 1.96.0 (30a34c682 2026-05-25)",
+    "clang": "Apple clang version 21.0.0 (clang-2100.1.1.101)\nTarget: arm64-apple-darwin25.5.0\nThread model: posix\nInstalledDir: /Library/Developer/CommandLineTools/usr/bin",
+    "sdkPath": "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk",
+    "sdkVersion": "26.5",
+    "macOS": "ProductName:\t\tmacOS\nProductVersion:\t\t26.5.2\nBuildVersion:\t\t25F84",
+    "environmentScript": "/private/tmp/kitu-native-toolchain/env.sh"
+  },
+  "profile": {
+    "CARGO_INCREMENTAL": "0",
+    "CARGO_PROFILE_DEV_DEBUG": "0",
+    "CARGO_PROFILE_TEST_DEBUG": "0",
+    "CARGO_TARGET_DIR": "/private/tmp/kitu-native-toolchain/target"
+  },
+  "tests": {
+    "initialIntegrationPassed": 4,
+    "doctestsPassed": 1,
+    "addedConsumableRegressionPassed": 1,
+    "failures": 0,
+    "commands": [
+      "cargo test --locked -p kitu-demo-game-native",
+      "cargo test --locked -p kitu-demo-game-native native_consumable_intents_cancel_on_pause_and_duplicate_use_consumes_once",
+      "cargo build --locked -p kitu-demo-game-native"
+    ]
+  },
+  "artifacts": {
+    "dynamicLibrary": {
+      "path": "/private/tmp/kitu-native-toolchain/target/debug/libkitu_demo_game_native.dylib",
+      "bytes": 14370992,
+      "sha256": "dc4469b1827f6dfe540b09a099772c1adcaa3ddf76d43a6b9adb24a6f089bc88"
+    },
+    "linkedDynamicLibrary": {
+      "path": "/private/tmp/kitu-native-toolchain/target/debug/deps/libkitu_demo_game_native.dylib",
+      "bytes": 14370992,
+      "sha256": "dc4469b1827f6dfe540b09a099772c1adcaa3ddf76d43a6b9adb24a6f089bc88"
+    },
+    "staticLibrary": {
+      "path": "/private/tmp/kitu-native-toolchain/target/debug/libkitu_demo_game_native.a",
+      "bytes": 56976840,
+      "sha256": "caa78fd09275a24275491a9b8b3aeb76749f5d255f63c53f6d95871dfac7523a"
+    },
+    "cCaller": {
+      "path": "/Users/mujina/.codex/worktrees/e19c/kitu-workspace/kitu-logic-processor/.tmp/stage10-macos/c-abi",
+      "bytes": 35368,
+      "sha256": "c3b3c00ed934ba9795fad522249d8688f65a39026d815816409f110e6688a7e4"
+    },
+    "header": {
+      "path": "/Users/mujina/.codex/worktrees/e19c/kitu-workspace/kitu-logic-processor/crates/kitu-unity-ffi/include/kitu_application.h",
+      "bytes": 5412,
+      "sha256": "7cee12f5de127ad359c01f016d9908b7151c7e70305725087ee5882381bf04f9"
+    },
+    "cSource": {
+      "path": "/Users/mujina/.codex/worktrees/e19c/kitu-workspace/kitu-logic-processor/apps/demo-game/native/tests/c_abi.c",
+      "bytes": 14729,
+      "sha256": "620e7a7b813c0d8a95adc7469e8dc69f536b1fd4864f51a9a44f7c4426105511"
+    },
+    "cargoLock": {
+      "path": "/Users/mujina/.codex/worktrees/e19c/kitu-workspace/kitu-logic-processor/Cargo.lock",
+      "bytes": 60825,
+      "sha256": "b36d7b33d28345048be788f1d60432aa5ff19d8a16cc6df4960364b6e9428865"
+    }
+  },
+  "architecture": {
+    "dynamicLibrary": "/private/tmp/kitu-native-toolchain/target/debug/libkitu_demo_game_native.dylib: Mach-O 64-bit dynamically linked shared library arm64",
+    "staticLibrary": "Non-fat file: /private/tmp/kitu-native-toolchain/target/debug/libkitu_demo_game_native.a is architecture: arm64",
+    "cCaller": "/Users/mujina/.codex/worktrees/e19c/kitu-workspace/kitu-logic-processor/.tmp/stage10-macos/c-abi: Mach-O 64-bit executable arm64"
+  },
+  "exportedApplicationSymbols": [
+    "kitu_application_abi_version",
+    "kitu_application_create",
+    "kitu_application_destroy",
+    "kitu_application_inspect_json",
+    "kitu_application_last_error",
+    "kitu_application_read_output",
+    "kitu_application_submit_json",
+    "kitu_application_tick"
+  ],
+  "dynamicLibraryDependencies": "/private/tmp/kitu-native-toolchain/target/debug/libkitu_demo_game_native.dylib:\n\t/private/tmp/kitu-native-toolchain/target/debug/deps/libkitu_demo_game_native.dylib (compatibility version 0.0.0, current version 0.0.0)\n\t/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 5026.5.4)\n\t/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)\n\t/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1356.0.0)",
+  "cCallerDependencies": "/Users/mujina/.codex/worktrees/e19c/kitu-workspace/kitu-logic-processor/.tmp/stage10-macos/c-abi:\n\t/private/tmp/kitu-native-toolchain/target/debug/deps/libkitu_demo_game_native.dylib (compatibility version 0.0.0, current version 0.0.0)\n\t/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1356.0.0)",
+  "packagingFollowup": "Stage11 must set the dylib install name to @rpath when bundling; current development library install name uses the absolute Cargo target/deps path.",
+  "executionBuildOutputs": [
+    {
+      "buildOutput": "/private/tmp/kitu-native-toolchain/target/debug/build/kitu-demo-game-6a63b4366cb4a19c/output",
+      "execution": [
+        "cargo:rustc-env=ARENA_EXECUTION_HASH=989230f7ff63ea94e15b98d93bbfcb9285b97c49d703d10c8436f9fc1e070b0c",
+        "cargo:rustc-env=ARENA_EXECUTION_TARGET=aarch64-apple-darwin"
+      ]
+    }
+  ],
+  "scenarios": [
+    {
+      "scenario": "preparation",
+      "ticks": 28,
+      "inputs": 40,
+      "lifetimeCycles": 10,
+      "stateAndOutput": "exact match",
+      "trace": {
+        "path": "/Users/mujina/.codex/worktrees/e19c/kitu-workspace/kitu-logic-processor/.tmp/stage10-macos/preparation.trace",
+        "bytes": 11733,
+        "sha256": "2c764a254771e919c33ca8093322c31093d547443b2c942b061bb9f8072d5362"
+      },
+      "expected": {
+        "path": "/Users/mujina/.codex/worktrees/e19c/kitu-workspace/kitu-logic-processor/.tmp/stage10-macos/preparation.expected.ndjson",
+        "bytes": 363311,
+        "sha256": "d1f06c141ad8444a8f843639b1cb231c8068538165164a0303e4b12b9e7f5084"
+      },
+      "actual": {
+        "path": "/Users/mujina/.codex/worktrees/e19c/kitu-workspace/kitu-logic-processor/.tmp/stage10-macos/preparation.actual.ndjson",
+        "bytes": 363311,
+        "sha256": "3e565d9dda71784ef6ded1688936ff76a5b12a8701d7104b974333687c7ecc9c"
+      }
+    },
+    {
+      "scenario": "stock-eleven-death-retry",
+      "ticks": 5528,
+      "inputs": 5581,
+      "lifetimeCycles": 10,
+      "stateAndOutput": "exact match",
+      "trace": {
+        "path": "/Users/mujina/.codex/worktrees/e19c/kitu-workspace/kitu-logic-processor/.tmp/stage10-macos/stock-eleven-death-retry.trace",
+        "bytes": 2209146,
+        "sha256": "0b14c384ac29e986a51cde1b5c206fc3844472b5dd50fec1793b713ad262d1f8"
+      },
+      "expected": {
+        "path": "/Users/mujina/.codex/worktrees/e19c/kitu-workspace/kitu-logic-processor/.tmp/stage10-macos/stock-eleven-death-retry.expected.ndjson",
+        "bytes": 74286921,
+        "sha256": "e245c9b92c340472cfe7d6c2c8c63b1398f8903d93cb84ddfa62aafca703bb50"
+      },
+      "actual": {
+        "path": "/Users/mujina/.codex/worktrees/e19c/kitu-workspace/kitu-logic-processor/.tmp/stage10-macos/stock-eleven-death-retry.actual.ndjson",
+        "bytes": 74286921,
+        "sha256": "53895b09088ff33fbb6235331c33b724df65643d1ffaeb1918cc73fb9244001c"
+      }
+    }
+  ],
+  "logs": [
+    "/private/tmp/kitu-stage10-macos-build.log",
+    "/private/tmp/kitu-stage10-macos-c-compile.log",
+    "/private/tmp/kitu-stage10-macos-c-preparation.log",
+    "/private/tmp/kitu-stage10-macos-c-stock.log",
+    "/private/tmp/kitu-stage10-macos-consumable.log",
+    "/private/tmp/kitu-stage10-macos-test.log"
+  ],
+  "unityBuild": "not run; belongs to stage11"
+}

--- a/doc/verification/arena-native/macos.json
+++ b/doc/verification/arena-native/macos.json
@@ -1,7 +1,7 @@
 {
-  "verifiedAtUtc": "2026-09-06T06:52:47.521294+00:00",
-  "baseRevision": "04e5dc17313b0ffd83c9d348ef2a7c2f4466e588",
-  "sourceState": "stage10 worktree before commit; no repository edits by native verifier",
+  "verifiedAtUtc": "2026-09-06T07:12:18.332870+00:00",
+  "baseRevision": "dc921aea3a35121c4452f6b298a9499de43d5a45",
+  "sourceState": "PR149 memory-bound review fix worktree before publication; no source or Git edits by native verifier",
   "toolchain": {
     "rustc": "rustc 1.96.0 (ac68faa20 2026-05-25)\nbinary: rustc\ncommit-hash: ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96\ncommit-date: 2026-05-25\nhost: aarch64-apple-darwin\nrelease: 1.96.0\nLLVM version: 22.1.2",
     "cargo": "cargo 1.96.0 (30a34c682 2026-05-25)",
@@ -18,31 +18,31 @@
     "CARGO_TARGET_DIR": "/private/tmp/kitu-native-toolchain/target"
   },
   "tests": {
-    "initialIntegrationPassed": 4,
+    "integrationPassed": 5,
     "doctestsPassed": 1,
-    "addedConsumableRegressionPassed": 1,
     "failures": 0,
     "commands": [
       "cargo test --locked -p kitu-demo-game-native",
-      "cargo test --locked -p kitu-demo-game-native native_consumable_intents_cancel_on_pause_and_duplicate_use_consumes_once",
       "cargo build --locked -p kitu-demo-game-native"
-    ]
+    ],
+    "testLog": "/private/tmp/kitu-stage10-macos-review-test.log",
+    "buildLog": "/private/tmp/kitu-stage10-macos-review-build.log"
   },
   "artifacts": {
     "dynamicLibrary": {
       "path": "/private/tmp/kitu-native-toolchain/target/debug/libkitu_demo_game_native.dylib",
-      "bytes": 14370992,
-      "sha256": "dc4469b1827f6dfe540b09a099772c1adcaa3ddf76d43a6b9adb24a6f089bc88"
+      "bytes": 14335120,
+      "sha256": "72bf9a0fad188a19b84179130514a4db101b3c2e630ee93719bf1d142456940b"
     },
     "linkedDynamicLibrary": {
       "path": "/private/tmp/kitu-native-toolchain/target/debug/deps/libkitu_demo_game_native.dylib",
-      "bytes": 14370992,
-      "sha256": "dc4469b1827f6dfe540b09a099772c1adcaa3ddf76d43a6b9adb24a6f089bc88"
+      "bytes": 14335120,
+      "sha256": "72bf9a0fad188a19b84179130514a4db101b3c2e630ee93719bf1d142456940b"
     },
     "staticLibrary": {
       "path": "/private/tmp/kitu-native-toolchain/target/debug/libkitu_demo_game_native.a",
-      "bytes": 56976840,
-      "sha256": "caa78fd09275a24275491a9b8b3aeb76749f5d255f63c53f6d95871dfac7523a"
+      "bytes": 56948848,
+      "sha256": "245878b9a324925225da74baff6df1af828f9524fccf39a821764c2fae749ee9"
     },
     "cCaller": {
       "path": "/Users/mujina/.codex/worktrees/e19c/kitu-workspace/kitu-logic-processor/.tmp/stage10-macos/c-abi",
@@ -87,7 +87,7 @@
     {
       "buildOutput": "/private/tmp/kitu-native-toolchain/target/debug/build/kitu-demo-game-6a63b4366cb4a19c/output",
       "execution": [
-        "cargo:rustc-env=ARENA_EXECUTION_HASH=989230f7ff63ea94e15b98d93bbfcb9285b97c49d703d10c8436f9fc1e070b0c",
+        "cargo:rustc-env=ARENA_EXECUTION_HASH=a57e2a2eee2507e735a39252e1dccc07b2347f4c6452a09d5de74a936af91af4",
         "cargo:rustc-env=ARENA_EXECUTION_TARGET=aarch64-apple-darwin"
       ]
     }
@@ -144,7 +144,29 @@
     "/private/tmp/kitu-stage10-macos-c-preparation.log",
     "/private/tmp/kitu-stage10-macos-c-stock.log",
     "/private/tmp/kitu-stage10-macos-consumable.log",
+    "/private/tmp/kitu-stage10-macos-review-build.log",
+    "/private/tmp/kitu-stage10-macos-review-c-preparation.log",
+    "/private/tmp/kitu-stage10-macos-review-c-stock.log",
+    "/private/tmp/kitu-stage10-macos-review-test.log",
     "/private/tmp/kitu-stage10-macos-test.log"
   ],
-  "unityBuild": "not run; belongs to stage11"
+  "unityBuild": "not run; belongs to stage11",
+  "validationPhase": "Final macOS verification after bounded borrowed OSC output encoding review fix",
+  "reviewSourceFiles": [
+    {
+      "path": "/Users/mujina/.codex/worktrees/e19c/kitu-workspace/kitu-logic-processor/crates/kitu-transport/src/wire.rs",
+      "bytes": 22024,
+      "sha256": "c5c7a99b671108961139dfffd7f2594beecedcc85a662c8973616ae2cf8d6be0"
+    },
+    {
+      "path": "/Users/mujina/.codex/worktrees/e19c/kitu-workspace/kitu-logic-processor/crates/kitu-unity-ffi/src/application.rs",
+      "bytes": 44771,
+      "sha256": "920202b72ebd660f32c99c7977a983cb5875ca8ed950e396c7fba71e31c505e6"
+    },
+    {
+      "path": "/Users/mujina/.codex/worktrees/e19c/kitu-workspace/kitu-logic-processor/apps/demo-game/native/src/lib.rs",
+      "bytes": 5931,
+      "sha256": "15d2f42ab352087e470b0539d5362c1f9c56acea206d42e0d442a6ad044a5c69"
+    }
+  ]
 }

--- a/doc/verification/arena-native/preparation-comparison.json
+++ b/doc/verification/arena-native/preparation-comparison.json
@@ -1,0 +1,6 @@
+{
+  "ticks": 28,
+  "stateAndOutput": "exact match",
+  "expected": "/Users/mujina/.codex/worktrees/e19c/kitu-workspace/kitu-logic-processor/.tmp/stage10-macos/preparation.expected.ndjson",
+  "actual": "/Users/mujina/.codex/worktrees/e19c/kitu-workspace/kitu-logic-processor/.tmp/stage10-macos/preparation.actual.ndjson"
+}

--- a/doc/verification/arena-native/results.json
+++ b/doc/verification/arena-native/results.json
@@ -5,8 +5,8 @@
   "sourceSha256": {
     "Cargo.toml": "21ae4f4266b7411bab485b6213fc5684c5834241156b99fb3943794654cbd232",
     "Cargo.lock": "b36d7b33d28345048be788f1d60432aa5ff19d8a16cc6df4960364b6e9428865",
-    "crates/kitu-transport/src/wire.rs": "5c2bbe011b3eaf640c1d28d31a36be388b852aa87b4ef075981dba4b49351771",
-    "crates/kitu-unity-ffi/src/application.rs": "374ab0d84f190905114f36ed51af3e7026445c248457c66e464573fa279a1eb6",
+    "crates/kitu-transport/src/wire.rs": "c5c7a99b671108961139dfffd7f2594beecedcc85a662c8973616ae2cf8d6be0",
+    "crates/kitu-unity-ffi/src/application.rs": "920202b72ebd660f32c99c7977a983cb5875ca8ed950e396c7fba71e31c505e6",
     "crates/kitu-unity-ffi/include/kitu_application.h": "7cee12f5de127ad359c01f016d9908b7151c7e70305725087ee5882381bf04f9",
     "apps/demo-game/native/src/lib.rs": "15d2f42ab352087e470b0539d5362c1f9c56acea206d42e0d442a6ad044a5c69",
     "apps/demo-game/native/tests/arena_native.rs": "0151b0155d65b828d411818d31981c3580e8a733d88a47349ac9a98a4711d573",
@@ -25,7 +25,8 @@
         "workspace rustdoc warnings denied",
         "transport/FFI/native internal package lists",
         "frozen C# source and fixture integrity"
-      ]
+      ],
+      "reviewAdditionalTestsAndDoctests": 7
     },
     "native": {
       "platform": "macOS arm64",
@@ -49,7 +50,13 @@
   },
   "review": {
     "independentAppAndOracleReview": "No correctness finding; destroy documentation clarified ownership consumption on OK or PANIC. Original oracle fixture hashes and all comparison rules preserved.",
-    "independentAbiSafetyReview": "No actionable finding; ownership, pointer checks, panic containment, queue/output bounds and typed conversion reviewed."
+    "independentAbiSafetyReview": "No actionable finding; ownership, pointer checks, panic containment, queue/output bounds and typed conversion reviewed.",
+    "githubReview": {
+      "comment": 3943246073,
+      "finding": "Output cap was applied after cloning the full wire batch.",
+      "fix": "Shared borrowed OSC serializers stream directly to a bounded writer; capped geometric allocation and exact encoded-byte limit apply before an intermediate copy can be made.",
+      "validation": "45 affected unit tests/doctests (7 new), Clippy, rustdoc, fmt, package lists and oracle integrity passed. Exactly 64 MiB accepted; overflow stops before later values, inspection remains recoverable, failed tick is poisoned. macOS all 5 native tests + doctest and both real C scenarios passed again against rebuilt libraries."
+    }
   },
   "limits": [
     "The caller schedules one60Hz tick loop; this library starts no server or clock.",

--- a/doc/verification/arena-native/results.json
+++ b/doc/verification/arena-native/results.json
@@ -1,0 +1,60 @@
+{
+  "stage": 10,
+  "issue": 148,
+  "baseRevision": "04e5dc17313b0ffd83c9d348ef2a7c2f4466e588",
+  "sourceSha256": {
+    "Cargo.toml": "21ae4f4266b7411bab485b6213fc5684c5834241156b99fb3943794654cbd232",
+    "Cargo.lock": "b36d7b33d28345048be788f1d60432aa5ff19d8a16cc6df4960364b6e9428865",
+    "crates/kitu-transport/src/wire.rs": "5c2bbe011b3eaf640c1d28d31a36be388b852aa87b4ef075981dba4b49351771",
+    "crates/kitu-unity-ffi/src/application.rs": "374ab0d84f190905114f36ed51af3e7026445c248457c66e464573fa279a1eb6",
+    "crates/kitu-unity-ffi/include/kitu_application.h": "7cee12f5de127ad359c01f016d9908b7151c7e70305725087ee5882381bf04f9",
+    "apps/demo-game/native/src/lib.rs": "15d2f42ab352087e470b0539d5362c1f9c56acea206d42e0d442a6ad044a5c69",
+    "apps/demo-game/native/tests/arena_native.rs": "0151b0155d65b828d411818d31981c3580e8a733d88a47349ac9a98a4711d573",
+    "apps/demo-game/native/tests/c_abi.c": "620e7a7b813c0d8a95adc7469e8dc69f536b1fd4864f51a9a44f7c4426105511",
+    "apps/demo-game/tests/support/mod.rs": "32fc4fe20e1bdee6eb334bf4a736c48dc3a3a6032ce1b20447c44e2cf60e3f92",
+    "tools/verify-arena-native.py": "755b4ede4ff51018b3b8bb623f4c8a4cb8e7c30a999c7ca916655121ae3498a9"
+  },
+  "validation": {
+    "devContainer": {
+      "testsAndDoctests": 203,
+      "failures": 0,
+      "checks": [
+        "workspace all features tests",
+        "all targets/all features Clippy warnings denied",
+        "rustfmt",
+        "workspace rustdoc warnings denied",
+        "transport/FFI/native internal package lists",
+        "frozen C# source and fixture integrity"
+      ]
+    },
+    "native": {
+      "platform": "macOS arm64",
+      "integrationTests": 5,
+      "doctests": 1,
+      "cCallerScenarios": [
+        {
+          "scenario": "preparation",
+          "ticks": 28,
+          "inputs": 40
+        },
+        {
+          "scenario": "stock-eleven-death-retry",
+          "ticks": 5528,
+          "inputs": 5581
+        }
+      ],
+      "comparison": "Exact same-target complete state and ordered outputs at every tick; shared C# checkpoint tolerance1e-4 and exact discrete outcomes/order",
+      "artifacts": "macos.json"
+    }
+  },
+  "review": {
+    "independentAppAndOracleReview": "No correctness finding; destroy documentation clarified ownership consumption on OK or PANIC. Original oracle fixture hashes and all comparison rules preserved.",
+    "independentAbiSafetyReview": "No actionable finding; ownership, pointer checks, panic containment, queue/output bounds and typed conversion reviewed."
+  },
+  "limits": [
+    "The caller schedules one60Hz tick loop; this library starts no server or clock.",
+    "Unity bundling and the shared Admin/CLI bridge remain stage11.",
+    "Native macOS dylib currently has Cargo absolute install name; set@rpath on the packaged copy before signing in stage11.",
+    "Parent workspace pointer publication remains separately blocked by GitHub integration write access403."
+  ]
+}

--- a/doc/verification/arena-native/stock-comparison.json
+++ b/doc/verification/arena-native/stock-comparison.json
@@ -1,0 +1,6 @@
+{
+  "ticks": 5528,
+  "stateAndOutput": "exact match",
+  "expected": "/Users/mujina/.codex/worktrees/e19c/kitu-workspace/kitu-logic-processor/.tmp/stage10-macos/stock-eleven-death-retry.expected.ndjson",
+  "actual": "/Users/mujina/.codex/worktrees/e19c/kitu-workspace/kitu-logic-processor/.tmp/stage10-macos/stock-eleven-death-retry.actual.ndjson"
+}

--- a/tools/verify-arena-native.py
+++ b/tools/verify-arena-native.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Compare complete native C output against the same-build Runtime oracle trace."""
+import argparse
+import itertools
+import json
+from pathlib import Path
+
+
+def compare(expected_path, actual_path):
+    ticks = 0
+    with expected_path.open() as expected, actual_path.open() as actual:
+        for line, (left, right) in enumerate(itertools.zip_longest(expected, actual), 1):
+            if left is None or right is None:
+                raise ValueError(f"trace length differs at line {line}")
+            left, right = json.loads(left), json.loads(right)
+            if left != right:
+                raise ValueError(f"complete output/state mismatch at line {line}, tick {left.get('tick')}")
+            if left["tick"] != ticks:
+                raise ValueError(f"non-contiguous tick at line {line}")
+            ticks += 1
+    if not ticks:
+        raise ValueError("empty traces do not verify a scenario")
+    return {"ticks": ticks, "stateAndOutput": "exact match", "expected": str(expected_path), "actual": str(actual_path)}
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("expected", type=Path)
+    parser.add_argument("actual", type=Path)
+    args = parser.parse_args()
+    print(json.dumps(compare(args.expected, args.actual), indent=2))


### PR DESCRIPTION
Closes #148. Stage 10 of #129, based on merged stage 9 #147.

The existing Unity FFI only exposed legacy movement and filtered transform output. A new full-application boundary now admits typed, ordered bundles with identity, advances the ordinary Runtime, retrieves every output event and inspects detached state. The application-owned native crate creates the same complete Arena used by the server, including embedded real Tanu content or validated saved configuration, and builds dynamic/static libraries. Generic ABI/driver/buffer behavior remains in kitu-unity-ffi; the shared OSC wire types remain in kitu-transport.

ABI 1 covers create/destroy, input, tick, output, inspection and diagnostics. Caller-owned length-delimited buffers avoid allocator ownership transfer; short reads retain the entire batch, pending output refuses the next tick before advancing, and queue/byte bounds prevent unbounded buffering. Handles belong to their creating thread. Invalid pointers/lengths that can be detected are rejected, and caught panics poison the handle; arbitrary dangling pointers remain a documented caller violation. The C header and all exports are exercised.

Validation: 203 Dev Container workspace tests/doctests; all-target/all-feature Clippy, fmt, rustdoc with warnings denied, internal package lists and frozen C# oracle integrity passed. macOS Rust 1.96.0/Apple SDK 26.5 built arm64 dylib/staticlib and an actual Apple clang C caller. Native integration tests (5) and doctest passed. The C program replayed preparation (28 ticks/40 inputs) and stock (5528 ticks/5581 inputs), with complete state/output matching the ordinary Runtime exactly at every tick; stock includes 11F death at 5526 and retry at 5527. Each C run also verifies ABI/config rejection, buffer retries, sequence, inspection, backpressure and ten lifetime cycles. Additional tests cover detached content, duplicate consumption, pause cancellation and grenade lifetime. Independent ABI and application/oracle reviews found no correctness issue; destruction documentation was clarified.

Review follow-up: an oversized output could be eagerly cloned before the byte cap. Borrowed serializers now stream directly into a fallibly allocated bounded writer. Seven additional unit/doctests (45 affected tests/doctests total) and repeated macOS native/C-caller comparisons passed on final head 3b79edd. All five final GitHub CI jobs passed; the review thread is resolved.

See doc/specs/arena-native-abi.md and doc/verification/arena-native/ for reproducible commands, hashes, platform details and evidence. Unity packaging and the same-run CLI/Admin bridge follow in stage 11. Cargo's macOS dylib install name must be changed to @rpath on the packaged copy before signing. Parent workspace pointer publication remains separately pending GitHub integration write access (403).