### PR TITLE
Bound WebTransport response batches under continuous Runtime events

### DIFF
--- a/doc/specs/webtransport-gateway.md
+++ b/doc/specs/webtransport-gateway.md
@@ -66,7 +66,8 @@ KEP JSON responses for at most 200 ms measured from that first response, then
 writes each retained response to the same WebTransport stream in arrival order
 before finishing it. Each request waits at most two seconds for its first
 response. The additional 200 ms deadline is absolute: continuous 60 Hz events do
-not restart it. A batch completes early after 128 retained response frames.
+not restart it. A batch completes early after 128 retained response frames and
+resets the relay to discard any growing backlog before the next request.
 Retained encoded response payloads are limited to 1 MiB in total; exceeding that
 budget fails the request and resets the internal relay. As with other failures
 after sending a mutation, the gateway does not resend that request. A later

--- a/doc/specs/webtransport-gateway.md
+++ b/doc/specs/webtransport-gateway.md
@@ -62,8 +62,16 @@ KEP frames. Each frame carries `t = "json"` and `p = ServerEvent JSON bytes`
 with route `/server/event`. This keeps the current `ServerEvent` shape intact
 while making the transport hop KEP-native in both directions. After the internal
 WebSocket produces the first KEP JSON response, the gateway drains additional
-KEP JSON responses for a short window and writes each one to the same
-WebTransport response stream in arrival order before finishing the stream.
+KEP JSON responses for at most 200 ms measured from that first response, then
+writes each retained response to the same WebTransport stream in arrival order
+before finishing it. Each request waits at most two seconds for its first
+response. The additional 200 ms deadline is absolute: continuous 60 Hz events do
+not restart it. A batch completes early after 128 retained response frames.
+Retained encoded response payloads are limited to 1 MiB in total; exceeding that
+budget fails the request and resets the internal relay. As with other failures
+after sending a mutation, the gateway does not resend that request. A later
+deliberate request may establish a fresh connection. These bounded batches are
+observation windows, not a guarantee of draining an ongoing event subscription.
 
 WebTransport datagrams are enabled only for loss-tolerant KEP JSON envelopes.
 The gateway currently accepts one MessagePack KEP envelope per datagram, rejects
@@ -297,6 +305,34 @@ empty response for the request and does not by itself reset the relay.
 The relay lifecycle is intentionally local to the WebTransport session. It does
 not replace the existing WebSocket endpoints, and it does not change the
 browser/Unity fallback paths.
+
+## Relay regression checks
+
+Run the gateway's separate Cargo workspace inside the Dev Container:
+
+```sh
+cd tools/kitu-webtransport-gateway
+cargo fmt --all --check
+cargo clippy --locked --all-targets --all-features -- -D warnings
+cargo test --locked --all
+cargo build --locked --bins
+```
+
+The loopback tests cover continuous 16 ms broadcasts, the frame cap, exact and
+overflowing byte budgets, delayed first responses, and reset without resending
+mutations. The real-host test is excluded from default test runs because it
+creates two entities. Run it explicitly against an isolated admin host:
+
+```sh
+KITU_GATEWAY_TEST_WS_URL=ws://127.0.0.1:8787/ws cargo test --locked \
+  --bin kitu-webtransport-gateway \
+  relay_tests::actual_admin_host_broadcasts_allow_two_consecutive_mutations \
+  -- --ignored --exact
+```
+
+The existing WebTransport smoke client separately verifies two response streams
+and a datagram acknowledgment through the TLS gateway. See the gateway scripts
+for certificate and smoke-client setup.
 
 ## Browser connection check
 

--- a/tools/kitu-webtransport-gateway/Cargo.lock
+++ b/tools/kitu-webtransport-gateway/Cargo.lock
@@ -532,6 +532,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_bytes",
+ "serde_json",
  "thiserror",
 ]
 

--- a/tools/kitu-webtransport-gateway/src/main.rs
+++ b/tools/kitu-webtransport-gateway/src/main.rs
@@ -333,7 +333,14 @@ impl InternalWebSocketRelay {
         }
 
         match self.relay_connected(bytes).await {
-            Ok(response) => Ok(response),
+            Ok(response) => {
+                if response.len() == MAX_RELAY_RESPONSES {
+                    // A capped batch may leave an actively growing backlog.
+                    // Drop it now; only a later explicit request reconnects.
+                    self.reset();
+                }
+                Ok(response)
+            }
             Err(err) => {
                 self.reset();
                 Err(err)

--- a/tools/kitu-webtransport-gateway/src/main.rs
+++ b/tools/kitu-webtransport-gateway/src/main.rs
@@ -27,11 +27,16 @@ type InternalReader = SplitStream<InternalSocket>;
 const DEFAULT_BIND_PORT: u16 = 9443;
 const DEFAULT_INTERNAL_WS_URL: &str = "ws://demo-game:8787/ws";
 const MAX_STREAM_BYTES: usize = 64 * 1024;
+const MAX_RELAY_RESPONSES: usize = 128;
+const MAX_RELAY_RESPONSE_BYTES: usize = 1024 * 1024;
 const MAX_DATAGRAM_BYTES: usize = 1200;
 const MAX_MESSAGES_PER_SECOND: usize = 240;
 const MAX_DATAGRAMS_PER_SECOND: usize = 240;
 const KEP_ROUTE_DATAGRAM_PROBE: &str = "/gateway/datagram/probe";
 const KEP_ROUTE_DATAGRAM_ACK: &str = "/gateway/datagram/ack";
+
+#[cfg(test)]
+mod relay_tests;
 
 #[derive(Debug, Clone)]
 struct GatewayConfig {
@@ -307,63 +312,6 @@ async fn read_stream(mut recv_stream: RecvStream) -> Result<Vec<u8>> {
     Ok(bytes)
 }
 
-#[cfg(test)]
-mod tests {
-    use kitu_transport::{encode_kep_envelope, KepEnvelope};
-
-    use super::{
-        handle_datagram_payload, KEP_ROUTE_DATAGRAM_ACK, KEP_ROUTE_DATAGRAM_PROBE,
-        MAX_DATAGRAM_BYTES,
-    };
-
-    #[test]
-    fn datagram_probe_returns_json_ack() {
-        let mut request = KepEnvelope::json(br#"{"type":"probe"}"#.to_vec());
-        request.route = Some(KEP_ROUTE_DATAGRAM_PROBE.to_string());
-        request.correlation_id = Some(7);
-        let bytes = encode_kep_envelope(&request).expect("encode probe envelope");
-
-        let ack = handle_datagram_payload(&bytes)
-            .expect("handle datagram")
-            .expect("ack response");
-        assert!(ack.len() <= MAX_DATAGRAM_BYTES);
-
-        let envelope = kitu_transport::decode_kep_envelope(&ack).expect("decode ack envelope");
-        assert_eq!(envelope.payload_type, kitu_transport::KEP_PAYLOAD_JSON);
-        assert_eq!(envelope.route.as_deref(), Some(KEP_ROUTE_DATAGRAM_ACK));
-        assert_eq!(envelope.correlation_id, Some(7));
-
-        let json: serde_json::Value =
-            serde_json::from_slice(&envelope.payload).expect("decode ack JSON");
-        assert_eq!(json["type"], "webTransportDatagramAck");
-        assert_eq!(json["receivedRoute"], KEP_ROUTE_DATAGRAM_PROBE);
-    }
-
-    #[test]
-    fn datagram_json_on_non_probe_route_is_receive_only() {
-        let mut request = KepEnvelope::json(br#"{"type":"telemetry"}"#.to_vec());
-        request.route = Some("/client/telemetry".to_string());
-        let bytes = encode_kep_envelope(&request).expect("encode telemetry envelope");
-
-        let ack = handle_datagram_payload(&bytes).expect("handle datagram");
-
-        assert!(ack.is_none());
-    }
-
-    #[test]
-    fn datagram_rejects_reliable_osc_commands() {
-        let mut request = KepEnvelope::osc(vec![0, 1, 2, 3]);
-        request.route = Some("/room/main".to_string());
-        let bytes = encode_kep_envelope(&request).expect("encode OSC envelope");
-
-        let err = handle_datagram_payload(&bytes).expect_err("OSC commands stay reliable");
-
-        assert!(err
-            .to_string()
-            .contains("unsupported KEP datagram payload type"));
-    }
-}
-
 struct InternalWebSocketRelay {
     url: String,
     writer: Option<InternalWriter>,
@@ -425,24 +373,38 @@ impl InternalWebSocketRelay {
             .as_mut()
             .context("internal WebSocket reader is not connected")?;
         let mut responses = Vec::new();
-        match tokio::time::timeout(
+        if let Ok(Some(response)) = tokio::time::timeout(
             Duration::from_secs(2),
             Self::read_next_json_kep_response(reader),
         )
         .await
         {
-            Ok(Some(response)) => responses.push(response?),
-            Ok(None) | Err(_) => {}
+            responses.push(response?);
         }
 
-        while !responses.is_empty() {
-            match tokio::time::timeout(
-                Duration::from_millis(200),
-                Self::read_next_json_kep_response(reader),
-            )
-            .await
+        let mut response_bytes = responses.first().map_or(0, Vec::len);
+        anyhow::ensure!(
+            response_bytes <= MAX_RELAY_RESPONSE_BYTES,
+            "internal WebSocket relay response exceeds {MAX_RELAY_RESPONSE_BYTES} byte budget"
+        );
+        // Broadcasts can arrive every tick. The whole drain must end even if
+        // there is never a per-message idle interval.
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(200);
+        while !responses.is_empty()
+            && responses.len() < MAX_RELAY_RESPONSES
+            && tokio::time::Instant::now() < deadline
+        {
+            match tokio::time::timeout_at(deadline, Self::read_next_json_kep_response(reader)).await
             {
-                Ok(Some(response)) => responses.push(response?),
+                Ok(Some(response)) => {
+                    let response = response?;
+                    anyhow::ensure!(
+                        response.len() <= MAX_RELAY_RESPONSE_BYTES - response_bytes,
+                        "internal WebSocket relay response exceeds {MAX_RELAY_RESPONSE_BYTES} byte budget"
+                    );
+                    response_bytes += response.len();
+                    responses.push(response);
+                }
                 Ok(None) | Err(_) => break,
             }
         }
@@ -536,5 +498,62 @@ fn prune_rate_window(recent_messages: &mut VecDeque<Instant>) {
         .is_some_and(|timestamp| *timestamp < cutoff)
     {
         recent_messages.pop_front();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use kitu_transport::{encode_kep_envelope, KepEnvelope};
+
+    use super::{
+        handle_datagram_payload, KEP_ROUTE_DATAGRAM_ACK, KEP_ROUTE_DATAGRAM_PROBE,
+        MAX_DATAGRAM_BYTES,
+    };
+
+    #[test]
+    fn datagram_probe_returns_json_ack() {
+        let mut request = KepEnvelope::json(br#"{"type":"probe"}"#.to_vec());
+        request.route = Some(KEP_ROUTE_DATAGRAM_PROBE.to_string());
+        request.correlation_id = Some(7);
+        let bytes = encode_kep_envelope(&request).expect("encode probe envelope");
+
+        let ack = handle_datagram_payload(&bytes)
+            .expect("handle datagram")
+            .expect("ack response");
+        assert!(ack.len() <= MAX_DATAGRAM_BYTES);
+
+        let envelope = kitu_transport::decode_kep_envelope(&ack).expect("decode ack envelope");
+        assert_eq!(envelope.payload_type, kitu_transport::KEP_PAYLOAD_JSON);
+        assert_eq!(envelope.route.as_deref(), Some(KEP_ROUTE_DATAGRAM_ACK));
+        assert_eq!(envelope.correlation_id, Some(7));
+
+        let json: serde_json::Value =
+            serde_json::from_slice(&envelope.payload).expect("decode ack JSON");
+        assert_eq!(json["type"], "webTransportDatagramAck");
+        assert_eq!(json["receivedRoute"], KEP_ROUTE_DATAGRAM_PROBE);
+    }
+
+    #[test]
+    fn datagram_json_on_non_probe_route_is_receive_only() {
+        let mut request = KepEnvelope::json(br#"{"type":"telemetry"}"#.to_vec());
+        request.route = Some("/client/telemetry".to_string());
+        let bytes = encode_kep_envelope(&request).expect("encode telemetry envelope");
+
+        let ack = handle_datagram_payload(&bytes).expect("handle datagram");
+
+        assert!(ack.is_none());
+    }
+
+    #[test]
+    fn datagram_rejects_reliable_osc_commands() {
+        let mut request = KepEnvelope::osc(vec![0, 1, 2, 3]);
+        request.route = Some("/room/main".to_string());
+        let bytes = encode_kep_envelope(&request).expect("encode OSC envelope");
+
+        let err = handle_datagram_payload(&bytes).expect_err("OSC commands stay reliable");
+
+        assert!(err
+            .to_string()
+            .contains("unsupported KEP datagram payload type"));
     }
 }

--- a/tools/kitu-webtransport-gateway/src/relay_tests.rs
+++ b/tools/kitu-webtransport-gateway/src/relay_tests.rs
@@ -1,0 +1,300 @@
+//! Real loopback regressions for bounded response batches and mutation ownership.
+use super::InternalWebSocketRelay;
+use futures_util::{SinkExt, StreamExt};
+use kitu_osc_ir::{OscArg, OscMessage};
+use kitu_transport::{decode_kep_envelope, encode_kep_envelope, encode_osc_packet, KepEnvelope};
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
+    time::Duration,
+};
+use tokio::{net::TcpListener, task::JoinHandle, time::timeout};
+use tokio_tungstenite::{accept_async, tungstenite::Message};
+
+const FRAME_LIMIT: usize = 128;
+const BYTE_LIMIT: usize = 1024 * 1024;
+
+#[derive(Clone)]
+enum Replies {
+    Continuous,
+    Burst(Vec<Vec<u8>>),
+    DelayedFirst,
+}
+
+struct Backend {
+    url: String,
+    requests: Arc<Mutex<Vec<u64>>>,
+    connections: Arc<AtomicUsize>,
+    task: JoinHandle<()>,
+}
+
+impl Backend {
+    async fn start(replies: Replies) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("ws://{}", listener.local_addr().unwrap());
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let connections = Arc::new(AtomicUsize::new(0));
+        let observed_requests = requests.clone();
+        let observed_connections = connections.clone();
+        let task = tokio::spawn(async move {
+            // The relay has one connection at a time. A reset closes this socket
+            // before accepting an explicitly requested replacement connection.
+            loop {
+                let (stream, _) = listener.accept().await.unwrap();
+                observed_connections.fetch_add(1, Ordering::SeqCst);
+                let mut socket = accept_async(stream).await.unwrap();
+                let mut interval = tokio::time::interval(Duration::from_millis(16));
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                let mut latest_request = None;
+                let mut tick = 0;
+                loop {
+                    tokio::select! {
+                        incoming = socket.next() => {
+                            let Some(Ok(Message::Binary(bytes))) = incoming else { break };
+                            let envelope = decode_kep_envelope(&bytes).unwrap();
+                            let id = envelope.correlation_id.unwrap();
+                            observed_requests.lock().unwrap().push(id);
+                            latest_request = Some(id);
+                            if matches!(replies, Replies::Continuous) {
+                                continue;
+                            }
+                            if id == 1 && matches!(replies, Replies::DelayedFirst) {
+                                tokio::time::sleep(Duration::from_millis(350)).await;
+                            }
+                            let frames = match &replies {
+                                Replies::Burst(frames) if id == 1 => frames.clone(),
+                                _ => vec![response(id, 0)],
+                            };
+                            let mut failed = false;
+                            for bytes in frames {
+                                if socket.send(Message::Binary(bytes.into())).await.is_err() {
+                                    failed = true;
+                                    break;
+                                }
+                            }
+                            if failed { break; }
+                        }
+                        _ = interval.tick(), if latest_request.is_some() && matches!(replies, Replies::Continuous) => {
+                            if socket.send(Message::Binary(response(latest_request.unwrap(), tick).into())).await.is_err() {
+                                break;
+                            }
+                            tick += 1;
+                        }
+                    }
+                }
+            }
+        });
+        Self {
+            url,
+            requests,
+            connections,
+            task,
+        }
+    }
+
+    fn received(&self) -> Vec<u64> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+impl Drop for Backend {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+fn request(id: u64) -> Vec<u8> {
+    let mut message = OscMessage::new("/mutation");
+    message.args.push(OscArg::Int(id as i32));
+    let mut envelope = KepEnvelope::osc(encode_osc_packet(&message).unwrap());
+    envelope.correlation_id = Some(id);
+    encode_kep_envelope(&envelope).unwrap()
+}
+
+fn response(request: u64, tick: u64) -> Vec<u8> {
+    encode_kep_envelope(&KepEnvelope::json(
+        serde_json::to_vec(&serde_json::json!({"request": request, "tick": tick})).unwrap(),
+    ))
+    .unwrap()
+}
+
+fn sized_response(bytes: usize) -> Vec<u8> {
+    // A valid JSON string with a bin32 KEP payload makes the encoded boundary
+    // exact. The cap applies to whole encoded responses, including KEP metadata.
+    let mut payload = vec![b'x'; bytes];
+    payload[0] = b'"';
+    *payload.last_mut().unwrap() = b'"';
+    let overhead = encode_kep_envelope(&KepEnvelope::json(payload.clone()))
+        .unwrap()
+        .len()
+        - payload.len();
+    payload.truncate(bytes - overhead);
+    *payload.last_mut().unwrap() = b'"';
+    let encoded = encode_kep_envelope(&KepEnvelope::json(payload)).unwrap();
+    assert_eq!(encoded.len(), bytes);
+    encoded
+}
+
+fn json_response(bytes: &[u8]) -> serde_json::Value {
+    serde_json::from_slice(&decode_kep_envelope(bytes).unwrap().payload).unwrap()
+}
+
+#[tokio::test]
+async fn continuous_sixty_hz_updates_finish_and_a_second_request_progresses() {
+    let backend = Backend::start(Replies::Continuous).await;
+    let mut relay = InternalWebSocketRelay::new(backend.url.clone());
+    for id in 1..=2 {
+        // A quiet-gap timeout restarts every16ms and never completes this call.
+        // The generous2s bound isolates that defect from a busy CI scheduler.
+        let frames = timeout(
+            Duration::from_secs(2),
+            relay.relay_kep_envelope(request(id)),
+        )
+        .await
+        .expect("continuous responses must not renew the batch deadline")
+        .unwrap();
+        assert!(!frames.is_empty());
+        assert!(frames.len() <= FRAME_LIMIT);
+        assert!(frames.iter().map(Vec::len).sum::<usize>() <= BYTE_LIMIT);
+        assert!(frames
+            .iter()
+            .any(|bytes| json_response(bytes)["request"] == id));
+    }
+    assert_eq!(
+        backend.received(),
+        vec![1, 2],
+        "each mutation is sent exactly once"
+    );
+    assert_eq!(backend.connections.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn a_burst_returns_only_the_first_128_response_frames() {
+    let all = (0..256).map(|tick| response(1, tick)).collect::<Vec<_>>();
+    let backend = Backend::start(Replies::Burst(all.clone())).await;
+    let mut relay = InternalWebSocketRelay::new(backend.url.clone());
+    let frames = timeout(Duration::from_secs(2), relay.relay_kep_envelope(request(1)))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(frames, all[..FRAME_LIMIT]);
+    assert_eq!(backend.received(), vec![1]);
+}
+
+#[tokio::test]
+async fn exactly_one_mebibyte_of_encoded_responses_is_accepted() {
+    let half = sized_response(BYTE_LIMIT / 2);
+    let backend = Backend::start(Replies::Burst(vec![half.clone(), half.clone()])).await;
+    let mut relay = InternalWebSocketRelay::new(backend.url.clone());
+    let frames = timeout(Duration::from_secs(2), relay.relay_kep_envelope(request(1)))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(frames, vec![half.clone(), half]);
+    assert_eq!(frames.iter().map(Vec::len).sum::<usize>(), BYTE_LIMIT);
+    assert_eq!(backend.received(), vec![1]);
+}
+
+#[tokio::test]
+async fn first_or_aggregate_byte_overflow_resets_without_resending_a_mutation() {
+    for frames in [
+        vec![sized_response(BYTE_LIMIT + 1)],
+        vec![
+            sized_response(BYTE_LIMIT / 2),
+            sized_response(BYTE_LIMIT / 2 + 1),
+        ],
+    ] {
+        let backend = Backend::start(Replies::Burst(frames)).await;
+        let mut relay = InternalWebSocketRelay::new(backend.url.clone());
+        timeout(Duration::from_secs(2), relay.relay_kep_envelope(request(1)))
+            .await
+            .unwrap()
+            .expect_err("response byte overflow must fail the exchange");
+        assert!(
+            relay.writer.is_none() && relay.reader.is_none(),
+            "overflow resets both socket halves"
+        );
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        assert_eq!(
+            backend.received(),
+            vec![1],
+            "overflow must never retry a mutation"
+        );
+        assert_eq!(
+            backend.connections.load(Ordering::SeqCst),
+            1,
+            "no automatic reconnect/resend"
+        );
+        let next = timeout(Duration::from_secs(2), relay.relay_kep_envelope(request(2)))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(next, vec![response(2, 0)]);
+        assert_eq!(backend.received(), vec![1, 2]);
+        assert_eq!(backend.connections.load(Ordering::SeqCst), 2);
+    }
+}
+
+#[tokio::test]
+async fn first_response_keeps_its_separate_two_second_wait() {
+    let backend = Backend::start(Replies::DelayedFirst).await;
+    let mut relay = InternalWebSocketRelay::new(backend.url.clone());
+    let frames = timeout(Duration::from_secs(2), relay.relay_kep_envelope(request(1)))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        frames,
+        vec![response(1, 0)],
+        "the200ms drain deadline starts after the first response"
+    );
+    assert_eq!(backend.received(), vec![1]);
+}
+
+#[tokio::test]
+#[ignore = "requires KITU_GATEWAY_TEST_WS_URL pointing to an isolated running admin host /ws endpoint"]
+async fn actual_admin_host_broadcasts_allow_two_consecutive_mutations() {
+    let url = std::env::var("KITU_GATEWAY_TEST_WS_URL")
+        .expect("set KITU_GATEWAY_TEST_WS_URL for this explicit real-host test");
+    let mut relay = InternalWebSocketRelay::new(url);
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    for id in 1..=2 {
+        let mut message = OscMessage::new("/admin/world/spawn");
+        message.push_arg(OscArg::Str(format!("bounded-relay-{unique}-{id}")));
+        message.push_arg(OscArg::Float(id as f32));
+        message.push_arg(OscArg::Float(2.0));
+        message.push_arg(OscArg::Float(3.0));
+        let mut envelope = KepEnvelope::osc(encode_osc_packet(&message).unwrap());
+        envelope.route = Some("/room/main".into());
+        envelope.correlation_id = Some(id);
+        let frames = timeout(
+            Duration::from_secs(2),
+            relay.relay_kep_envelope(encode_kep_envelope(&envelope).unwrap()),
+        )
+        .await
+        .expect("the live host's tick broadcasts must not hold the relay indefinitely")
+        .unwrap();
+        assert!(!frames.is_empty());
+        assert!(frames.len() <= FRAME_LIMIT);
+        assert!(frames.iter().map(Vec::len).sum::<usize>() <= BYTE_LIMIT);
+        for frame in &frames {
+            let decoded = decode_kep_envelope(frame).unwrap();
+            assert_eq!(decoded.payload_type, kitu_transport::KEP_PAYLOAD_JSON);
+            let value: serde_json::Value = serde_json::from_slice(&decoded.payload).unwrap();
+            assert!(value.get("type").is_some());
+        }
+        eprintln!(
+            "actual admin host request {id}: {} bounded JSON responses",
+            frames.len()
+        );
+    }
+    if let Some(writer) = relay.writer.as_mut() {
+        writer.close().await.unwrap();
+    }
+    relay.reset();
+}

--- a/tools/kitu-webtransport-gateway/src/relay_tests.rs
+++ b/tools/kitu-webtransport-gateway/src/relay_tests.rs
@@ -180,7 +180,28 @@ async fn a_burst_returns_only_the_first_128_response_frames() {
         .unwrap()
         .unwrap();
     assert_eq!(frames, all[..FRAME_LIMIT]);
+    assert!(
+        relay.writer.is_none() && relay.reader.is_none(),
+        "a capped batch must discard both socket halves and their backlog"
+    );
+    tokio::time::sleep(Duration::from_millis(250)).await;
     assert_eq!(backend.received(), vec![1]);
+    assert_eq!(
+        backend.connections.load(Ordering::SeqCst),
+        1,
+        "returning the capped batch must not reconnect or resend the mutation"
+    );
+    let next = timeout(Duration::from_secs(2), relay.relay_kep_envelope(request(2)))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        next,
+        vec![response(2, 0)],
+        "old burst frames cannot leak into the next reply"
+    );
+    assert_eq!(backend.received(), vec![1, 2]);
+    assert_eq!(backend.connections.load(Ordering::SeqCst), 2);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Continuous Runtime broadcasts arrive faster than the gateway's old 200 ms quiet-gap timeout. Each event restarted that timeout, so a WebTransport response could retain its relay mutex and accumulated frames indefinitely. This change gives the additional response batch one absolute 200 ms deadline, a 128-frame cap and a 1 MiB encoded-byte budget. Reaching the frame cap discards the remaining backlog by resetting the relay after retaining the bounded batch. Byte overflow also resets the relay with an error. Neither path automatically resends a mutation; a later explicit request reconnects.

The separate first-response wait remains two seconds. The gateway spec documents bounded observation windows and reproducible regression commands. Its previously stale lockfile adds only the existing `serde_json` dependency edge from `kitu-transport`; external versions/checksums are unchanged. The existing datagram test module moves to EOF and the first-response match becomes an equivalent `if let` to satisfy Clippy.

Validation in the Dev Container:

- Same regression and lockfile: original develop `3a168080791d6d40f6719f03ccd42440d3fa2564` fails the continuous 16 ms broadcast test at 2.01 seconds; fixed gateway passes.
- The frame-cap regression also asserts both socket halves are dropped, no automatic reconnect/resend occurs, and request 2 reconnects without receiving leftover burst frames.
- Gateway fmt, all-target Clippy with warnings denied, all-target tests (8 passed, 0 failed), all-bin build and rustdoc with warnings denied pass.
- The normally excluded actual-host test was explicitly run against an isolated standalone admin host: 1 passed, 0 ignored.
- Actual TLS WebTransport smoke against that host completes two response streams and a datagram acknowledgment in 0.582 seconds. State inspection finds each requested entity exactly once. Owned test processes were stopped.
- Host binary SHA256: `c6b392508f27c875e003f22b1eacf80616562302d90570543d642ca5219e70ef`; fixed gateway SHA256: `9dec63e121f16bf85f04a135204e1e6992268f36cd6914b93f0d828d043ae9f7`.
- Gateway is an internal `publish = false` executable; no package publication or publish-ready crate change.

This is the prerequisite fix for the valid P1 finding in #167, before creating the development milestone. Its relationship to the user's unspecified manual-operation problems remains unknown. General Arena/native CI does not replace the gateway-specific verification above.

Closes #168.
Related: #166, #167.
